### PR TITLE
[#217] 프론트엔드 프로덕션 빌드·서빙 경로 구축

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@ KAKAO_REDIRECT_URI=http://localhost:5173/auth/kakao/callback
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:5173/auth/google/callback
+
+# 프론트엔드 프로덕션 이미지(docker-compose.prod.yml) 빌드 인자.
+# 클라이언트 ID 는 브라우저에 노출되는 공개값이라 시크릿이 아니다. 시크릿은 위 백엔드 항목에만 둔다.
+# 개발 서버(Vite)는 이 값이 아니라 frontend/.env.local 을 읽는다.
+VITE_KAKAO_CLIENT_ID=
+VITE_KAKAO_REDIRECT_URI=http://localhost:5173/auth/kakao/callback
+VITE_GOOGLE_CLIENT_ID=
+VITE_GOOGLE_REDIRECT_URI=http://localhost:5173/auth/google/callback

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,8 +26,10 @@ services:
     environment: !reset {}
     ports: !override
       - "5173:80"
+    # nginx 는 IPv4 에만 붙는다 (공식 이미지의 IPv6 자동 추가 스크립트는 default.conf 를
+    # 덮어쓰면 동작하지 않는다). 컨테이너 안에서 localhost 는 ::1 로 먼저 풀리므로 주소를 못 잡는다.
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--spider", "http://localhost/"]
+      test: ["CMD", "wget", "--quiet", "--spider", "http://127.0.0.1/"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,34 @@
+# 프로덕션 프론트엔드 오버레이.
+# 기본 compose 의 frontend 는 Vite 개발 서버(소스 마운트 + HMR)라 배포에 쓸 수 없다.
+# 이 파일을 겹쳐 올리면 같은 자리에 빌드된 정적 번들을 nginx 가 서빙한다.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build frontend
+#
+# VITE_ 값은 빌드 시점에 번들에 박히므로, 값을 바꾸면 반드시 --build 로 다시 굽는다.
+services:
+  frontend:
+    image: ${FRONTEND_IMAGE:-kimsehee98/trypto-frontend:v1}
+    build:
+      context: ./frontend
+      args:
+        VITE_KAKAO_CLIENT_ID: ${VITE_KAKAO_CLIENT_ID:-}
+        VITE_KAKAO_REDIRECT_URI: ${VITE_KAKAO_REDIRECT_URI:-http://localhost:5173/auth/kakao/callback}
+        VITE_KAKAO_AUTH_URL: ${VITE_KAKAO_AUTH_URL:-https://kauth.kakao.com/oauth/authorize}
+        VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID:-}
+        VITE_GOOGLE_REDIRECT_URI: ${VITE_GOOGLE_REDIRECT_URI:-http://localhost:5173/auth/google/callback}
+        VITE_GOOGLE_AUTH_URL: ${VITE_GOOGLE_AUTH_URL:-https://accounts.google.com/o/oauth2/v2/auth}
+    # 개발 서버용 설정을 전부 걷어낸다 (소스 마운트·npm run dev·파일 감시).
+    # ports 와 volumes 는 오버레이가 이어붙이는 필드라 !override / !reset 로 명시적으로 덮어쓴다.
+    # 그러지 않으면 5173:5173 과 5173:80 이 함께 남아 컨테이너가 자기 포트와 충돌한다.
+    command: !override []
+    working_dir: /
+    volumes: !reset []
+    environment: !reset {}
+    ports: !override
+      - "5173:80"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--spider", "http://localhost/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.env
+.env.local
+.env.*.local
+tests
+playwright-report
+test-results

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,34 @@
+# 1단계: 프로덕션 번들 빌드
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+# VITE_ 값은 런타임 환경변수가 아니라 빌드 시점에 번들에 박힌다. 따라서 build arg 로 받는다.
+# 클라이언트 ID 와 redirect URI 는 브라우저에 노출되는 공개값이며, 시크릿은 백엔드에만 둔다.
+ARG VITE_KAKAO_CLIENT_ID
+ARG VITE_KAKAO_REDIRECT_URI
+ARG VITE_KAKAO_AUTH_URL
+ARG VITE_GOOGLE_CLIENT_ID
+ARG VITE_GOOGLE_REDIRECT_URI
+ARG VITE_GOOGLE_AUTH_URL
+
+ENV VITE_KAKAO_CLIENT_ID=$VITE_KAKAO_CLIENT_ID \
+    VITE_KAKAO_REDIRECT_URI=$VITE_KAKAO_REDIRECT_URI \
+    VITE_KAKAO_AUTH_URL=$VITE_KAKAO_AUTH_URL \
+    VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID \
+    VITE_GOOGLE_REDIRECT_URI=$VITE_GOOGLE_REDIRECT_URI \
+    VITE_GOOGLE_AUTH_URL=$VITE_GOOGLE_AUTH_URL
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# 2단계: 정적 파일 서빙
+FROM nginx:1.27-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -11,8 +11,7 @@ server {
 
     # 해시가 박힌 번들 파일은 내용이 바뀌면 이름도 바뀌므로 장기 캐시가 안전하다.
     location /assets/ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
+        add_header Cache-Control "public, max-age=31536000, immutable";
     }
 
     location /api/ {

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,41 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+
+    # 해시가 박힌 번들 파일은 내용이 바뀌면 이름도 바뀌므로 장기 캐시가 안전하다.
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /api/ {
+        proxy_pass http://backend:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # STOMP over WebSocket. 시세 스트림이 끊기지 않도록 타임아웃을 길게 잡는다.
+    location /ws {
+        proxy_pass http://backend:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    # SPA 라우팅. 서버에 없는 경로는 index.html 로 넘겨 클라이언트 라우터가 처리한다.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: '../resources/static',
+    outDir: 'dist',
     emptyOutDir: true,
   },
 })


### PR DESCRIPTION
## Summary

프론트엔드를 프로덕션 번들로 빌드해 nginx 로 서빙하는 경로를 만든다.

- **멀티 스테이지 Dockerfile** — Node 로 번들을 만들고 nginx 이미지에 정적 파일만 실어 보낸다.
- **nginx 설정** — SPA history fallback, `/api` 프록시, 정적 자산 캐시 정책.
- **프로덕션 컴포즈** — `docker-compose.prod.yml` 에 프론트엔드 컨테이너를 정의한다.
- **빌드 산출물 경로 교정** — `outDir` 을 `../resources/static` 에서 `dist` 로 바로잡는다.

---

## 핵심 흐름

```
docker compose -f docker-compose.prod.yml up
  └─ frontend (multi-stage)
       build stage : npm ci → npm run build (tsc -b && vite build) → /app/dist
       serve stage : nginx  ← COPY --from=build /app/dist
                      ├─ /            → index.html (SPA fallback)
                      ├─ /assets/*    → 정적 자산 (장기 캐시)
                      └─ /api/*       → api 컨테이너로 프록시
```

---

## 주요 변경 사항

### 인프라 및 설정

- `frontend/Dockerfile` — 빌드 스테이지와 서빙 스테이지를 분리한 멀티 스테이지 빌드.
- `frontend/nginx.conf` — SPA fallback, `/api` 프록시, 정적 자산 `Cache-Control` 을 한 줄로 정리.
- `frontend/.dockerignore` — `node_modules`·`dist` 등 빌드 컨텍스트에서 제외.
- `docker-compose.prod.yml` — 프론트엔드 서비스와 헬스체크 정의. 헬스체크 주소는 `127.0.0.1` 로 고정한다.
- `.env.example` — 프론트엔드 빌드에 필요한 환경 변수 추가.
- `frontend/vite.config.ts` — `outDir` 을 `dist` 로 교정(Dockerfile 의 `COPY --from=build /app/dist` 와 짝).

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 헬스체크 주소를 `localhost` 가 아니라 `127.0.0.1` 로 고정 | 컨테이너 안에서 `localhost` 가 IPv6(`::1`)로 풀리는데 nginx 는 IPv4 로만 listen 해 헬스체크가 항상 실패한다 |
| 정적 자산 `Cache-Control` 을 한 줄로 통합 | 같은 헤더를 두 곳에서 내리면 응답에 중복으로 실린다 |
| 빌드 스테이지에서 `tsc -b` 를 함께 돌린다 | 타입 오류가 있는 코드가 이미지로 굳는 것을 막는 게이트가 된다 |

---

## Test Plan

- [x] `npm run build`(= `tsc -b && vite build`) 성공, 산출물이 `frontend/dist` 에 생성됨
- [x] 타입 검사 오류 0건

Closes #217