### PR TITLE
[#42] 구현된 백엔드 API 기준 프론트 연동

### DIFF
--- a/src/main/frontend/src/components/auth/RoundGuard.tsx
+++ b/src/main/frontend/src/components/auth/RoundGuard.tsx
@@ -4,9 +4,10 @@ import { useRound } from "@/contexts/RoundContext";
 
 export function RoundGuard() {
   const { isAuthenticated } = useAuth();
-  const { hasActiveRound } = useRound();
+  const { hasActiveRound, isRoundLoading } = useRound();
 
   if (!isAuthenticated) return <Navigate to="/login" replace />;
+  if (isRoundLoading) return null;
   if (hasActiveRound) return <Navigate to="/market" replace />;
 
   return <Outlet />;

--- a/src/main/frontend/src/components/market/OrderPanel.tsx
+++ b/src/main/frontend/src/components/market/OrderPanel.tsx
@@ -1,33 +1,30 @@
-import { useMemo, useState } from "react";
+﻿import { useCallback, useEffect, useMemo, useState } from "react";
 import { Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  cancelOrder,
+  getOrderAvailability,
+  listOrderHistory,
+  placeOrder,
+  type OrderHistoryItem,
+  type OrderSide,
+  type OrderStatus,
+} from "@/lib/api/order-api";
+import { isApiClientError } from "@/lib/api/types";
+import type { OrderTargetIds } from "@/lib/api/id-mapping";
 
 type OrderTab = "buy" | "sell" | "history";
 type OrderType = "limit" | "market";
-type OrderSide = "BUY" | "SELL";
-type OrderStatus = "FILLED" | "PENDING" | "CANCELLED";
-
-interface OrderHistoryItem {
-  id: number;
-  side: OrderSide;
-  type: "LIMIT" | "MARKET";
-  status: OrderStatus;
-  price: number;
-  quantity: number;
-  amount: number;
-  time: string;
-}
 
 interface OrderPanelProps {
   baseCurrency: string;
   coinSymbol: string;
   coinName: string;
   currentPrice: number;
-  availableBase: number;
-  availableCoin: number;
   feeRate: number;
+  orderTargetIds: OrderTargetIds | null;
 }
 
 const ORDER_TABS: { key: OrderTab; label: string }[] = [
@@ -43,16 +40,11 @@ const ORDER_TYPES: { key: OrderType; label: string }[] = [
 
 const QUICK_RATIO_BUTTONS = [10, 25, 50, 100];
 
-const MOCK_HISTORY: OrderHistoryItem[] = [
-  { id: 1, side: "BUY", type: "LIMIT", status: "FILLED", price: 99850000, quantity: 0.0032, amount: 319520, time: "방금 전" },
-  { id: 2, side: "SELL", type: "MARKET", status: "FILLED", price: 100120000, quantity: 0.0011, amount: 110132, time: "12분 전" },
-  { id: 3, side: "BUY", type: "LIMIT", status: "PENDING", price: 99000000, quantity: 0.002, amount: 198000, time: "38분 전" },
-];
-
-const STATUS_STYLES: Record<string, { text: string; className: string }> = {
+const STATUS_STYLES: Record<OrderStatus, { text: string; className: string }> = {
   FILLED: { text: "체결", className: "bg-positive/15 text-positive" },
   PENDING: { text: "대기", className: "bg-warning/15 text-warning" },
   CANCELLED: { text: "취소", className: "bg-muted text-muted-foreground" },
+  FAILED: { text: "실패", className: "bg-destructive/15 text-destructive" },
 };
 
 function formatNumber(value: number, digits = 0) {
@@ -67,35 +59,62 @@ function parseNumber(value: string) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+function toClientOrderId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function toReadableError(error: unknown): string {
+  if (isApiClientError(error)) {
+    return error.message || error.code;
+  }
+  return "요청 처리 중 오류가 발생했습니다.";
+}
+
+function formatRelativeTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "-";
+
+  const diffMinutes = Math.floor((Date.now() - date.getTime()) / 60000);
+  if (diffMinutes < 1) return "방금 전";
+  if (diffMinutes < 60) return `${diffMinutes}분 전`;
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}시간 전`;
+
+  return date.toLocaleString("ko-KR");
+}
+
 export function OrderPanel({
   baseCurrency,
   coinSymbol,
   coinName,
   currentPrice,
-  availableBase,
-  availableCoin,
   feeRate,
+  orderTargetIds,
 }: OrderPanelProps) {
   const [activeTab, setActiveTab] = useState<OrderTab>("buy");
   const [historyFilter, setHistoryFilter] = useState<"filled" | "pending">("filled");
-  const [historyItems, setHistoryItems] = useState(MOCK_HISTORY);
+  const [historyItems, setHistoryItems] = useState<OrderHistoryItem[]>([]);
+  const [historyNextCursor, setHistoryNextCursor] = useState<number | null>(null);
+  const [historyHasNext, setHistoryHasNext] = useState(false);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState("");
+
+  const [availableBuy, setAvailableBuy] = useState(0);
+  const [availableSell, setAvailableSell] = useState(0);
+  const [availabilityError, setAvailabilityError] = useState("");
+
   const [orderType, setOrderType] = useState<OrderType>("limit");
   const [price, setPrice] = useState("");
   const [quantity, setQuantity] = useState("");
   const [amount, setAmount] = useState("");
   const [lastEdited, setLastEdited] = useState<"quantity" | "amount" | null>(null);
-
-  const filteredHistory = historyItems.filter((item) =>
-    historyFilter === "filled" ? item.status === "FILLED" : item.status === "PENDING",
-  );
-
-  const handleCancel = (id: number) => {
-    setHistoryItems((prev) =>
-      prev.map((item) =>
-        item.id === id ? { ...item, status: "CANCELLED" as const } : item,
-      ),
-    );
-  };
+  const [submitError, setSubmitError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const isBuy = activeTab === "buy";
   const isTradeTab = activeTab === "buy" || activeTab === "sell";
@@ -103,7 +122,7 @@ export function OrderPanel({
   const showQuantityInput = !isMarket || !isBuy;
   const showAmountInput = !isMarket || isBuy;
 
-  const tradeBase = isBuy ? availableBase : availableCoin;
+  const tradeBase = isBuy ? availableBuy : availableSell;
   const unitLabel = isBuy ? baseCurrency : coinSymbol;
 
   const displayPrice = useMemo(() => {
@@ -112,26 +131,98 @@ export function OrderPanel({
     return parsed > 0 ? parsed : currentPrice;
   }, [isMarket, price, currentPrice]);
 
+  const historyStatus: OrderStatus = historyFilter === "filled" ? "FILLED" : "PENDING";
+
+  const loadAvailability = useCallback(async () => {
+    if (!orderTargetIds) {
+      setAvailableBuy(0);
+      setAvailableSell(0);
+      return;
+    }
+
+    try {
+      const [buy, sell] = await Promise.all([
+        getOrderAvailability(orderTargetIds.walletId, orderTargetIds.exchangeCoinId, "BUY"),
+        getOrderAvailability(orderTargetIds.walletId, orderTargetIds.exchangeCoinId, "SELL"),
+      ]);
+
+      setAvailableBuy(buy.available);
+      setAvailableSell(sell.available);
+      setAvailabilityError("");
+    } catch (error) {
+      setAvailabilityError(toReadableError(error));
+      setAvailableBuy(0);
+      setAvailableSell(0);
+    }
+  }, [orderTargetIds]);
+
+  const loadHistory = useCallback(
+    async (reset: boolean) => {
+      if (!orderTargetIds) {
+        setHistoryItems([]);
+        setHistoryHasNext(false);
+        setHistoryNextCursor(null);
+        return;
+      }
+
+      setHistoryLoading(true);
+      setHistoryError("");
+      try {
+        const data = await listOrderHistory({
+          walletId: orderTargetIds.walletId,
+          exchangeCoinId: orderTargetIds.exchangeCoinId,
+          status: historyStatus,
+          cursorOrderId: reset ? undefined : historyNextCursor ?? undefined,
+          size: 20,
+        });
+
+        setHistoryItems((prev) => (reset ? data.content : [...prev, ...data.content]));
+        setHistoryNextCursor(data.nextCursor);
+        setHistoryHasNext(data.hasNext);
+      } catch (error) {
+        setHistoryError(toReadableError(error));
+      } finally {
+        setHistoryLoading(false);
+      }
+    },
+    [historyNextCursor, historyStatus, orderTargetIds],
+  );
+
+  useEffect(() => {
+    void loadAvailability();
+  }, [loadAvailability]);
+
+  useEffect(() => {
+    if (activeTab !== "history") return;
+    void loadHistory(true);
+  }, [activeTab, historyFilter, orderTargetIds, loadHistory]);
+
+  useEffect(() => {
+    setPrice("");
+    setQuantity("");
+    setAmount("");
+    setSubmitError("");
+  }, [coinSymbol, orderTargetIds, activeTab]);
+
   const syncByPrice = (nextPrice: number) => {
     if (orderType !== "limit" || nextPrice <= 0) return;
+
     if (lastEdited === "amount") {
       const nextAmount = parseNumber(amount);
       if (nextAmount <= 0) return;
-      const nextQty = nextAmount / nextPrice;
-      setQuantity(formatNumber(nextQty, 6));
+      setQuantity(formatNumber(nextAmount / nextPrice, 6));
     }
+
     if (lastEdited === "quantity") {
       const nextQty = parseNumber(quantity);
       if (nextQty <= 0) return;
-      const nextAmount = nextQty * nextPrice;
-      setAmount(formatNumber(nextAmount));
+      setAmount(formatNumber(nextQty * nextPrice));
     }
   };
 
   const handlePriceChange = (value: string) => {
     setPrice(value);
-    const nextPrice = parseNumber(value);
-    syncByPrice(nextPrice);
+    syncByPrice(parseNumber(value));
   };
 
   const handleStepPrice = (delta: number) => {
@@ -144,43 +235,111 @@ export function OrderPanel({
   const handleQuantityChange = (value: string) => {
     setQuantity(value);
     setLastEdited("quantity");
+
     if (orderType !== "limit") return;
+
     const nextQty = parseNumber(value);
     if (nextQty <= 0) return;
-    const nextAmount = nextQty * displayPrice;
-    setAmount(formatNumber(nextAmount));
+
+    setAmount(formatNumber(nextQty * displayPrice));
   };
 
   const handleAmountChange = (value: string) => {
     setAmount(value);
     setLastEdited("amount");
+
     if (orderType !== "limit") return;
+
     const nextAmount = parseNumber(value);
     if (nextAmount <= 0) return;
-    const nextQty = nextAmount / displayPrice;
-    setQuantity(formatNumber(nextQty, 6));
+
+    setQuantity(formatNumber(nextAmount / displayPrice, 6));
   };
 
   const handleRatioClick = (ratio: number) => {
     if (!isTradeTab) return;
+
     if (isBuy) {
-      const nextAmount = (availableBase * ratio) / 100;
+      const nextAmount = (availableBuy * ratio) / 100;
       setAmount(formatNumber(nextAmount));
       setLastEdited("amount");
       if (orderType === "limit") {
-        const nextQty = nextAmount / displayPrice;
-        setQuantity(formatNumber(nextQty, 6));
+        setQuantity(formatNumber(nextAmount / displayPrice, 6));
       }
-    } else {
-      const nextQty = (availableCoin * ratio) / 100;
-      setQuantity(formatNumber(nextQty, 6));
-      setLastEdited("quantity");
-      if (orderType === "limit") {
-        const nextAmount = nextQty * displayPrice;
-        setAmount(formatNumber(nextAmount));
-      }
+      return;
+    }
+
+    const nextQty = (availableSell * ratio) / 100;
+    setQuantity(formatNumber(nextQty, 6));
+    setLastEdited("quantity");
+    if (orderType === "limit") {
+      setAmount(formatNumber(nextQty * displayPrice));
     }
   };
+
+  async function handleCancel(orderId: number) {
+    try {
+      await cancelOrder(orderId);
+      setHistoryItems((prev) => prev.filter((item) => item.orderId !== orderId));
+      await loadAvailability();
+    } catch (error) {
+      setHistoryError(toReadableError(error));
+    }
+  }
+
+  async function handleSubmitOrder() {
+    if (!orderTargetIds) {
+      setSubmitError("선택한 거래소/코인의 주문 매핑이 없습니다.");
+      return;
+    }
+
+    const side: OrderSide = isBuy ? "BUY" : "SELL";
+    const parsedAmount = parseNumber(amount);
+    const parsedQuantity = parseNumber(quantity);
+    const parsedPrice = parseNumber(price);
+
+    const requestAmount = side === "BUY" ? parsedAmount : parsedQuantity;
+
+    if (requestAmount <= 0) {
+      setSubmitError(side === "BUY" ? "주문 총액을 입력해 주세요." : "주문 수량을 입력해 주세요.");
+      return;
+    }
+
+    if (orderType === "limit" && parsedPrice <= 0) {
+      setSubmitError("지정가를 입력해 주세요.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError("");
+
+    try {
+      await placeOrder({
+        clientOrderId: toClientOrderId(),
+        walletId: orderTargetIds.walletId,
+        exchangeCoinId: orderTargetIds.exchangeCoinId,
+        side,
+        orderType: orderType === "limit" ? "LIMIT" : "MARKET",
+        price: orderType === "limit" ? parsedPrice : undefined,
+        amount: requestAmount,
+      });
+
+      setPrice("");
+      setQuantity("");
+      setAmount("");
+
+      await Promise.all([
+        loadAvailability(),
+        activeTab === "history" ? loadHistory(true) : Promise.resolve(),
+      ]);
+    } catch (error) {
+      setSubmitError(toReadableError(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const mappedUnavailable = !orderTargetIds;
 
   return (
     <div className="sticky top-24 space-y-4">
@@ -192,9 +351,17 @@ export function OrderPanel({
               <h2 className="mt-1 text-lg font-extrabold tracking-tight">
                 {coinSymbol} <span className="text-muted-foreground">/ {baseCurrency}</span>
               </h2>
-              <p className="mt-1 text-xs text-muted-foreground">{coinName} · {formatNumber(currentPrice)} {baseCurrency}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {coinName} · {formatNumber(currentPrice)} {baseCurrency}
+              </p>
             </div>
           </div>
+
+          {mappedUnavailable && (
+            <div className="mt-4 rounded-xl border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
+              이 코인은 아직 주문 ID 매핑이 없어 주문 API를 호출할 수 없습니다.
+            </div>
+          )}
 
           <div className="mt-5 rounded-2xl bg-secondary/60 p-1">
             <div className="grid grid-cols-3 gap-1">
@@ -242,12 +409,14 @@ export function OrderPanel({
                 </button>
               </div>
 
-              {filteredHistory.map((item) => {
+              {historyItems.map((item) => {
                 const status = STATUS_STYLES[item.status] ?? STATUS_STYLES.PENDING;
                 const isBuySide = item.side === "BUY";
+                const priceValue = item.filledPrice ?? item.price ?? 0;
+
                 return (
                   <div
-                    key={item.id}
+                    key={item.orderId}
                     className="rounded-2xl border border-border/60 bg-white px-4 py-3 shadow-sm transition hover:shadow-card-hover"
                   >
                     <div className="flex items-center justify-between">
@@ -261,7 +430,7 @@ export function OrderPanel({
                           {isBuySide ? "매수" : "매도"}
                         </span>
                         <span className="text-xs font-semibold text-muted-foreground">
-                          {item.type === "MARKET" ? "시장가" : "지정가"}
+                          {item.orderType === "MARKET" ? "시장가" : "지정가"}
                         </span>
                         <span className={cn("rounded-full px-2 py-0.5 text-[10px] font-semibold", status.className)}>
                           {status.text}
@@ -270,20 +439,20 @@ export function OrderPanel({
                       <div className="flex items-center gap-2">
                         {item.status === "PENDING" && (
                           <button
-                            onClick={() => handleCancel(item.id)}
+                            onClick={() => void handleCancel(item.orderId)}
                             className="rounded-full border border-border/60 px-2.5 py-1 text-[10px] font-semibold text-muted-foreground transition hover:border-destructive/30 hover:text-destructive"
                           >
                             취소
                           </button>
                         )}
-                        <span className="text-[11px] text-muted-foreground">{item.time}</span>
+                        <span className="text-[11px] text-muted-foreground">{formatRelativeTime(item.createdAt)}</span>
                       </div>
                     </div>
                     <div className="mt-2 grid grid-cols-3 gap-2 text-[11px] text-muted-foreground">
                       <div>
                         <p>가격</p>
                         <p className="font-mono text-xs font-semibold text-foreground">
-                          {formatNumber(item.price)} {baseCurrency}
+                          {formatNumber(priceValue)} {baseCurrency}
                         </p>
                       </div>
                       <div>
@@ -295,7 +464,7 @@ export function OrderPanel({
                       <div>
                         <p>금액</p>
                         <p className="font-mono text-xs font-semibold text-foreground">
-                          {formatNumber(item.amount)} {baseCurrency}
+                          {formatNumber(item.orderAmount)} {baseCurrency}
                         </p>
                       </div>
                     </div>
@@ -303,10 +472,31 @@ export function OrderPanel({
                 );
               })}
 
-              {filteredHistory.length === 0 && (
+              {historyLoading && (
+                <div className="rounded-2xl border border-dashed border-border/70 bg-secondary/30 px-4 py-3 text-center text-sm text-muted-foreground">
+                  거래 내역을 불러오는 중입니다...
+                </div>
+              )}
+
+              {!historyLoading && historyItems.length === 0 && (
                 <div className="rounded-2xl border border-dashed border-border/70 bg-secondary/30 px-4 py-6 text-center text-sm text-muted-foreground">
                   {historyFilter === "filled" ? "체결 내역이 없습니다." : "미체결 주문이 없습니다."}
                 </div>
+              )}
+
+              {historyHasNext && (
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => void loadHistory(false)}
+                  disabled={historyLoading}
+                >
+                  더보기
+                </Button>
+              )}
+
+              {historyError && (
+                <p className="text-xs font-medium text-destructive">{historyError}</p>
               )}
             </div>
           )}
@@ -314,10 +504,10 @@ export function OrderPanel({
           {isTradeTab && (
             <>
               <div className="mt-5 flex items-center justify-between text-xs font-semibold text-muted-foreground">
-                <span>주문유형</span>
+                <span>주문 유형</span>
                 <span className="flex items-center gap-1 text-[11px]">
                   <Info className="h-3 w-3" />
-                  주문 가능
+                  주문 가능 조회
                 </span>
               </div>
 
@@ -339,7 +529,7 @@ export function OrderPanel({
               </div>
 
               <div className="mt-5 flex items-center justify-between text-xs font-semibold text-muted-foreground">
-                <span>주문가능</span>
+                <span>주문 가능</span>
                 <span className="font-mono text-sm text-foreground">
                   {formatNumber(tradeBase, isBuy ? 0 : 6)} {unitLabel}
                 </span>
@@ -348,12 +538,12 @@ export function OrderPanel({
               <div className="mt-4 space-y-3">
                 <div>
                   <label className="text-xs font-semibold text-muted-foreground">
-                    {isBuy ? "매수가격" : "매도가격"} ({baseCurrency})
+                    {isBuy ? "매수 가격" : "매도 가격"} ({baseCurrency})
                   </label>
                   <div className="mt-1.5 flex items-center gap-2 rounded-2xl border border-border/70 bg-white px-3 py-2">
                     <Input
                       value={isMarket ? formatNumber(currentPrice) : price}
-                      onChange={(e) => handlePriceChange(e.target.value)}
+                      onChange={(event) => handlePriceChange(event.target.value)}
                       disabled={isMarket}
                       className="h-8 border-0 bg-transparent p-0 text-right text-sm font-semibold shadow-none focus-visible:ring-0"
                     />
@@ -377,19 +567,17 @@ export function OrderPanel({
                 </div>
 
                 {showQuantityInput && (
-                <div>
-                  <label className="text-xs font-semibold text-muted-foreground">
-                    주문수량 ({coinSymbol})
-                  </label>
-                  <div className="mt-1.5 rounded-2xl border border-border/70 bg-white px-3 py-2">
-                    <Input
-                      value={quantity}
-                      onChange={(e) => handleQuantityChange(e.target.value)}
-                      placeholder="0"
-                      className="h-8 border-0 bg-transparent p-0 text-right text-sm font-semibold shadow-none focus-visible:ring-0"
-                    />
+                  <div>
+                    <label className="text-xs font-semibold text-muted-foreground">주문 수량 ({coinSymbol})</label>
+                    <div className="mt-1.5 rounded-2xl border border-border/70 bg-white px-3 py-2">
+                      <Input
+                        value={quantity}
+                        onChange={(event) => handleQuantityChange(event.target.value)}
+                        placeholder="0"
+                        className="h-8 border-0 bg-transparent p-0 text-right text-sm font-semibold shadow-none focus-visible:ring-0"
+                      />
+                    </div>
                   </div>
-                </div>
                 )}
 
                 <div className="flex flex-wrap gap-2">
@@ -402,35 +590,47 @@ export function OrderPanel({
                       {ratio}%
                     </button>
                   ))}
-                  <button className="rounded-lg border border-border/70 bg-white px-3 py-1.5 text-xs font-semibold text-muted-foreground transition hover:border-primary/30 hover:text-foreground">
-                    직접입력
-                  </button>
                 </div>
 
                 {showAmountInput && (
-                <div>
-                  <label className="text-xs font-semibold text-muted-foreground">
-                    주문총액 ({baseCurrency})
-                  </label>
-                  <div className="mt-1.5 rounded-2xl border border-border/70 bg-white px-3 py-2">
-                    <Input
-                      value={amount}
-                      onChange={(e) => handleAmountChange(e.target.value)}
-                      placeholder="0"
-                      className="h-8 border-0 bg-transparent p-0 text-right text-sm font-semibold shadow-none focus-visible:ring-0"
-                    />
+                  <div>
+                    <label className="text-xs font-semibold text-muted-foreground">주문 총액 ({baseCurrency})</label>
+                    <div className="mt-1.5 rounded-2xl border border-border/70 bg-white px-3 py-2">
+                      <Input
+                        value={amount}
+                        onChange={(event) => handleAmountChange(event.target.value)}
+                        placeholder="0"
+                        className="h-8 border-0 bg-transparent p-0 text-right text-sm font-semibold shadow-none focus-visible:ring-0"
+                      />
+                    </div>
                   </div>
-                </div>
                 )}
               </div>
 
               <div className="mt-4 flex items-center justify-between text-[11px] text-muted-foreground">
                 <span>수수료 {formatNumber(feeRate * 100, 2)}%</span>
-                <span>최소주문 5,000 {baseCurrency}</span>
+                <span>최소 주문 5,000 {baseCurrency}</span>
               </div>
 
+              {availabilityError && (
+                <p className="mt-2 text-xs font-medium text-destructive">{availabilityError}</p>
+              )}
+
+              {submitError && (
+                <p className="mt-2 text-xs font-medium text-destructive">{submitError}</p>
+              )}
+
               <div className="mt-5 grid grid-cols-2 gap-2">
-                <Button variant="outline" className="h-11 rounded-2xl text-sm font-semibold">
+                <Button
+                  variant="outline"
+                  className="h-11 rounded-2xl text-sm font-semibold"
+                  onClick={() => {
+                    setPrice("");
+                    setQuantity("");
+                    setAmount("");
+                    setSubmitError("");
+                  }}
+                >
                   초기화
                 </Button>
                 <Button
@@ -438,8 +638,10 @@ export function OrderPanel({
                     "h-11 rounded-2xl text-sm font-semibold",
                     isBuy ? "bg-primary text-primary-foreground" : "bg-destructive text-white",
                   )}
+                  onClick={() => void handleSubmitOrder()}
+                  disabled={isSubmitting || mappedUnavailable}
                 >
-                  {isBuy ? "매수" : "매도"}
+                  {isSubmitting ? "요청 중..." : isBuy ? "매수" : "매도"}
                 </Button>
               </div>
             </>
@@ -449,3 +651,4 @@ export function OrderPanel({
     </div>
   );
 }
+

--- a/src/main/frontend/src/components/round/EmergencyFundingCard.tsx
+++ b/src/main/frontend/src/components/round/EmergencyFundingCard.tsx
@@ -19,7 +19,7 @@ import type { InvestmentRound } from "@/mocks/round";
 
 interface EmergencyFundingCardProps {
   round: InvestmentRound;
-  onCharge: (amount: number) => boolean;
+  onCharge: (amount: number) => Promise<boolean>;
 }
 
 export function EmergencyFundingCard({ round, onCharge }: EmergencyFundingCardProps) {
@@ -46,9 +46,9 @@ export function EmergencyFundingCard({ round, onCharge }: EmergencyFundingCardPr
     }
   }
 
-  function handleConfirm() {
+  async function handleConfirm() {
     if (!canCharge || !isValidAmount) return;
-    const ok = onCharge(amount);
+    const ok = await onCharge(amount);
     if (ok) {
       setOpen(false);
       setAmount(0);

--- a/src/main/frontend/src/contexts/RoundContext.tsx
+++ b/src/main/frontend/src/contexts/RoundContext.tsx
@@ -1,77 +1,123 @@
-import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
 import {
-  type InvestmentRound,
-  type RuleType,
-  createMockRound,
-  clearMockRound,
-  mockActiveRound,
-  setMockActiveRound,
-} from "@/mocks/round";
-
-interface CreateRoundParams {
-  userId: number;
-  initialSeed: number;
-  emergencyFundingLimit: number;
-  rules: { ruleType: RuleType; thresholdValue: number }[];
-}
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import type { InvestmentRound } from "@/mocks/round";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  chargeEmergencyFunding as chargeEmergencyFundingApi,
+  createIdempotencyKey,
+  createRound as createRoundApi,
+  fetchActiveRound,
+  type CreateRoundParams,
+} from "@/lib/api/round-api";
 
 interface RoundContextValue {
   activeRound: InvestmentRound | null;
   hasActiveRound: boolean;
-  createRound: (params: CreateRoundParams) => InvestmentRound;
+  isRoundLoading: boolean;
+  createRound: (params: CreateRoundParams) => Promise<InvestmentRound | null>;
   clearRound: () => void;
-  chargeEmergencyFunding: (amount: number) => boolean;
+  refreshActiveRound: () => Promise<void>;
+  chargeEmergencyFunding: (amount: number, exchangeId: number) => Promise<boolean>;
 }
 
 const RoundContext = createContext<RoundContextValue | null>(null);
 
 export function RoundProvider({ children }: { children: ReactNode }) {
-  const [activeRound, setActiveRound] = useState<InvestmentRound | null>(mockActiveRound);
+  const { user } = useAuth();
+  const [activeRound, setActiveRound] = useState<InvestmentRound | null>(null);
+  const [isRoundLoading, setIsRoundLoading] = useState(false);
 
-  const createRound = useCallback((params: CreateRoundParams): InvestmentRound => {
-    const round = createMockRound(
-      params.userId,
-      params.initialSeed,
-      params.emergencyFundingLimit,
-      params.rules,
-    );
-    setActiveRound(round);
-    return round;
+  const refreshActiveRound = useCallback(async () => {
+    if (!user) {
+      setActiveRound(null);
+      return;
+    }
+
+    setIsRoundLoading(true);
+    try {
+      const round = await fetchActiveRound(user.userId);
+      setActiveRound(round);
+    } catch (error) {
+      console.error("Failed to load active round", error);
+      setActiveRound(null);
+    } finally {
+      setIsRoundLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    void refreshActiveRound();
+  }, [refreshActiveRound]);
+
+  const createRound = useCallback(async (params: CreateRoundParams): Promise<InvestmentRound | null> => {
+    try {
+      const round = await createRoundApi(params);
+      setActiveRound(round);
+      return round;
+    } catch (error) {
+      console.error("Failed to create round", error);
+      return null;
+    }
   }, []);
 
   const clearRound = useCallback(() => {
-    clearMockRound();
     setActiveRound(null);
   }, []);
 
-  const chargeEmergencyFunding = useCallback((amount: number): boolean => {
-    if (!activeRound) return false;
-    if (activeRound.status !== "ACTIVE") return false;
-    if (activeRound.emergencyChargeCount <= 0) return false;
-    if (amount <= 0 || amount > activeRound.emergencyFundingLimit) return false;
+  const chargeEmergencyFunding = useCallback(
+    async (amount: number, exchangeId: number): Promise<boolean> => {
+      if (!activeRound || !user) return false;
+      if (activeRound.status !== "ACTIVE") return false;
+      if (activeRound.emergencyChargeCount <= 0) return false;
+      if (amount <= 0 || amount > activeRound.emergencyFundingLimit) return false;
 
-    const updated: InvestmentRound = {
-      ...activeRound,
-      emergencyChargeCount: Math.max(0, activeRound.emergencyChargeCount - 1),
-    };
-    setMockActiveRound(updated);
-    setActiveRound(updated);
-    return true;
-  }, [activeRound]);
+      try {
+        const result = await chargeEmergencyFundingApi({
+          roundId: activeRound.roundId,
+          userId: user.userId,
+          exchangeId,
+          amount,
+          idempotencyKey: createIdempotencyKey(),
+        });
 
-  return (
-    <RoundContext.Provider
-      value={{
-        activeRound,
-        hasActiveRound: activeRound !== null,
-        createRound,
-        clearRound,
-        chargeEmergencyFunding,
-      }}
-    >
-      {children}
-    </RoundContext.Provider>
+        setActiveRound((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            emergencyChargeCount: result.remainingChargeCount,
+          };
+        });
+
+        return true;
+      } catch (error) {
+        console.error("Failed to charge emergency funding", error);
+        return false;
+      }
+    },
+    [activeRound, user],
   );
+
+  const value = useMemo(
+    () => ({
+      activeRound,
+      hasActiveRound: activeRound !== null,
+      isRoundLoading,
+      createRound,
+      clearRound,
+      refreshActiveRound,
+      chargeEmergencyFunding,
+    }),
+    [activeRound, isRoundLoading, createRound, clearRound, refreshActiveRound, chargeEmergencyFunding],
+  );
+
+  return <RoundContext.Provider value={value}>{children}</RoundContext.Provider>;
 }
 
 export function useRound(): RoundContextValue {

--- a/src/main/frontend/src/lib/api/client.ts
+++ b/src/main/frontend/src/lib/api/client.ts
@@ -1,0 +1,95 @@
+﻿import {
+  ApiClientError,
+  type ApiRequestOptions,
+  type ApiResponseDto,
+  type QueryParams,
+} from "./types";
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? "";
+const SUCCESS_CODES = new Set(["SUCCESS", "CREATED"]);
+
+function toQueryString(query?: QueryParams): string {
+  if (!query) return "";
+
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+    search.set(key, String(value));
+  }
+
+  const raw = search.toString();
+  return raw ? `?${raw}` : "";
+}
+
+function toUrl(path: string, query?: QueryParams): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${API_BASE_URL}${normalizedPath}${toQueryString(query)}`;
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export async function apiRequest<T>(
+  path: string,
+  options: ApiRequestOptions = {},
+): Promise<T> {
+  const { body, query, headers, ...requestInit } = options;
+  const response = await fetch(toUrl(path, query), {
+    ...requestInit,
+    headers: {
+      ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+      ...headers,
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  const parsed = await parseJson(response);
+  const envelope = parsed as ApiResponseDto<T> | null;
+
+  if (!response.ok) {
+    if (envelope && typeof envelope === "object") {
+      throw new ApiClientError(
+        envelope.message ?? "Request failed",
+        envelope.status ?? response.status,
+        envelope.code ?? "UNKNOWN_ERROR",
+        envelope.data,
+      );
+    }
+
+    throw new ApiClientError("Request failed", response.status, "UNKNOWN_ERROR");
+  }
+
+  if (!envelope || typeof envelope !== "object") {
+    throw new ApiClientError("Invalid API response", response.status, "INVALID_RESPONSE");
+  }
+
+  if (!SUCCESS_CODES.has(envelope.code)) {
+    throw new ApiClientError(
+      envelope.message ?? "Request failed",
+      envelope.status ?? response.status,
+      envelope.code,
+      envelope.data,
+    );
+  }
+
+  return envelope.data;
+}
+
+export function apiGet<T>(path: string, query?: QueryParams): Promise<T> {
+  return apiRequest<T>(path, { method: "GET", query });
+}
+
+export function apiPost<T>(path: string, body?: unknown): Promise<T> {
+  return apiRequest<T>(path, { method: "POST", body });
+}
+

--- a/src/main/frontend/src/lib/api/id-mapping.ts
+++ b/src/main/frontend/src/lib/api/id-mapping.ts
@@ -1,0 +1,52 @@
+﻿export interface OrderTargetIds {
+  exchangeId: number;
+  walletId: number;
+  exchangeCoinId: number;
+}
+
+const BACKEND_EXCHANGE_ID_MAP: Record<string, number> = {
+  upbit: 1,
+  bithumb: 2,
+  binance: 3,
+  jupiter: 4,
+};
+
+// Order API currently requires walletId + exchangeCoinId lookup from client.
+// This table only contains IDs verified/assumed from project docs/tests.
+// Add mappings here as backend seed data expands.
+const ORDER_ID_MAP: Record<string, Record<string, { walletId: number; exchangeCoinId: number }>> = {
+  upbit: {
+    BTC: { walletId: 1, exchangeCoinId: 1 },
+  },
+  bithumb: {
+    BTC: { walletId: 2, exchangeCoinId: 7 },
+  },
+  binance: {
+    BTC: { walletId: 3, exchangeCoinId: 13 },
+  },
+};
+
+export function getBackendExchangeId(exchangeKey: string): number | null {
+  return BACKEND_EXCHANGE_ID_MAP[exchangeKey] ?? null;
+}
+
+export function resolveOrderTargetIds(
+  exchangeKey: string,
+  coinSymbol: string,
+): OrderTargetIds | null {
+  const exchangeId = getBackendExchangeId(exchangeKey);
+  if (!exchangeId) return null;
+
+  const byExchange = ORDER_ID_MAP[exchangeKey];
+  if (!byExchange) return null;
+
+  const ids = byExchange[coinSymbol.toUpperCase()];
+  if (!ids) return null;
+
+  return {
+    exchangeId,
+    walletId: ids.walletId,
+    exchangeCoinId: ids.exchangeCoinId,
+  };
+}
+

--- a/src/main/frontend/src/lib/api/mappers.ts
+++ b/src/main/frontend/src/lib/api/mappers.ts
@@ -1,0 +1,56 @@
+﻿import type { RankingPeriod } from "@/mocks/ranking";
+import type { RuleType } from "@/mocks/round";
+
+export type BackendRuleType =
+  | "LOSS_CUT"
+  | "PROFIT_TAKE"
+  | "CHASE_BUY_BAN"
+  | "AVERAGING_DOWN_LIMIT"
+  | "OVERTRADING_LIMIT";
+
+export type BackendRankingPeriod = "DAILY" | "WEEKLY" | "MONTHLY";
+
+const FRONT_TO_BACK_RULE_TYPE: Record<RuleType, BackendRuleType> = {
+  STOP_LOSS: "LOSS_CUT",
+  TAKE_PROFIT: "PROFIT_TAKE",
+  NO_CHASE_BUY: "CHASE_BUY_BAN",
+  AVERAGING_LIMIT: "AVERAGING_DOWN_LIMIT",
+  OVERTRADE_LIMIT: "OVERTRADING_LIMIT",
+};
+
+const BACK_TO_FRONT_RULE_TYPE: Record<BackendRuleType, RuleType> = {
+  LOSS_CUT: "STOP_LOSS",
+  PROFIT_TAKE: "TAKE_PROFIT",
+  CHASE_BUY_BAN: "NO_CHASE_BUY",
+  AVERAGING_DOWN_LIMIT: "AVERAGING_LIMIT",
+  OVERTRADING_LIMIT: "OVERTRADE_LIMIT",
+};
+
+const FRONT_TO_BACK_PERIOD: Record<RankingPeriod, BackendRankingPeriod> = {
+  daily: "DAILY",
+  weekly: "WEEKLY",
+  monthly: "MONTHLY",
+};
+
+const BACK_TO_FRONT_PERIOD: Record<BackendRankingPeriod, RankingPeriod> = {
+  DAILY: "daily",
+  WEEKLY: "weekly",
+  MONTHLY: "monthly",
+};
+
+export function toBackendRuleType(ruleType: RuleType): BackendRuleType {
+  return FRONT_TO_BACK_RULE_TYPE[ruleType];
+}
+
+export function toFrontRuleType(ruleType: BackendRuleType): RuleType {
+  return BACK_TO_FRONT_RULE_TYPE[ruleType];
+}
+
+export function toBackendRankingPeriod(period: RankingPeriod): BackendRankingPeriod {
+  return FRONT_TO_BACK_PERIOD[period];
+}
+
+export function toFrontRankingPeriod(period: BackendRankingPeriod): RankingPeriod {
+  return BACK_TO_FRONT_PERIOD[period];
+}
+

--- a/src/main/frontend/src/lib/api/order-api.ts
+++ b/src/main/frontend/src/lib/api/order-api.ts
@@ -1,0 +1,126 @@
+﻿import { apiGet, apiPost } from "./client";
+import type { CursorPageResponseDto } from "./types";
+
+export type OrderSide = "BUY" | "SELL";
+export type OrderType = "MARKET" | "LIMIT";
+export type OrderStatus = "FILLED" | "PENDING" | "CANCELLED" | "FAILED";
+
+export interface OrderAvailability {
+  available: number;
+  currentPrice: number;
+}
+
+export interface OrderHistoryItem {
+  orderId: number;
+  exchangeCoinId: number;
+  side: OrderSide;
+  orderType: OrderType;
+  status: OrderStatus;
+  filledPrice: number | null;
+  price: number | null;
+  quantity: number;
+  orderAmount: number;
+  fee: number;
+  createdAt: string;
+  filledAt: string | null;
+}
+
+export interface PlaceOrderRequest {
+  clientOrderId: string;
+  walletId: number;
+  exchangeCoinId: number;
+  side: OrderSide;
+  orderType: OrderType;
+  price?: number;
+  amount: number;
+}
+
+export interface PlaceOrderResult {
+  orderId: number;
+  side: OrderSide;
+  orderType: OrderType;
+  orderAmount: number;
+  quantity: number;
+  price: number | null;
+  filledPrice: number | null;
+  fee: number | null;
+  status: OrderStatus;
+  createdAt: string;
+  filledAt: string | null;
+}
+
+export interface CancelOrderResult {
+  orderId: number;
+  status: OrderStatus;
+}
+
+export interface FindOrderHistoryParams {
+  walletId: number;
+  exchangeCoinId?: number;
+  side?: OrderSide;
+  status?: OrderStatus;
+  cursorOrderId?: number;
+  size?: number;
+}
+
+export async function getOrderAvailability(
+  walletId: number,
+  exchangeCoinId: number,
+  side: OrderSide,
+): Promise<OrderAvailability> {
+  const data = await apiGet<OrderAvailability>("/api/orders/available", {
+    walletId,
+    exchangeCoinId,
+    side,
+  });
+
+  return {
+    available: Number(data.available),
+    currentPrice: Number(data.currentPrice),
+  };
+}
+
+export async function listOrderHistory(
+  params: FindOrderHistoryParams,
+): Promise<CursorPageResponseDto<OrderHistoryItem>> {
+  const data = await apiGet<CursorPageResponseDto<OrderHistoryItem>>("/api/orders", {
+    walletId: params.walletId,
+    exchangeCoinId: params.exchangeCoinId,
+    side: params.side,
+    status: params.status,
+    cursorOrderId: params.cursorOrderId,
+    size: params.size,
+  });
+
+  return {
+    content: data.content.map((item) => ({
+      ...item,
+      status: params.status ?? "FILLED",
+      filledPrice: item.filledPrice != null ? Number(item.filledPrice) : null,
+      price: item.price != null ? Number(item.price) : null,
+      quantity: Number(item.quantity),
+      orderAmount: Number(item.orderAmount),
+      fee: Number(item.fee),
+    })),
+    nextCursor: data.nextCursor,
+    hasNext: data.hasNext,
+  };
+}
+
+export async function placeOrder(request: PlaceOrderRequest): Promise<PlaceOrderResult> {
+  const data = await apiPost<PlaceOrderResult>("/api/orders", request);
+
+  return {
+    ...data,
+    orderAmount: Number(data.orderAmount),
+    quantity: Number(data.quantity),
+    price: data.price != null ? Number(data.price) : null,
+    filledPrice: data.filledPrice != null ? Number(data.filledPrice) : null,
+    fee: data.fee != null ? Number(data.fee) : null,
+  };
+}
+
+export function cancelOrder(orderId: number): Promise<CancelOrderResult> {
+  return apiPost<CancelOrderResult>(`/api/orders/${orderId}/cancel`);
+}
+

--- a/src/main/frontend/src/lib/api/ranking-api.ts
+++ b/src/main/frontend/src/lib/api/ranking-api.ts
@@ -1,0 +1,117 @@
+﻿import type { RankingPeriod } from "@/mocks/ranking";
+import { apiGet } from "./client";
+import { toBackendRankingPeriod } from "./mappers";
+import type { CursorPageResponseDto } from "./types";
+
+export interface RankingItem {
+  rank: number;
+  userId: number;
+  nickname: string;
+  profitRate: number;
+  tradeCount: number;
+  portfolioPublic: boolean;
+}
+
+export interface MyRanking {
+  rank: number;
+  nickname: string;
+  profitRate: number;
+  tradeCount: number;
+}
+
+export interface RankingStats {
+  totalParticipants: number;
+  maxProfitRate: number;
+  avgProfitRate: number;
+}
+
+export interface RankerHolding {
+  coinSymbol: string;
+  exchangeName: string;
+  assetRatio: number;
+  profitRate: number;
+}
+
+export interface RankerPortfolio {
+  userId: number;
+  nickname: string;
+  rank: number;
+  profitRate: number;
+  holdings: RankerHolding[];
+}
+
+export interface GetRankingsParams {
+  period: RankingPeriod;
+  referenceDate?: string;
+  cursorRank?: number;
+  size?: number;
+}
+
+export async function getRankings(
+  params: GetRankingsParams,
+): Promise<CursorPageResponseDto<RankingItem>> {
+  const data = await apiGet<CursorPageResponseDto<RankingItem>>("/api/rankings", {
+    period: toBackendRankingPeriod(params.period),
+    referenceDate: params.referenceDate,
+    cursorRank: params.cursorRank,
+    size: params.size,
+  });
+
+  return {
+    content: data.content.map((item) => ({
+      ...item,
+      profitRate: Number(item.profitRate),
+    })),
+    nextCursor: data.nextCursor,
+    hasNext: data.hasNext,
+  };
+}
+
+export async function getMyRanking(
+  userId: number,
+  period: RankingPeriod,
+): Promise<MyRanking | null> {
+  const data = await apiGet<MyRanking | null>("/api/rankings/me", {
+    userId,
+    period: toBackendRankingPeriod(period),
+  });
+
+  if (!data) return null;
+
+  return {
+    ...data,
+    profitRate: Number(data.profitRate),
+  };
+}
+
+export async function getRankingStats(period: RankingPeriod): Promise<RankingStats> {
+  const data = await apiGet<RankingStats>("/api/rankings/stats", {
+    period: toBackendRankingPeriod(period),
+  });
+
+  return {
+    ...data,
+    maxProfitRate: Number(data.maxProfitRate),
+    avgProfitRate: Number(data.avgProfitRate),
+  };
+}
+
+export async function getRankerPortfolio(
+  userId: number,
+  period: RankingPeriod,
+): Promise<RankerPortfolio> {
+  const data = await apiGet<RankerPortfolio>(`/api/rankings/${userId}/portfolio`, {
+    period: toBackendRankingPeriod(period),
+  });
+
+  return {
+    ...data,
+    profitRate: Number(data.profitRate),
+    holdings: data.holdings.map((holding) => ({
+      ...holding,
+      assetRatio: Number(holding.assetRatio),
+      profitRate: Number(holding.profitRate),
+    })),
+  };
+}
+

--- a/src/main/frontend/src/lib/api/round-api.ts
+++ b/src/main/frontend/src/lib/api/round-api.ts
@@ -1,0 +1,154 @@
+﻿import type { InvestmentRound, RuleType } from "@/mocks/round";
+import { apiGet, apiPost } from "./client";
+import { toBackendRuleType, toFrontRuleType, type BackendRuleType } from "./mappers";
+import { isApiClientError } from "./types";
+
+interface BackendRoundRule {
+  ruleId: number;
+  ruleType: BackendRuleType;
+  thresholdValue: number;
+}
+
+interface BackendRound {
+  roundId: number;
+  userId: number;
+  roundNumber: number;
+  status: "ACTIVE" | "BANKRUPT" | "ENDED";
+  initialSeed: number;
+  emergencyFundingLimit: number;
+  emergencyChargeCount: number;
+  startedAt: string;
+  endedAt: string | null;
+  rules: BackendRoundRule[];
+}
+
+interface StartRoundSeedRequest {
+  exchangeId: number;
+  amount: number;
+}
+
+interface StartRoundRuleRequest {
+  ruleType: BackendRuleType;
+  thresholdValue: number;
+}
+
+interface StartRoundRequestBody {
+  userId: number;
+  seeds: StartRoundSeedRequest[];
+  emergencyFundingLimit: number;
+  rules: StartRoundRuleRequest[];
+}
+
+export interface CreateRoundParams {
+  userId: number;
+  initialSeed: number;
+  emergencyFundingLimit: number;
+  rules: Array<{
+    ruleType: RuleType;
+    thresholdValue: number;
+  }>;
+}
+
+interface ChargeEmergencyFundingRequestBody {
+  userId: number;
+  exchangeId: number;
+  amount: number;
+  idempotencyKey: string;
+}
+
+interface ChargeEmergencyFundingResponse {
+  roundId: number;
+  exchangeId: number;
+  chargedAmount: number;
+  remainingChargeCount: number;
+  chargedAt: string;
+}
+
+export interface ChargeEmergencyFundingParams {
+  roundId: number;
+  userId: number;
+  exchangeId: number;
+  amount: number;
+  idempotencyKey: string;
+}
+
+function mapRound(data: BackendRound): InvestmentRound {
+  return {
+    roundId: data.roundId,
+    userId: data.userId,
+    roundNumber: data.roundNumber,
+    initialSeed: Number(data.initialSeed),
+    emergencyFundingLimit: Number(data.emergencyFundingLimit),
+    emergencyChargeCount: data.emergencyChargeCount,
+    status: data.status,
+    rules: (data.rules ?? []).map((rule) => ({
+      ruleId: rule.ruleId,
+      ruleType: toFrontRuleType(rule.ruleType),
+      thresholdValue: Number(rule.thresholdValue),
+    })),
+    startedAt: data.startedAt,
+    endedAt: data.endedAt,
+  };
+}
+
+function toStartRoundBody(params: CreateRoundParams): StartRoundRequestBody {
+  return {
+    userId: params.userId,
+    seeds: [
+      { exchangeId: 1, amount: params.initialSeed },
+      { exchangeId: 2, amount: 0 },
+      { exchangeId: 3, amount: 0 },
+    ],
+    emergencyFundingLimit: params.emergencyFundingLimit,
+    rules: params.rules.map((rule) => ({
+      ruleType: toBackendRuleType(rule.ruleType),
+      thresholdValue: rule.thresholdValue,
+    })),
+  };
+}
+
+export async function createRound(params: CreateRoundParams): Promise<InvestmentRound> {
+  const data = await apiPost<BackendRound>("/api/rounds", toStartRoundBody(params));
+  return mapRound(data);
+}
+
+export async function fetchActiveRound(userId: number): Promise<InvestmentRound | null> {
+  try {
+    const data = await apiGet<BackendRound>("/api/rounds/active", { userId });
+    return mapRound(data);
+  } catch (error) {
+    if (isApiClientError(error) && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function chargeEmergencyFunding(
+  params: ChargeEmergencyFundingParams,
+): Promise<ChargeEmergencyFundingResponse> {
+  const requestBody: ChargeEmergencyFundingRequestBody = {
+    userId: params.userId,
+    exchangeId: params.exchangeId,
+    amount: params.amount,
+    idempotencyKey: params.idempotencyKey,
+  };
+
+  return apiPost<ChargeEmergencyFundingResponse>(
+    `/api/rounds/${params.roundId}/emergency-funding`,
+    requestBody,
+  );
+}
+
+export async function endRound(roundId: number, userId: number): Promise<void> {
+  await apiPost(`/api/rounds/${roundId}/end`, { userId });
+}
+
+export function createIdempotencyKey(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+

--- a/src/main/frontend/src/lib/api/types.ts
+++ b/src/main/frontend/src/lib/api/types.ts
@@ -1,0 +1,39 @@
+﻿export interface ApiResponseDto<T> {
+  status: number;
+  code: string;
+  message: string;
+  data: T;
+}
+
+export interface CursorPageResponseDto<T> {
+  content: T[];
+  nextCursor: number | null;
+  hasNext: boolean;
+}
+
+export type QueryPrimitive = string | number | boolean | null | undefined;
+export type QueryParams = Record<string, QueryPrimitive>;
+
+export interface ApiRequestOptions extends Omit<RequestInit, "body"> {
+  body?: unknown;
+  query?: QueryParams;
+}
+
+export class ApiClientError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly data: unknown;
+
+  constructor(message: string, status: number, code: string, data?: unknown) {
+    super(message);
+    this.name = "ApiClientError";
+    this.status = status;
+    this.code = code;
+    this.data = data;
+  }
+}
+
+export function isApiClientError(error: unknown): error is ApiClientError {
+  return error instanceof ApiClientError;
+}
+

--- a/src/main/frontend/src/pages/MarketPage.tsx
+++ b/src/main/frontend/src/pages/MarketPage.tsx
@@ -11,6 +11,7 @@ import { OrderPanel } from "@/components/market/OrderPanel";
 import { EmergencyFundingCard } from "@/components/round/EmergencyFundingCard";
 import { useRound } from "@/contexts/RoundContext";
 import { cexExchanges, dexExchanges } from "@/mocks/coins";
+import { getBackendExchangeId, resolveOrderTargetIds } from "@/lib/api/id-mapping";
 import type { MarketType } from "@/components/market/MarketTypeTabs";
 import type { FilterType } from "@/components/market/FilterChips";
 
@@ -31,6 +32,7 @@ export function MarketPage() {
     () => activeExchanges.find((e) => e.id === selectedExchange) ?? activeExchanges[0],
     [activeExchanges, selectedExchange],
   );
+  const backendExchangeId = getBackendExchangeId(selectedExchange);
 
   const filteredCoins = useMemo(() => {
     let coins = exchange.coins;
@@ -63,6 +65,9 @@ export function MarketPage() {
     const fromSelection = exchange.coins.find((coin) => coin.symbol === selectedSymbol);
     return fromSelection ?? filteredCoins[0] ?? exchange.coins[0];
   }, [exchange.coins, filteredCoins, selectedSymbol]);
+  const orderTargetIds = selectedCoin
+    ? resolveOrderTargetIds(selectedExchange, selectedCoin.symbol)
+    : null;
 
   const handleMarketTypeChange = (type: MarketType) => {
     const newExchanges = type === "cex" ? cexExchanges : dexExchanges;
@@ -135,10 +140,10 @@ export function MarketPage() {
 
           {/* Side panel */}
           <div className="space-y-4">
-            {activeRound && (
+            {activeRound && backendExchangeId !== null && (
               <EmergencyFundingCard
                 round={activeRound}
-                onCharge={chargeEmergencyFunding}
+                onCharge={(amount) => chargeEmergencyFunding(amount, backendExchangeId)}
               />
             )}
             {selectedCoin && (
@@ -147,9 +152,8 @@ export function MarketPage() {
                 coinSymbol={selectedCoin.symbol}
                 coinName={selectedCoin.name}
                 currentPrice={selectedCoin.currentPrice}
-                availableBase={exchange.baseCurrency === "KRW" ? 2500000 : 3250}
-                availableCoin={1.234567}
                 feeRate={0.0005}
+                orderTargetIds={orderTargetIds}
               />
             )}
           </div>

--- a/src/main/frontend/src/pages/RankingPage.tsx
+++ b/src/main/frontend/src/pages/RankingPage.tsx
@@ -1,11 +1,21 @@
-import { useState, useMemo } from "react";
+﻿import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import { BarChart3, Lock, Trophy, Users } from "lucide-react";
 import { Header } from "@/components/layout/Header";
-import { Trophy, ChevronDown, Lock, TrendingUp, Users, BarChart3 } from "lucide-react";
 import { CoinIcon } from "@/components/market/CoinIcon";
-import { rankingData, MY_USER_ID } from "@/mocks/ranking";
-import type { RankingPeriod, RankingEntry } from "@/mocks/ranking";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  getMyRanking,
+  getRankerPortfolio,
+  getRankings,
+  getRankingStats,
+  type MyRanking,
+  type RankerPortfolio,
+  type RankingItem,
+  type RankingStats,
+} from "@/lib/api/ranking-api";
 import { cn } from "@/lib/utils";
+import type { RankingPeriod } from "@/mocks/ranking";
 
 const PERIOD_TABS: { key: RankingPeriod; label: string }[] = [
   { key: "daily", label: "일간" },
@@ -13,387 +23,152 @@ const PERIOD_TABS: { key: RankingPeriod; label: string }[] = [
   { key: "monthly", label: "월간" },
 ];
 
-const MEDAL_COLORS: Record<number, { bg: string; text: string; ring: string }> = {
-  1: { bg: "bg-amber-400", text: "text-amber-900", ring: "ring-amber-300" },
-  2: { bg: "bg-gray-300", text: "text-gray-700", ring: "ring-gray-200" },
-  3: { bg: "bg-amber-600", text: "text-amber-100", ring: "ring-amber-500" },
-};
+function asRatio(value: number): number {
+  return value > 1 ? value / 100 : value;
+}
 
-function RankBadge({ rank, size = "sm" }: { rank: number; size?: "sm" | "lg" }) {
-  const medal = MEDAL_COLORS[rank];
-  const sizeClasses = size === "lg" ? "h-10 w-10 text-sm" : "h-7 w-7 text-xs";
-  if (medal) {
-    return (
-      <span
-        className={cn(
-          "inline-flex items-center justify-center rounded-full font-extrabold ring-2",
-          sizeClasses,
-          medal.bg,
-          medal.text,
-          medal.ring,
-        )}
-      >
-        {rank}
-      </span>
-    );
-  }
+function formatProfitRate(value: number): string {
+  return `${value >= 0 ? "+" : ""}${value.toFixed(2)}%`;
+}
+
+function RankBadge({ rank }: { rank: number }) {
   return (
-    <span
-      className={cn(
-        "inline-flex items-center justify-center rounded-full font-bold text-muted-foreground",
-        sizeClasses,
-      )}
-    >
+    <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-secondary/60 text-xs font-bold text-foreground">
       {rank}
     </span>
   );
 }
 
-function CoinStack({ coins, max = 3 }: { coins: { coinSymbol: string }[]; max?: number }) {
-  const display = coins.slice(0, max);
-  return (
-    <div className="flex items-center">
-      {display.map((coin, i) => (
-        <div
-          key={coin.coinSymbol}
-          className={cn("relative rounded-full ring-2 ring-card", i > 0 && "-ml-1.5")}
-          style={{ zIndex: max - i }}
-        >
-          <CoinIcon symbol={coin.coinSymbol} size={20} />
-        </div>
-      ))}
-    </div>
-  );
-}
+export function RankingPage() {
+  const { user } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const periodParam = searchParams.get("period");
+  const period: RankingPeriod =
+    periodParam === "weekly" || periodParam === "monthly" ? periodParam : "daily";
 
-function PortfolioPanel({ entry }: { entry: RankingEntry }) {
-  if (!entry.portfolioPublic) {
-    return (
-      <div className="flex items-center gap-2 px-4 py-5 text-xs text-muted-foreground">
-        <Lock className="h-3.5 w-3.5" />
-        비공개 포트폴리오입니다.
-      </div>
-    );
+  const [entries, setEntries] = useState<RankingItem[]>([]);
+  const [myRanking, setMyRanking] = useState<MyRanking | null>(null);
+  const [stats, setStats] = useState<RankingStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState("");
+  const [hasNext, setHasNext] = useState(false);
+  const [nextCursor, setNextCursor] = useState<number | null>(null);
+
+  const [expandedUserId, setExpandedUserId] = useState<number | null>(null);
+  const [portfolioByUser, setPortfolioByUser] = useState<Record<number, RankerPortfolio>>({});
+  const [portfolioLoadingByUser, setPortfolioLoadingByUser] = useState<Record<number, boolean>>({});
+  const [portfolioErrorByUser, setPortfolioErrorByUser] = useState<Record<number, string>>({});
+
+  const periodLabel = useMemo(
+    () => PERIOD_TABS.find((tab) => tab.key === period)?.label ?? "",
+    [period],
+  );
+
+  useEffect(() => {
+    let canceled = false;
+
+    async function loadInitialData() {
+      setIsLoading(true);
+      setError("");
+      setExpandedUserId(null);
+      setPortfolioByUser({});
+      setPortfolioLoadingByUser({});
+      setPortfolioErrorByUser({});
+
+      try {
+        const [rankingPage, rankingStats, my] = await Promise.all([
+          getRankings({ period, size: 20 }),
+          getRankingStats(period),
+          user ? getMyRanking(user.userId, period) : Promise.resolve(null),
+        ]);
+
+        if (canceled) return;
+
+        setEntries(rankingPage.content);
+        setHasNext(rankingPage.hasNext);
+        setNextCursor(rankingPage.nextCursor);
+        setStats(rankingStats);
+        setMyRanking(my);
+      } catch (fetchError) {
+        if (canceled) return;
+
+        console.error(fetchError);
+        setEntries([]);
+        setStats(null);
+        setMyRanking(null);
+        setHasNext(false);
+        setNextCursor(null);
+        setError("랭킹 데이터를 불러오지 못했습니다.");
+      } finally {
+        if (!canceled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadInitialData();
+
+    return () => {
+      canceled = true;
+    };
+  }, [period, user]);
+
+  async function handleLoadMore() {
+    if (!hasNext || nextCursor == null || isLoadingMore) return;
+
+    setIsLoadingMore(true);
+    try {
+      const page = await getRankings({ period, cursorRank: nextCursor, size: 20 });
+      setEntries((prev) => [...prev, ...page.content]);
+      setHasNext(page.hasNext);
+      setNextCursor(page.nextCursor);
+    } catch (fetchError) {
+      console.error(fetchError);
+      setError("추가 랭킹을 불러오지 못했습니다.");
+    } finally {
+      setIsLoadingMore(false);
+    }
   }
 
-  return (
-    <div className="px-4 pb-4 pt-2">
-      <p className="mb-2.5 text-[11px] font-medium text-muted-foreground">보유 코인 비중</p>
-      <div className="space-y-2">
-        {entry.portfolio.map((item) => {
-          const pct = item.ratio * 100;
-          return (
-            <div key={item.coinSymbol} className="flex items-center gap-3">
-              <CoinIcon symbol={item.coinSymbol} size={24} />
-              <div className="min-w-0 flex-1">
-                <div className="mb-1 flex items-center justify-between">
-                  <span className="text-xs font-semibold">{item.coinSymbol}</span>
-                  <span className="font-mono text-xs font-semibold tabular-nums">
-                    {pct.toFixed(1)}%
-                  </span>
-                </div>
-                <div className="h-1.5 w-full overflow-hidden rounded-full bg-secondary">
-                  <div
-                    className="h-full rounded-full bg-primary transition-all duration-500"
-                    style={{ width: `${pct}%` }}
-                  />
-                </div>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
+  async function loadPortfolio(userId: number) {
+    if (portfolioByUser[userId] || portfolioLoadingByUser[userId]) {
+      return;
+    }
 
-function RankingRow({
-  entry,
-  isExpanded,
-  onToggle,
-}: {
-  entry: RankingEntry;
-  isExpanded: boolean;
-  onToggle: () => void;
-}) {
-  const isPositive = entry.profitRate >= 0;
-  const topCoins = entry.portfolioPublic ? entry.portfolio.slice(0, 3) : [];
+    setPortfolioLoadingByUser((prev) => ({ ...prev, [userId]: true }));
+    setPortfolioErrorByUser((prev) => ({ ...prev, [userId]: "" }));
 
-  return (
-    <div
-      className={cn(
-        "overflow-hidden rounded-2xl bg-card transition-shadow",
-        isExpanded ? "shadow-card-active" : "shadow-card hover:shadow-card-hover",
-      )}
-    >
-      <button
-        onClick={onToggle}
-        className="flex w-full items-center gap-4 px-4 py-3.5 text-left transition-colors hover:bg-primary/[0.03]"
-      >
-        <RankBadge rank={entry.rank} />
+    try {
+      const portfolio = await getRankerPortfolio(userId, period);
+      setPortfolioByUser((prev) => ({ ...prev, [userId]: portfolio }));
+    } catch (fetchError) {
+      console.error(fetchError);
+      setPortfolioErrorByUser((prev) => ({
+        ...prev,
+        [userId]: "포트폴리오를 불러오지 못했습니다.",
+      }));
+    } finally {
+      setPortfolioLoadingByUser((prev) => ({ ...prev, [userId]: false }));
+    }
+  }
 
-        <div className="min-w-0 flex-1">
-          <span className="text-sm font-semibold">{entry.nickname}</span>
-          <span className="ml-2 text-[11px] text-muted-foreground">
-            {entry.tradeCount}회 거래
-          </span>
-        </div>
+  function handleToggleRow(entry: RankingItem) {
+    const nextExpanded = expandedUserId === entry.userId ? null : entry.userId;
+    setExpandedUserId(nextExpanded);
 
-        {topCoins.length > 0 && (
-          <div className="hidden sm:block">
-            <CoinStack coins={topCoins} />
-          </div>
-        )}
+    if (nextExpanded && entry.portfolioPublic) {
+      void loadPortfolio(entry.userId);
+    }
+  }
 
-        <span
-          className={cn(
-            "font-mono text-sm font-bold tabular-nums",
-            isPositive ? "text-positive" : "text-negative",
-          )}
-        >
-          {isPositive ? "+" : ""}
-          {entry.profitRate.toFixed(2)}%
-        </span>
-
-        <ChevronDown
-          className={cn(
-            "h-4 w-4 shrink-0 text-muted-foreground/50 transition-transform duration-200",
-            isExpanded && "rotate-180",
-          )}
-        />
-      </button>
-
-      <div
-        className={cn(
-          "grid transition-[grid-template-rows] duration-300 ease-in-out",
-          isExpanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
-        )}
-      >
-        <div className="overflow-hidden">
-          {isExpanded && (
-            <div className="border-t border-border/60">
-              <PortfolioPanel entry={entry} />
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-const TOP3_ACCENTS: Record<number, { border: string; glow: string }> = {
-  1: { border: "border-amber-400", glow: "shadow-[0_0_0_1px_rgba(251,191,36,0.15),0_4px_24px_rgba(251,191,36,0.10)]" },
-  2: { border: "border-gray-300", glow: "shadow-card" },
-  3: { border: "border-amber-700/40", glow: "shadow-card" },
-};
-
-function Podium({
-  entries,
-  expandedId,
-  onToggle,
-}: {
-  entries: RankingEntry[];
-  expandedId: number | null;
-  onToggle: (userId: number) => void;
-}) {
-  const top3 = entries.slice(0, 3);
-  if (top3.length < 3) return null;
-
-  return (
-    <div className="mx-auto max-w-6xl px-4 pb-2 pt-8">
-      <div className="grid grid-cols-3 items-end gap-3 sm:gap-4">
-        {[top3[1], top3[0], top3[2]].map((entry) => {
-          const isPositive = entry.profitRate >= 0;
-          const topCoins = entry.portfolioPublic ? entry.portfolio.slice(0, 3) : [];
-          const accent = TOP3_ACCENTS[entry.rank];
-          const isFirst = entry.rank === 1;
-          const isExpanded = expandedId === entry.userId;
-
-          return (
-            <div
-              key={entry.userId}
-              className={cn(
-                "overflow-hidden rounded-2xl border-t-[3px] bg-card transition-shadow",
-                accent.border,
-                isExpanded ? "shadow-card-active" : accent.glow,
-              )}
-            >
-              <button
-                onClick={() => onToggle(entry.userId)}
-                className={cn(
-                  "flex w-full flex-col items-center px-3 pb-4 pt-5 transition-colors hover:bg-primary/[0.03] sm:px-5",
-                  isFirst && "sm:pb-6 sm:pt-7",
-                )}
-              >
-                <RankBadge rank={entry.rank} size="lg" />
-                <span
-                  className={cn(
-                    "mt-2.5 max-w-full truncate font-bold",
-                    isFirst ? "text-base" : "text-sm",
-                  )}
-                >
-                  {entry.nickname}
-                </span>
-                <span
-                  className={cn(
-                    "mt-1 font-mono font-bold tabular-nums",
-                    isFirst ? "text-base" : "text-sm",
-                    isPositive ? "text-positive" : "text-negative",
-                  )}
-                >
-                  {isPositive ? "+" : ""}
-                  {entry.profitRate.toFixed(2)}%
-                </span>
-                <div className="mt-2.5 flex items-center gap-2">
-                  {topCoins.length > 0 && <CoinStack coins={topCoins} />}
-                  <span className="text-[11px] text-muted-foreground">
-                    {entry.tradeCount}회 거래
-                  </span>
-                </div>
-                <ChevronDown
-                  className={cn(
-                    "mt-2 h-4 w-4 text-muted-foreground/40 transition-transform duration-200",
-                    isExpanded && "rotate-180",
-                  )}
-                />
-              </button>
-
-              <div
-                className={cn(
-                  "grid transition-[grid-template-rows] duration-300 ease-in-out",
-                  isExpanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
-                )}
-              >
-                <div className="overflow-hidden">
-                  {isExpanded && (
-                    <div className="border-t border-border/60">
-                      <PortfolioPanel entry={entry} />
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function MyRankCard({
-  entry,
-  periodLabel,
-}: {
-  entry: RankingEntry | undefined;
-  periodLabel: string;
-}) {
-  if (!entry) return null;
-  const isPositive = entry.profitRate >= 0;
-
-  return (
-    <div className="rounded-2xl bg-card p-4 shadow-card">
-      <p className="mb-3 text-xs font-semibold text-muted-foreground">내 {periodLabel} 랭킹</p>
-      <div className="flex items-center gap-3">
-        <RankBadge rank={entry.rank} size="lg" />
-        <div className="min-w-0 flex-1">
-          <p className="text-sm font-bold">{entry.nickname}</p>
-          <p className="text-[11px] text-muted-foreground">{entry.tradeCount}회 거래</p>
-        </div>
-      </div>
-      <div className="mt-3 rounded-xl bg-secondary/50 px-3 py-2.5 text-center">
-        <p className="text-[11px] text-muted-foreground">수익률</p>
-        <p
-          className={cn(
-            "mt-0.5 font-mono text-lg font-extrabold tabular-nums",
-            isPositive ? "text-positive" : "text-negative",
-          )}
-        >
-          {isPositive ? "+" : ""}
-          {entry.profitRate.toFixed(2)}%
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function PeriodStats({
-  entries,
-  periodLabel,
-}: {
-  entries: RankingEntry[];
-  periodLabel: string;
-}) {
-  const stats = useMemo(() => {
-    const avgProfit = entries.reduce((sum, e) => sum + e.profitRate, 0) / entries.length;
-    const positiveCount = entries.filter((e) => e.profitRate >= 0).length;
-    return {
-      totalParticipants: entries.length,
-      avgProfit,
-      maxProfit: entries[0]?.profitRate ?? 0,
-      positiveRate: Math.round((positiveCount / entries.length) * 100),
-    };
-  }, [entries]);
-
-  const items = [
-    {
-      icon: Users,
-      label: "참여자",
-      value: `${stats.totalParticipants}명`,
-    },
-    {
-      icon: TrendingUp,
-      label: "최고 수익률",
-      value: `+${stats.maxProfit.toFixed(2)}%`,
-      color: "text-positive" as const,
-    },
-    {
-      icon: BarChart3,
-      label: "평균 수익률",
-      value: `${stats.avgProfit >= 0 ? "+" : ""}${stats.avgProfit.toFixed(2)}%`,
-      color: (stats.avgProfit >= 0 ? "text-positive" : "text-negative") as string,
-    },
-  ];
-
-  return (
-    <div className="rounded-2xl bg-card p-4 shadow-card">
-      <p className="mb-3 text-xs font-semibold text-muted-foreground">{periodLabel} 통계</p>
-      <div className="space-y-3">
-        {items.map((item) => (
-          <div key={item.label} className="flex items-center gap-2.5">
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/8">
-              <item.icon className="h-4 w-4 text-primary" />
-            </div>
-            <div className="min-w-0 flex-1">
-              <p className="text-[11px] text-muted-foreground">{item.label}</p>
-              <p className={cn("text-sm font-bold tabular-nums", item.color)}>{item.value}</p>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-export function RankingPage() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const period = (searchParams.get("period") ?? "daily") as RankingPeriod;
-  const [expandedId, setExpandedId] = useState<number | null>(null);
-
-  const entries = useMemo(() => rankingData[period] ?? rankingData.daily, [period]);
-  const myEntry = useMemo(() => entries.find((e) => e.userId === MY_USER_ID), [entries]);
-  const restEntries = useMemo(() => entries.slice(3), [entries]);
-
-  const handleToggle = (userId: number) => {
-    setExpandedId((prev) => (prev === userId ? null : userId));
-  };
-
-  const periodLabel = PERIOD_TABS.find((t) => t.key === period)?.label ?? "";
+  const topThree = entries.slice(0, 3);
+  const restEntries = entries.slice(3);
 
   return (
     <div className="min-h-screen bg-background">
       <Header />
 
-      {/* Hero */}
       <section className="bg-gradient-to-r from-primary/8 via-chart-4/6 to-primary/4 pb-8 pt-8">
         <div className="mx-auto max-w-6xl px-4">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -403,7 +178,7 @@ export function RankingPage() {
                 <h1 className="text-3xl font-extrabold tracking-tight">랭킹</h1>
               </div>
               <p className="mt-1.5 text-sm font-medium text-muted-foreground">
-                {periodLabel} 수익률 기준 · 상위 100명
+                {periodLabel} 수익률 기준 순위
               </p>
             </div>
 
@@ -411,10 +186,7 @@ export function RankingPage() {
               {PERIOD_TABS.map((tab) => (
                 <button
                   key={tab.key}
-                  onClick={() => {
-                    setSearchParams({ period: tab.key });
-                    setExpandedId(null);
-                  }}
+                  onClick={() => setSearchParams({ period: tab.key })}
                   className={cn(
                     "rounded-lg px-4 py-1.5 text-sm font-semibold transition-all",
                     period === tab.key
@@ -430,35 +202,193 @@ export function RankingPage() {
         </div>
       </section>
 
-      {/* TOP 3 Podium */}
-      <Podium entries={entries} expandedId={expandedId} onToggle={handleToggle} />
-
-      {/* Main: sidebar + ranking list */}
-      <main className="mx-auto max-w-6xl px-4 pb-8">
+      <main className="mx-auto max-w-6xl px-4 pb-8 pt-6">
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr]">
           <aside className="flex flex-col gap-4 lg:sticky lg:top-24 lg:self-start">
-            <MyRankCard entry={myEntry} periodLabel={periodLabel} />
-            <PeriodStats entries={entries} periodLabel={periodLabel} />
-          </aside>
-
-          <div>
-            <div className="space-y-2">
-              {restEntries.map((entry) => (
-                <RankingRow
-                  key={entry.userId}
-                  entry={entry}
-                  isExpanded={expandedId === entry.userId}
-                  onToggle={() => handleToggle(entry.userId)}
-                />
-              ))}
+            <div className="rounded-2xl bg-card p-4 shadow-card">
+              <p className="mb-3 text-xs font-semibold text-muted-foreground">내 랭킹</p>
+              {myRanking ? (
+                <div>
+                  <div className="flex items-center gap-3">
+                    <RankBadge rank={myRanking.rank} />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-bold">{myRanking.nickname}</p>
+                      <p className="text-[11px] text-muted-foreground">{myRanking.tradeCount}회 거래</p>
+                    </div>
+                  </div>
+                  <p className="mt-3 rounded-xl bg-secondary/50 px-3 py-2.5 text-center font-mono text-lg font-extrabold tabular-nums">
+                    {formatProfitRate(myRanking.profitRate)}
+                  </p>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">내 랭킹 데이터가 없습니다.</p>
+              )}
             </div>
 
-            <p className="mt-3 text-[11px] text-muted-foreground/60">
-              * 모의투자 데이터입니다. 배치 집계 기준.
-            </p>
-          </div>
+            <div className="rounded-2xl bg-card p-4 shadow-card">
+              <p className="mb-3 text-xs font-semibold text-muted-foreground">{periodLabel} 통계</p>
+              {stats ? (
+                <div className="space-y-3">
+                  <div className="flex items-center gap-2">
+                    <Users className="h-4 w-4 text-primary" />
+                    <span className="text-sm">참여자 {stats.totalParticipants.toLocaleString("ko-KR")}명</span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">최고 수익률</span>
+                    <span className="font-mono font-bold text-positive">{formatProfitRate(stats.maxProfitRate)}</span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">평균 수익률</span>
+                    <span className={cn(
+                      "font-mono font-bold",
+                      stats.avgProfitRate >= 0 ? "text-positive" : "text-negative",
+                    )}>
+                      {formatProfitRate(stats.avgProfitRate)}
+                    </span>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <BarChart3 className="h-4 w-4" />
+                  통계를 불러오지 못했습니다.
+                </div>
+              )}
+            </div>
+          </aside>
+
+          <section className="space-y-3">
+            {isLoading ? (
+              <div className="rounded-2xl bg-card px-4 py-6 text-sm text-muted-foreground shadow-card">
+                랭킹 데이터를 불러오는 중입니다...
+              </div>
+            ) : (
+              <>
+                {topThree.length > 0 && (
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                    {topThree.map((entry) => (
+                      <button
+                        key={entry.userId}
+                        onClick={() => handleToggleRow(entry)}
+                        className={cn(
+                          "rounded-2xl bg-card px-4 py-4 text-left shadow-card transition hover:shadow-card-hover",
+                          expandedUserId === entry.userId && "ring-1 ring-primary/40",
+                        )}
+                      >
+                        <div className="mb-2 flex items-center gap-2">
+                          <RankBadge rank={entry.rank} />
+                          <span className="truncate text-sm font-semibold">{entry.nickname}</span>
+                        </div>
+                        <p className={cn(
+                          "font-mono text-lg font-extrabold tabular-nums",
+                          entry.profitRate >= 0 ? "text-positive" : "text-negative",
+                        )}>
+                          {formatProfitRate(entry.profitRate)}
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">{entry.tradeCount}회 거래</p>
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {entries.length === 0 && (
+                  <div className="rounded-2xl bg-card px-4 py-6 text-sm text-muted-foreground shadow-card">
+                    랭킹 데이터가 없습니다.
+                  </div>
+                )}
+
+                {[...restEntries].map((entry) => {
+                  const isExpanded = expandedUserId === entry.userId;
+                  const portfolio = portfolioByUser[entry.userId];
+                  const loadingPortfolio = portfolioLoadingByUser[entry.userId] ?? false;
+                  const portfolioError = portfolioErrorByUser[entry.userId] ?? "";
+
+                  return (
+                    <div key={entry.userId} className="overflow-hidden rounded-2xl bg-card shadow-card">
+                      <button
+                        onClick={() => handleToggleRow(entry)}
+                        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-primary/[0.03]"
+                      >
+                        <RankBadge rank={entry.rank} />
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-semibold">{entry.nickname}</p>
+                          <p className="text-[11px] text-muted-foreground">{entry.tradeCount}회 거래</p>
+                        </div>
+                        {!entry.portfolioPublic && <Lock className="h-4 w-4 text-muted-foreground" />}
+                        <span className={cn(
+                          "font-mono text-sm font-bold tabular-nums",
+                          entry.profitRate >= 0 ? "text-positive" : "text-negative",
+                        )}>
+                          {formatProfitRate(entry.profitRate)}
+                        </span>
+                      </button>
+
+                      {isExpanded && (
+                        <div className="border-t border-border/50 px-4 py-3">
+                          {!entry.portfolioPublic && (
+                            <p className="text-xs text-muted-foreground">비공개 포트폴리오입니다.</p>
+                          )}
+
+                          {entry.portfolioPublic && loadingPortfolio && (
+                            <p className="text-xs text-muted-foreground">포트폴리오를 불러오는 중입니다...</p>
+                          )}
+
+                          {entry.portfolioPublic && portfolioError && (
+                            <p className="text-xs text-destructive">{portfolioError}</p>
+                          )}
+
+                          {entry.portfolioPublic && portfolio && (
+                            <div className="space-y-2">
+                              {portfolio.holdings.length === 0 && (
+                                <p className="text-xs text-muted-foreground">보유 자산 정보가 없습니다.</p>
+                              )}
+
+                              {portfolio.holdings.map((holding) => {
+                                const ratio = asRatio(holding.assetRatio);
+                                return (
+                                  <div key={`${entry.userId}-${holding.coinSymbol}`} className="flex items-center gap-3">
+                                    <CoinIcon symbol={holding.coinSymbol} size={24} />
+                                    <div className="min-w-0 flex-1">
+                                      <div className="mb-1 flex items-center justify-between gap-2">
+                                        <span className="text-xs font-semibold">{holding.coinSymbol}</span>
+                                        <span className="font-mono text-xs font-semibold">
+                                          {(ratio * 100).toFixed(1)}%
+                                        </span>
+                                      </div>
+                                      <div className="h-1.5 w-full overflow-hidden rounded-full bg-secondary">
+                                        <div
+                                          className="h-full rounded-full bg-primary"
+                                          style={{ width: `${Math.max(0, Math.min(100, ratio * 100))}%` }}
+                                        />
+                                      </div>
+                                    </div>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+
+                {hasNext && (
+                  <button
+                    onClick={handleLoadMore}
+                    disabled={isLoadingMore}
+                    className="mt-2 w-full rounded-2xl border border-border/60 bg-white px-4 py-3 text-sm font-semibold text-muted-foreground transition hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isLoadingMore ? "불러오는 중..." : "랭킹 더보기"}
+                  </button>
+                )}
+
+                {error && <p className="text-xs font-medium text-destructive">{error}</p>}
+              </>
+            )}
+          </section>
         </div>
       </main>
     </div>
   );
 }
+

--- a/src/main/frontend/src/pages/RoundCreatePage.tsx
+++ b/src/main/frontend/src/pages/RoundCreatePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+﻿import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Rocket } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
@@ -20,6 +20,8 @@ export function RoundCreatePage() {
   const [seed, setSeed] = useState(0);
   const [emergencyLimit, setEmergencyLimit] = useState(0);
   const [rules, setRules] = useState<RulesMap>(getDefaultRules);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
 
   function handleRuleToggle(type: RuleType, enabled: boolean) {
     setRules((prev) => ({ ...prev, [type]: { ...prev[type], enabled } }));
@@ -32,18 +34,29 @@ export function RoundCreatePage() {
   const enabledRules = Object.entries(rules).filter(([, r]) => r.enabled);
   const canSubmit = seed > 0 && emergencyLimit > 0 && enabledRules.length >= 1;
 
-  function handleSubmit() {
+  async function handleSubmit() {
     if (!canSubmit || !user) return;
 
-    createRound({
+    setSubmitError("");
+    setIsSubmitting(true);
+
+    const created = await createRound({
       userId: user.userId,
       initialSeed: seed,
       emergencyFundingLimit: emergencyLimit,
-      rules: enabledRules.map(([type, r]) => ({
+      rules: enabledRules.map(([type, rule]) => ({
         ruleType: type as RuleType,
-        thresholdValue: r.value,
+        thresholdValue: rule.value,
       })),
     });
+
+    setIsSubmitting(false);
+
+    if (!created) {
+      setSubmitError("라운드 생성에 실패했습니다. 입력값을 다시 확인해 주세요.");
+      return;
+    }
+
     navigate("/market", { replace: true });
   }
 
@@ -51,19 +64,17 @@ export function RoundCreatePage() {
     <div className="min-h-dvh bg-background">
       <RoundCreateHeader />
 
-      {/* Hero */}
       <section className="bg-gradient-to-r from-primary/8 via-chart-2/6 to-primary/4 pb-8 pt-8">
         <div className="mx-auto max-w-2xl px-4">
-          <h1 className="text-3xl font-extrabold tracking-tight">새 라운드</h1>
+          <h1 className="text-3xl font-extrabold tracking-tight">투자 라운드 시작</h1>
           <p className="mt-1.5 text-sm font-medium text-muted-foreground">
-            시드머니와 투자 원칙을 설정하고 모의투자를 시작하세요
+            시드머니와 투자 원칙을 설정하고 모의투자를 시작하세요.
           </p>
         </div>
       </section>
 
       <main className="mx-auto max-w-2xl px-4 py-6">
         <div className="flex flex-col gap-8">
-          {/* 시드머니 섹션 */}
           <div>
             <h2 className="mb-4 text-lg font-extrabold tracking-tight">자금 설정</h2>
             <SeedMoneyCard
@@ -74,33 +85,30 @@ export function RoundCreatePage() {
             />
           </div>
 
-          {/* 투자 원칙 섹션 */}
           <InvestmentRulesSection
             rules={rules}
             onRuleToggle={handleRuleToggle}
             onRuleValueChange={handleRuleValueChange}
           />
 
-          {/* 제출 */}
           <div>
             <button
-              disabled={!canSubmit}
+              disabled={!canSubmit || isSubmitting}
               onClick={handleSubmit}
               className="flex h-12 w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-primary to-[#9A6AFF] text-sm font-bold text-white shadow-md transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg active:translate-y-0 disabled:pointer-events-none disabled:opacity-40"
             >
               <Rocket className="h-4 w-4" />
-              라운드 시작하기
+              {isSubmitting ? "생성 중..." : "라운드 시작하기"}
             </button>
 
             {!canSubmit && (
               <p className="mt-2 text-center text-[11px] text-muted-foreground">
-                {seed <= 0 && "시드머니"}
-                {seed <= 0 && emergencyLimit <= 0 && ", "}
-                {emergencyLimit <= 0 && "긴급 자금 상한"}
-                {(seed <= 0 || emergencyLimit <= 0) && enabledRules.length < 1 && ", "}
-                {enabledRules.length < 1 && "투자 원칙 1개 이상"}
-                {" "}설정이 필요합니다
+                시드머니, 긴급 자금 상한, 투자 원칙 1개 이상 설정이 필요합니다.
               </p>
+            )}
+
+            {submitError && (
+              <p className="mt-2 text-center text-xs font-medium text-destructive">{submitError}</p>
             )}
           </div>
         </div>
@@ -108,3 +116,4 @@ export function RoundCreatePage() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary

구현 완료된 백엔드 API 범위(`orders`, `rankings`, `rounds`)에 맞춰 프론트 화면을 실제 API 연동 상태로 정렬했다.
미구현 도메인(`wallet`, `portfolio`, `regret`, `mypage`)은 기존 화면을 그대로 유지했다.

- 공통 API 클라이언트 계층 추가 (`ApiResponseDto` 파싱/공통 에러 처리)
- 라운드 생성/활성 조회/긴급 자금 충전 API 연동
- 랭킹 목록/내 랭킹/통계/랭커 포트폴리오 API 연동
- 주문 가능 조회/주문 생성/주문 내역/주문 취소 API 연동
- 거래소+코인 기준 주문 ID 매핑 테이블 추가

---

## 주요 변경 사항

### 1) 공통 API 계층 추가

- `src/main/frontend/src/lib/api/*`
  - `client.ts`: `fetch` 래퍼, 쿼리 빌드, 응답 래핑 처리
  - `types.ts`: 공통 응답/에러 타입
  - `mappers.ts`: 프론트 enum ↔ 백엔드 enum 매핑
  - `id-mapping.ts`: `exchange + symbol -> walletId/exchangeCoinId` 변환
  - `round-api.ts`, `ranking-api.ts`, `order-api.ts`: 도메인별 API 함수

### 2) Round 연동

- `RoundContext`를 mock 중심 상태 관리에서 API 중심으로 전환
  - 활성 라운드 조회 (`GET /api/rounds/active`)
  - 라운드 생성 (`POST /api/rounds`)
  - 긴급 자금 충전 (`POST /api/rounds/{id}/emergency-funding`)
- `RoundGuard`에 로딩 경계 추가
- `RoundCreatePage`에 비동기 생성/오류 처리 반영

### 3) Ranking 연동

- `RankingPage`에서 mock 데이터 제거
- 기간별 랭킹, 내 랭킹, 통계 API 호출로 교체
- 랭커 포트폴리오는 row expand 시 lazy fetch
- 커서 기반 더보기(`nextCursor`, `hasNext`) 적용

### 4) Order 연동

- `OrderPanel`의 로컬 mock 주문 흐름 제거
- API 기반으로 교체
  - 주문 가능 (`GET /api/orders/available`)
  - 주문 생성 (`POST /api/orders`)
  - 주문 내역 (`GET /api/orders`)
  - 주문 취소 (`POST /api/orders/{id}/cancel`)
- `MarketPage`에서 선택 거래소/코인 기준 ID 매핑 연결
- 매핑 누락 시 주문 호출 차단 및 안내

---

## Test Plan

- [x] `npx tsc -p tsconfig.app.json --noEmit`
- [x] 라운드 생성 후 마켓 진입 확인
- [x] 랭킹 탭 전환 시 목록/통계/내 랭킹 확인
- [x] 주문 패널에서 가용 조회/주문 생성/내역/취소 흐름 확인

---

## 참고

- 본문 구성은 PR #2 형식을 참고했다.
- Closes #42