### PR TITLE
[#92] 인수테스트 INSERT SQL에 누락된 NOT NULL 컬럼 추가

### DIFF
--- a/src/test/java/ksh/tryptobackend/acceptance/steps/RankerPortfolioStepDefinition.java
+++ b/src/test/java/ksh/tryptobackend/acceptance/steps/RankerPortfolioStepDefinition.java
@@ -57,17 +57,20 @@ public class RankerPortfolioStepDefinition {
     }
 
     private void insertUsers() {
-        jdbcTemplate.execute("INSERT IGNORE INTO user (user_id, nickname, portfolio_public) VALUES "
-            + "(1, '트레이더1', true), "
-            + "(2, '트레이더2', false), "
-            + "(3, '트레이더3', true)");
+        LocalDateTime now = LocalDateTime.now();
+        jdbcTemplate.update(
+            "INSERT IGNORE INTO user (user_id, email, nickname, portfolio_public, created_at, updated_at) VALUES "
+                + "(1, 'trader1@test.com', '트레이더1', true, ?, ?), "
+                + "(2, 'trader2@test.com', '트레이더2', false, ?, ?), "
+                + "(3, 'trader3@test.com', '트레이더3', true, ?, ?)",
+            now, now, now, now, now, now);
     }
 
     private void insertExchangeAndCoins() {
         jdbcTemplate.execute("INSERT IGNORE INTO exchange_market (exchange_id, name, market_type, base_currency_coin_id) VALUES "
             + "(1, 'UPBIT', 'DOMESTIC', 1)");
-        jdbcTemplate.execute("INSERT IGNORE INTO coin (coin_id, symbol) VALUES "
-            + "(1, 'BTC'), (2, 'ETH')");
+        jdbcTemplate.execute("INSERT IGNORE INTO coin (coin_id, symbol, name) VALUES "
+            + "(1, 'BTC', 'Bitcoin'), (2, 'ETH', 'Ethereum')");
     }
 
     private void insertRankings() {

--- a/src/test/java/ksh/tryptobackend/acceptance/steps/RankingStepDefinition.java
+++ b/src/test/java/ksh/tryptobackend/acceptance/steps/RankingStepDefinition.java
@@ -95,9 +95,10 @@ public class RankingStepDefinition {
     }
 
     private void insertUser(Long userId, String nickname, boolean portfolioPublic) {
+        LocalDateTime now = LocalDateTime.now();
         jdbcTemplate.update(
-            "INSERT INTO user (user_id, nickname, portfolio_public) VALUES (?, ?, ?)",
-            userId, nickname, portfolioPublic
+            "INSERT INTO user (user_id, email, nickname, portfolio_public, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+            userId, nickname + "@test.com", nickname, portfolioPublic, now, now
         );
     }
 

--- a/src/test/java/ksh/tryptobackend/acceptance/steps/RegretChartStepDefinition.java
+++ b/src/test/java/ksh/tryptobackend/acceptance/steps/RegretChartStepDefinition.java
@@ -103,9 +103,10 @@ public class RegretChartStepDefinition {
     }
 
     private void insertUser() {
+        LocalDateTime now = LocalDateTime.now();
         jdbcTemplate.update(
-            "INSERT INTO user (user_id, nickname, portfolio_public) VALUES (?, ?, ?)",
-            USER_ID, "regretTester", true);
+            "INSERT INTO user (user_id, email, nickname, portfolio_public, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+            USER_ID, "regretTester@test.com", "regretTester", true, now, now);
     }
 
     private void insertExchanges() {

--- a/src/test/java/ksh/tryptobackend/acceptance/steps/RegretReportStepDefinition.java
+++ b/src/test/java/ksh/tryptobackend/acceptance/steps/RegretReportStepDefinition.java
@@ -146,8 +146,8 @@ public class RegretReportStepDefinition {
     }
 
     private void insertCoins() {
-        jdbcTemplate.update("INSERT INTO `coin` (`coin_id`, `symbol`) VALUES (?, ?)", KRW_COIN_ID, "KRW");
-        jdbcTemplate.update("INSERT INTO `coin` (`coin_id`, `symbol`) VALUES (?, ?)", BTC_COIN_ID, "BTC");
+        jdbcTemplate.update("INSERT INTO `coin` (`coin_id`, `symbol`, `name`) VALUES (?, ?, ?)", KRW_COIN_ID, "KRW", "Korean Won");
+        jdbcTemplate.update("INSERT INTO `coin` (`coin_id`, `symbol`, `name`) VALUES (?, ?, ?)", BTC_COIN_ID, "BTC", "Bitcoin");
     }
 
     private void insertExchanges() {


### PR DESCRIPTION
## Summary

엔티티에 NOT NULL 컬럼이 추가된 후 인수테스트 step definition의 JdbcTemplate INSERT SQL이 동기화되지 않아 14개 인수테스트가 실패하던 문제를 수정한다.

- **User 테이블** — `email`, `created_at`, `updated_at` 컬럼 추가
- **Coin 테이블** — `name` 컬럼 추가

---

## 주요 변경 사항

### 인수테스트 Step Definition (4개 파일)

| 파일 | 변경 내용 |
|------|----------|
| `RankingStepDefinition` | `insertUser()` SQL에 `email`, `created_at`, `updated_at` 추가 |
| `RegretChartStepDefinition` | `insertUser()` SQL에 동일 3개 컬럼 추가 |
| `RankerPortfolioStepDefinition` | `insertUsers()` SQL에 동일 3개 컬럼 추가, `insertExchangeAndCoins()` coin SQL에 `name` 추가 |
| `RegretReportStepDefinition` | `insertCoins()` SQL에 `name` 추가 |

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| JdbcTemplate SQL에 직접 컬럼 추가 | JPA repository가 아닌 raw SQL로 데이터를 삽입하는 기존 방식 유지 |
| `execute` → `update` 변경 (RankerPortfolio) | `INSERT IGNORE`에 파라미터 바인딩이 필요하여 `update()` 메서드 사용 |

---

## Test Plan

### 인수 테스트

- [x] 랭킹 목록 조회 — 일간 랭킹 조회 성공
- [x] 랭킹 목록 조회 — 기준 날짜 지정 랭킹 조회 성공
- [x] 랭킹 목록 조회 — 커서 기반 페이징 조회
- [x] 랭킹 목록 조회 — 존재하지 않는 기간 조회 시 실패
- [x] 랭커 포트폴리오 조회 — 비공개 포트폴리오 조회 실패
- [x] 복기 그래프 데이터 조회 — 5개 시나리오 전체 통과
- [x] 투자 복기 리포트 조회 — 4개 시나리오 전체 통과

Closes #92