### PR TITLE
[#215] 마켓 화면의 null 가능 값 방어 누락 수정

### DIFF
--- a/frontend/src/components/market/OrderPanel.tsx
+++ b/frontend/src/components/market/OrderPanel.tsx
@@ -292,6 +292,11 @@ export function OrderPanel({
   };
 
   async function handleCancel(orderId: number) {
+    if (!orderTargetIds) {
+      setHistoryError("선택한 거래소/코인의 주문 매핑이 없습니다.");
+      return;
+    }
+
     try {
       await cancelOrder(orderId, orderTargetIds.walletId);
       setHistoryItems((prev) => prev.filter((item) => item.orderId !== orderId));

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -33,7 +33,7 @@ export function MarketPage() {
   const handleOrderFilled = useCallback((event: UserEvent) => {
     setOrderFilledEvent(event);
   }, []);
-  useUserEvents({ userId: user.userId, onOrderFilled: handleOrderFilled });
+  useUserEvents({ userId: user?.userId ?? null, onOrderFilled: handleOrderFilled });
 
   const marketType = (searchParams.get("type") === "dex" ? "dex" : "cex") as MarketType;
   const isCex = marketType === "cex";


### PR DESCRIPTION
## Summary

마켓 화면에서 `null` 일 수 있는 두 값을 검사 없이 읽던 곳을 방어한다. 런타임 오류를 막고, 프로덕션 빌드의 strict 타입 검사(TS18047)도 통과하게 된다.

- **로그인 사용자** — `useUserEvents` 에 넘기는 사용자 식별자를 `user?.userId ?? null` 로 좁힌다.
- **주문 대상 매핑** — 주문 취소 진입부에서 매핑 결과가 없으면 즉시 반환한다.

---

## 주요 변경 사항

### 화면

- `MarketPage` — `useUserEvents({ userId: user?.userId ?? null })`. `useUserEvents` 는 이미 `number | null` 을 받도록 선언돼 있어 훅 쪽 변경은 필요 없다.
- `OrderPanel` — `handleCancel` 진입부에 `orderTargetIds` null 가드를 추가한다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 사용자가 없을 때 훅을 끄지 않고 `null` 을 넘긴다 | `useUserEvents` 가 이미 `null` 을 받아 구독을 보류하도록 설계돼 있어, 호출부에서 조건부 훅을 쓰면 오히려 훅 규칙을 어기게 된다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사(`tsc -b`) 오류 0건
- [x] 세션이 복구되기 전(마켓 직접 진입)에도 화면이 정상 렌더됨
- [x] 매핑 실패 상태에서 주문 취소를 눌러도 오류가 나지 않음

Closes #215