### PR TITLE
[#219] 캔들 조회 시 Influx 태그명을 symbol 로 맞춤

### DIFF
--- a/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/BtcPriceHistoryQueryAdapter.java
+++ b/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/BtcPriceHistoryQueryAdapter.java
@@ -74,8 +74,8 @@ public class BtcPriceHistoryQueryAdapter implements BtcPriceHistoryQueryPort {
                 + " and r.exchange == \""
                 + source.exchange()
                 + "\""
-                + " and r.coin == \""
-                + source.coin()
+                + " and r.symbol == \""
+                + source.symbol()
                 + "\" and r._field == \"close\") |> aggregateWindow(every: 1d, fn: last,"
                 + " createEmpty: false, timeSrc: \"_start\") |> sort(columns: [\"_time\"])";
     }
@@ -115,7 +115,7 @@ public class BtcPriceHistoryQueryAdapter implements BtcPriceHistoryQueryPort {
     }
 
     private BigDecimal queryTickerPrice(BtcPriceSource source) {
-        String key = TICKER_KEY_PREFIX + source.exchange() + ":" + source.coin();
+        String key = TICKER_KEY_PREFIX + source.exchange() + ":" + source.symbol();
         String json = redisTemplate.opsForValue().get(key);
         if (json == null) {
             return null;
@@ -136,5 +136,5 @@ public class BtcPriceHistoryQueryAdapter implements BtcPriceHistoryQueryPort {
         return BigDecimal.ZERO;
     }
 
-    private record BtcPriceSource(String exchange, String coin) {}
+    private record BtcPriceSource(String exchange, String symbol) {}
 }

--- a/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/CandleQueryAdapter.java
+++ b/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/CandleQueryAdapter.java
@@ -53,7 +53,7 @@ public class CandleQueryAdapter implements CandleQueryPort {
                 .append(filter.interval().getMeasurement())
                 .append("\"");
         sb.append(" and r.exchange == \"").append(filter.exchange()).append("\"");
-        sb.append(" and r.coin == \"").append(filter.coin()).append("\"");
+        sb.append(" and r.symbol == \"").append(filter.symbol()).append("\"");
         sb.append(" and (r._field == \"open\" or r._field == \"high\" or r._field == \"low\" or"
                 + " r._field == \"close\"))");
         sb.append(" |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")");

--- a/api/src/main/java/ksh/tryptobackend/marketdata/domain/model/CandleFilter.java
+++ b/api/src/main/java/ksh/tryptobackend/marketdata/domain/model/CandleFilter.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 import ksh.tryptobackend.common.exception.CustomException;
 import ksh.tryptobackend.common.exception.ErrorCode;
 
-public record CandleFilter(String exchange, String coin, CandleInterval interval, int limit, Instant cursor) {
+public record CandleFilter(String exchange, String symbol, CandleInterval interval, int limit, Instant cursor) {
 
     private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
     private static final String MARKET_SYMBOL_SEPARATOR = "/";

--- a/api/src/test/java/ksh/tryptobackend/marketdata/application/service/FindCandlesServiceTest.java
+++ b/api/src/test/java/ksh/tryptobackend/marketdata/application/service/FindCandlesServiceTest.java
@@ -119,7 +119,7 @@ class FindCandlesServiceTest {
 
             // Then
             verify(candleQueryPort).findByFilter(captor.capture());
-            assertThat(captor.getValue().coin()).isEqualTo("BTC/KRW");
+            assertThat(captor.getValue().symbol()).isEqualTo("BTC/KRW");
         }
 
         @Test
@@ -135,7 +135,7 @@ class FindCandlesServiceTest {
 
             // Then
             verify(candleQueryPort).findByFilter(captor.capture());
-            assertThat(captor.getValue().coin()).isEqualTo("ETH/USDT");
+            assertThat(captor.getValue().symbol()).isEqualTo("ETH/USDT");
         }
     }
 

--- a/docs/contracts/influx-candle.md
+++ b/docs/contracts/influx-candle.md
@@ -24,7 +24,7 @@
 | 구분 | 이름 | 타입 | 설명 |
 |------|------|------|------|
 | tag | `exchange` | String | 거래소 식별자 (UPBIT, BITHUMB, BINANCE) |
-| tag | `coin` | String | 코인 심볼 (BTC, ETH 등) |
+| tag | `symbol` | String | 마켓 심볼, `BASE/QUOTE` 형식 (BTC/KRW, ETH/USDT 등) |
 | field | `open` | Float | 시가 |
 | field | `high` | Float | 고가 |
 | field | `low` | Float | 저가 |


### PR DESCRIPTION
## Summary

collector 가 `symbol` 태그로 적재한 캔들을 api 가 `coin` 태그로 질의해 결과가 항상 비어 있던 문제를 고친다.

- **질의 태그 교정** — 캔들·BTC 일봉 조회의 Influx 태그명을 `symbol` 로 맞춘다.
- **계약 문서 동기화** — 같은 결함을 다시 만들지 않도록 계약 문서의 태그명을 바로잡는다.

---

## 주요 변경 사항

### 어댑터 계층

- `CandleQueryAdapter` — Flux 질의의 태그 필터를 `coin` → `symbol` 로 교정한다.
- `BtcPriceHistoryQueryAdapter` — 동일하게 교정한다.

### 도메인 계층

- `CandleFilter` — 필드명을 `coin` → `symbol` 로 바꿔 적재 측 용어와 일치시킨다. 내부 이름이라 컨트롤러·요청 DTO 는 그대로이며 외부 API 계약은 바뀌지 않는다.

### 문서

- `docs/contracts/influx-candle.md` — 태그명을 `symbol` 로 갱신한다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 조회 쪽을 `symbol` 로 맞춘다(적재 쪽을 `coin` 으로 바꾸지 않는다) | 이미 적재된 시계열 데이터가 `symbol` 태그를 갖고 있어, 적재 측을 바꾸면 기존 데이터를 조회할 수 없게 된다 |
| `CandleFilter` 필드명까지 함께 바꾼다 | 조회 조건 객체가 계속 `coin` 이면 다음 사람이 같은 혼동을 반복한다 |

---

## Test Plan

### 단위 테스트

- [x] `FindCandlesServiceTest` — 필드명 변경 반영, 통과
- [x] `compileJava`, `compileTestJava` 성공

Closes #219