### PR TITLE
[#227] 지갑·포트폴리오 조회 경로에서 userId 제거

### DIFF
--- a/frontend/src/lib/api/portfolio-api.ts
+++ b/frontend/src/lib/api/portfolio-api.ts
@@ -16,9 +16,6 @@ export interface MyHoldingsResponse {
   holdings: HoldingItem[];
 }
 
-export function getMyHoldings(
-  userId: number,
-  walletId: number,
-): Promise<MyHoldingsResponse> {
-  return apiGet<MyHoldingsResponse>(`/api/users/${userId}/wallets/${walletId}/portfolio`);
+export function getMyHoldings(walletId: number): Promise<MyHoldingsResponse> {
+  return apiGet<MyHoldingsResponse>(`/api/wallets/${walletId}/portfolio`);
 }

--- a/frontend/src/lib/api/wallet-api.ts
+++ b/frontend/src/lib/api/wallet-api.ts
@@ -14,9 +14,6 @@ export interface WalletBalancesResponse {
   balances: WalletBalanceItem[];
 }
 
-export function getWalletBalances(
-  userId: number,
-  walletId: number,
-): Promise<WalletBalancesResponse> {
-  return apiGet<WalletBalancesResponse>(`/api/users/${userId}/wallets/${walletId}/balances`);
+export function getWalletBalances(walletId: number): Promise<WalletBalancesResponse> {
+  return apiGet<WalletBalancesResponse>(`/api/wallets/${walletId}/balances`);
 }

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -70,7 +70,7 @@ export function PortfolioPage() {
 
     setLoading(true);
     try {
-      const data = await getMyHoldings(user.userId, wallet.walletId);
+      const data = await getMyHoldings(wallet.walletId);
       setPortfolio(toPortfolioSummary(exchange.id, data));
     } catch (error) {
       console.error("Failed to load portfolio", error);

--- a/frontend/src/pages/WalletPage.tsx
+++ b/frontend/src/pages/WalletPage.tsx
@@ -72,7 +72,7 @@ export function WalletPage() {
     setLoading(true);
     try {
       const [balancesData, exchangeCoins, transferData] = await Promise.all([
-        getWalletBalances(user.userId, walletEntry.walletId),
+        getWalletBalances(walletEntry.walletId),
         getExchangeCoins(exchange.id),
         getTransferHistory(walletEntry.walletId, user.userId, { size: 50 }),
       ]);


### PR DESCRIPTION
## Summary

프론트가 서버에 없는 `/api/users/{userId}/wallets/...` 경로를 호출해 지갑 잔고·포트폴리오 조회가 실패하던 문제를 고친다. 서버 매핑(`/api/wallets/{walletId}/...`)에 맞춰 경로를 바로잡고, 더는 필요 없는 `userId` 인자를 걷어낸다.

---

## 주요 변경 사항

### API 클라이언트

- `wallet-api.ts` — `getWalletBalances(walletId)`. 경로를 `/api/wallets/{walletId}/balances` 로 교정하고 `userId` 인자를 제거한다.
- `portfolio-api.ts` — `getMyHoldings(walletId)`. 경로를 `/api/wallets/{walletId}/portfolio` 로 교정한다.

### 화면

- `WalletPage`, `PortfolioPage` — 인자가 줄어든 호출부를 맞춘다. `useAuth`/`user` 는 화면 가드와 훅 의존성에서 계속 쓰이므로 그대로 둔다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 서버가 아니라 프론트를 고친다 | 지갑 식별자만으로 소유자를 특정할 수 있고 인증 주체는 세션에서 나온다. 경로에 `userId` 를 실으면 남의 지갑을 조회하는 형태가 그대로 노출된다 |
| API 클라이언트와 호출부를 한 커밋에 | 인자 개수가 2개 → 1개로 바뀌어 한쪽만 올리면 타입 검사가 깨진다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 지갑 화면에서 잔고가 조회됨
- [x] 투자내역 화면에서 보유 자산이 조회됨

Closes #227