### PR TITLE
[#229] 송금 중복 제출을 막고 성공 시 지갑을 갱신

### DIFF
--- a/frontend/src/components/wallet/TransferModal.tsx
+++ b/frontend/src/components/wallet/TransferModal.tsx
@@ -28,6 +28,7 @@ export interface TransferDestination {
 interface TransferModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onSuccess?: () => void;
   coin: WalletCoinBalance;
   baseCurrency: string;
   fromWalletId: number;
@@ -37,6 +38,7 @@ interface TransferModalProps {
 export function TransferModal({
   isOpen,
   onClose,
+  onSuccess,
   coin,
   baseCurrency,
   fromWalletId,
@@ -45,6 +47,7 @@ export function TransferModal({
   const [selectedDestination, setSelectedDestination] = useState("");
   const [amountStr, setAmountStr] = useState("");
   const [submitted, setSubmitted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const amount = parseFloat(amountStr) || 0;
@@ -65,12 +68,14 @@ export function TransferModal({
   async function handleSubmit() {
     setSubmitted(true);
     setError(null);
+    if (submitting) return;
     if (!selectedDestination || amount <= 0 || amount > coin.available) return;
     if (!coin.coinId) return;
 
     const dest = destinations.find((d) => d.exchangeId === selectedDestination);
     if (!dest) return;
 
+    setSubmitting(true);
     try {
       await createTransfer({
         idempotencyKey: crypto.randomUUID(),
@@ -79,9 +84,12 @@ export function TransferModal({
         coinId: coin.coinId,
         amount,
       });
+      onSuccess?.();
       onClose();
     } catch {
       setError("송금에 실패했습니다.");
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -176,8 +184,8 @@ export function TransferModal({
           )}
 
           {/* Submit */}
-          <Button className="w-full" onClick={handleSubmit}>
-            출금하기
+          <Button className="w-full" onClick={handleSubmit} disabled={submitting}>
+            {submitting ? "출금 중..." : "출금하기"}
           </Button>
         </div>
       </DialogContent>

--- a/frontend/src/pages/WalletPage.tsx
+++ b/frontend/src/pages/WalletPage.tsx
@@ -218,20 +218,20 @@ export function WalletPage() {
               {/* Desktop: side panel */}
               {selectedCoin && (
                 <div className="hidden lg:block">
-                  <div className="sticky top-24">
+                  <div className="sticky top-24 flex max-h-[calc(100vh-7rem)] flex-col gap-4 overflow-y-auto">
                     <WalletAssetDetail
                       coin={selectedCoin}
                       baseCurrency={wallet.baseCurrency}
                       onClose={() => setSelectedCoin(null)}
                       onTransfer={handleTransfer}
                     />
+                    <TransferHistoryPanel
+                      exchangeId={wallet.exchangeId}
+                      exchanges={walletList}
+                      records={transfers}
+                      assetFilter={selectedCoin.coinSymbol}
+                    />
                   </div>
-                  <TransferHistoryPanel
-                    exchangeId={wallet.exchangeId}
-                    exchanges={walletList}
-                    records={transfers}
-                    assetFilter={selectedCoin.coinSymbol}
-                  />
                 </div>
               )}
             </div>
@@ -279,6 +279,7 @@ export function WalletPage() {
         <TransferModal
           isOpen
           onClose={() => setTransferCoin(null)}
+          onSuccess={() => { void loadWalletData(); }}
           coin={transferCoin}
           baseCurrency={wallet.baseCurrency}
           fromWalletId={wallet.walletId}


### PR DESCRIPTION
## Summary

송금 요청 중 버튼을 다시 눌러 중복 송금이 나갈 수 있던 문제를 막고, 송금 성공 시 지갑 잔고를 다시 조회해 화면에 반영한다.

- **제출 잠금** — 요청이 진행 중이면 제출 버튼을 잠근다.
- **성공 후 갱신** — 송금이 성공하면 지갑 잔고를 재조회한다.

---

## 주요 변경 사항

### 화면

- `TransferModal` — `submitting` 상태로 제출을 잠그고, 성공 시 호출할 `onSuccess` prop 을 받는다.
- `WalletPage` — `onSuccess` 로 `loadWalletData` 를 넘겨 송금 성공 후 잔고를 다시 불러온다. 곁들여 데스크톱 사이드 패널을 sticky 로 두고 이체 내역을 같은 컬럼 안으로 옮긴다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 화면에서 제출을 잠근다 | 중복 클릭이라는 원인을 입구에서 막는다. 서버 멱등 처리는 별개 주제로 다룬다 |
| 성공 콜백으로 재조회 | 모달이 지갑 조회 로직을 알 필요 없이, 지갑 화면이 자기 데이터를 갱신하게 한다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 송금 요청 중 제출 버튼이 잠김
- [x] 송금 성공 후 지갑 잔고가 갱신됨

Closes #229