### PR TITLE
[#225] 주문 불가 사유를 구분해 안내

### DIFF
--- a/frontend/src/components/market/OrderPanel.tsx
+++ b/frontend/src/components/market/OrderPanel.tsx
@@ -1,4 +1,5 @@
 ﻿import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -13,7 +14,7 @@ import {
   type OrderStatus,
 } from "@/lib/api/order-api";
 import { isApiClientError } from "@/lib/api/types";
-import type { OrderTargetIds } from "@/lib/api/id-mapping";
+import type { OrderTargetFailure, OrderTargetIds } from "@/lib/api/id-mapping";
 import type { UserEvent } from "@/lib/api/websocket";
 
 type OrderTab = "buy" | "sell" | "history";
@@ -26,6 +27,7 @@ interface OrderPanelProps {
   currentPrice: number;
   feeRate: number;
   orderTargetIds: OrderTargetIds | null;
+  orderTargetFailure: OrderTargetFailure | null;
   orderFilledEvent: UserEvent | null;
 }
 
@@ -97,6 +99,7 @@ export function OrderPanel({
   currentPrice,
   feeRate,
   orderTargetIds,
+  orderTargetFailure,
   orderFilledEvent,
 }: OrderPanelProps) {
   const [activeTab, setActiveTab] = useState<OrderTab>("buy");
@@ -380,9 +383,27 @@ export function OrderPanel({
             </div>
           </div>
 
-          {mappedUnavailable && (
+          {mappedUnavailable && orderTargetFailure === "NO_ROUND" && (
+            <div className="mt-4 rounded-xl border border-warning/30 bg-warning/10 px-3 py-3 text-xs text-warning-foreground">
+              <p>진행 중인 라운드가 없어 주문할 수 없습니다.</p>
+              <Link
+                to="/round/new"
+                className="mt-2 inline-block font-semibold underline underline-offset-2"
+              >
+                라운드 시작하기
+              </Link>
+            </div>
+          )}
+
+          {mappedUnavailable && orderTargetFailure === "COIN_UNLISTED" && (
             <div className="mt-4 rounded-xl border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
-              이 코인은 아직 주문 ID 매핑이 없어 주문 API를 호출할 수 없습니다.
+              이 코인은 아직 주문을 지원하지 않습니다.
+            </div>
+          )}
+
+          {mappedUnavailable && orderTargetFailure === "LOOKUP_FAILED" && (
+            <div className="mt-4 rounded-xl border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
+              주문 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
             </div>
           )}
 

--- a/frontend/src/lib/api/id-mapping.ts
+++ b/frontend/src/lib/api/id-mapping.ts
@@ -6,6 +6,12 @@ export interface OrderTargetIds {
   exchangeCoinId: number;
 }
 
+export type OrderTargetFailure = "NO_ROUND" | "COIN_UNLISTED" | "LOOKUP_FAILED";
+
+export type OrderTargetResult =
+  | { ok: true; ids: OrderTargetIds }
+  | { ok: false; reason: OrderTargetFailure };
+
 const BACKEND_EXCHANGE_ID_MAP: Record<string, number> = {
   upbit: 1,
   bithumb: 2,
@@ -41,24 +47,27 @@ export async function resolveOrderTargetIds(
   exchangeKey: string,
   coinSymbol: string,
   getWalletId: (exchangeId: number) => number | null,
-): Promise<OrderTargetIds | null> {
+): Promise<OrderTargetResult> {
   const exchangeId = getBackendExchangeId(exchangeKey);
-  if (!exchangeId) return null;
+  if (!exchangeId) return { ok: false, reason: "LOOKUP_FAILED" };
 
   const walletId = getWalletId(exchangeId);
-  if (!walletId) return null;
+  if (!walletId) return { ok: false, reason: "NO_ROUND" };
 
   try {
     const coins = await fetchExchangeCoinsWithCache(exchangeId);
     const coin = coins.find((c) => c.coinSymbol.toUpperCase() === coinSymbol.toUpperCase());
-    if (!coin) return null;
+    if (!coin) return { ok: false, reason: "COIN_UNLISTED" };
 
     return {
-      exchangeId,
-      walletId,
-      exchangeCoinId: coin.exchangeCoinId,
+      ok: true,
+      ids: {
+        exchangeId,
+        walletId,
+        exchangeCoinId: coin.exchangeCoinId,
+      },
     };
   } catch {
-    return null;
+    return { ok: false, reason: "LOOKUP_FAILED" };
   }
 }

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -12,7 +12,7 @@ import { EmergencyFundingCard } from "@/components/round/EmergencyFundingCard";
 import { useRound } from "@/contexts/RoundContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { EXCHANGES } from "@/lib/types/coins";
-import { resolveOrderTargetIds, type OrderTargetIds } from "@/lib/api/id-mapping";
+import { resolveOrderTargetIds, type OrderTargetResult } from "@/lib/api/id-mapping";
 import { useExchangeCoins } from "@/hooks/useExchangeCoins";
 import { useTickers } from "@/hooks/useTickers";
 import { useUserEvents } from "@/hooks/useUserEvents";
@@ -78,19 +78,22 @@ export function MarketPage() {
     return fromSelection ?? filteredCoins[0] ?? coins[0];
   }, [coins, filteredCoins, selectedSymbol]);
 
-  const [orderTargetIds, setOrderTargetIds] = useState<OrderTargetIds | null>(null);
+  const [orderTarget, setOrderTarget] = useState<OrderTargetResult | null>(null);
   const selectedCoinSymbol = selectedCoin?.symbol ?? null;
   useEffect(() => {
     if (!selectedCoinSymbol) {
-      setOrderTargetIds(null);
+      setOrderTarget(null);
       return;
     }
     let cancelled = false;
-    void resolveOrderTargetIds(exchange.key, selectedCoinSymbol, getWalletId).then((ids) => {
-      if (!cancelled) setOrderTargetIds(ids);
+    void resolveOrderTargetIds(exchange.key, selectedCoinSymbol, getWalletId).then((result) => {
+      if (!cancelled) setOrderTarget(result);
     });
     return () => { cancelled = true; };
   }, [exchange.key, selectedCoinSymbol, getWalletId]);
+
+  const orderTargetIds = orderTarget?.ok ? orderTarget.ids : null;
+  const orderTargetFailure = orderTarget && !orderTarget.ok ? orderTarget.reason : null;
 
   const handleExchangeChange = (key: string) => {
     setSearchParams({ exchange: key });
@@ -183,6 +186,7 @@ export function MarketPage() {
                   currentPrice={selectedCoin.currentPrice}
                   feeRate={0.0005}
                   orderTargetIds={orderTargetIds}
+                  orderTargetFailure={orderTargetFailure}
                   orderFilledEvent={orderFilledEvent}
                 />
               )}


### PR DESCRIPTION
## Summary

주문 대상을 해석하지 못했을 때 원인을 구분해 안내한다.

- **판별 유니온 도입** — `resolveOrderTargetIds` 의 반환을 `OrderTargetIds | null` 에서 성공/실패와 실패 사유를 담은 `OrderTargetResult` 로 바꾼다.
- **사유별 안내** — 코인 미상장 / 조회 실패 / 진행 중인 라운드 없음을 구분해 주문 패널에 표시하고, 라운드가 없으면 라운드 시작 링크를 함께 보여준다.

---

## 주요 변경 사항

### 매핑

- `lib/api/id-mapping.ts` — `OrderTargetResult` 판별 유니온(`ok` / `reason`)을 도입한다. 실패 사유는 `COIN_NOT_LISTED`, `LOOKUP_FAILED`, `NO_ROUND`.

### 화면

- `OrderPanel` — 실패 사유를 받아 각각 다른 안내를 렌더한다.
- `MarketPage` — 해석 결과를 사유와 함께 주문 패널로 넘긴다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| `null` 반환 대신 판별 유니온 | `null` 하나로는 실패 사유를 실어 보낼 수 없어 호출부가 원인을 추측할 수밖에 없다 |
| 타입 변경과 호출부를 한 커밋에 둔다 | 반환 타입이 바뀌므로 매핑·주문 패널·마켓 화면이 함께 바뀌어야 타입 검사가 통과한다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 상장되지 않은 코인 선택 시 미상장 안내가 뜸
- [x] 진행 중인 라운드가 없을 때 라운드 시작 링크가 뜸

Closes #225