### PR TITLE
[#231] 위반 판정이 없는 손절·익절 원칙을 설정 대상에서 제외

### DIFF
--- a/frontend/src/components/round/InvestmentRulesSection.tsx
+++ b/frontend/src/components/round/InvestmentRulesSection.tsx
@@ -6,16 +6,22 @@ export interface RuleState {
   value: number;
 }
 
-export type RulesMap = Record<RuleType, RuleState>;
+/**
+ * 손절(STOP_LOSS)·익절(TAKE_PROFIT)은 백엔드에 위반 판정 로직이 없어 설정해도 아무 위반도 기록되지 않는다.
+ * 지키지 않아도 복기에 0건으로 나와 사용자를 오도하므로, 판정이 구현될 때까지 설정 대상에서 제외한다.
+ */
+export type SelectableRuleType = Exclude<RuleType, "STOP_LOSS" | "TAKE_PROFIT">;
+
+export type RulesMap = Record<SelectableRuleType, RuleState>;
 
 interface InvestmentRulesSectionProps {
   rules: RulesMap;
-  onRuleToggle: (type: RuleType, enabled: boolean) => void;
-  onRuleValueChange: (type: RuleType, value: number) => void;
+  onRuleToggle: (type: SelectableRuleType, enabled: boolean) => void;
+  onRuleValueChange: (type: SelectableRuleType, value: number) => void;
 }
 
 const RULE_CONFIGS: {
-  type: RuleType;
+  type: SelectableRuleType;
   label: string;
   description: string;
   min: number;
@@ -24,26 +30,6 @@ const RULE_CONFIGS: {
   inputType: "slider" | "number";
   defaultValue: number;
 }[] = [
-  {
-    type: "STOP_LOSS",
-    label: "손절",
-    description: "설정한 손실률 도달 시 매도",
-    min: 1,
-    max: 50,
-    unit: "%",
-    inputType: "slider",
-    defaultValue: 10,
-  },
-  {
-    type: "TAKE_PROFIT",
-    label: "익절",
-    description: "설정한 수익률 도달 시 매도",
-    min: 1,
-    max: 100,
-    unit: "%",
-    inputType: "slider",
-    defaultValue: 30,
-  },
   {
     type: "NO_CHASE_BUY",
     label: "추격 매수 금지",
@@ -57,7 +43,7 @@ const RULE_CONFIGS: {
   {
     type: "AVERAGING_LIMIT",
     label: "물타기 제한",
-    description: "같은 코인 반복 매수 제한",
+    description: "손실 중인 코인의 추가 매수 횟수 제한",
     min: 1,
     max: 10,
     unit: "회",

--- a/frontend/src/pages/RoundCreatePage.tsx
+++ b/frontend/src/pages/RoundCreatePage.tsx
@@ -9,8 +9,9 @@ import {
   InvestmentRulesSection,
   getDefaultRules,
   type RulesMap,
+  type RuleState,
+  type SelectableRuleType,
 } from "@/components/round/InvestmentRulesSection";
-import type { RuleType } from "@/lib/types/round";
 
 export function RoundCreatePage() {
   const { user } = useAuth();
@@ -23,15 +24,17 @@ export function RoundCreatePage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState("");
 
-  function handleRuleToggle(type: RuleType, enabled: boolean) {
+  function handleRuleToggle(type: SelectableRuleType, enabled: boolean) {
     setRules((prev) => ({ ...prev, [type]: { ...prev[type], enabled } }));
   }
 
-  function handleRuleValueChange(type: RuleType, value: number) {
+  function handleRuleValueChange(type: SelectableRuleType, value: number) {
     setRules((prev) => ({ ...prev, [type]: { ...prev[type], value } }));
   }
 
-  const enabledRules = Object.entries(rules).filter(([, r]) => r.enabled);
+  const enabledRules = (Object.entries(rules) as [SelectableRuleType, RuleState][]).filter(
+    ([, r]) => r.enabled,
+  );
   const canSubmit = seed > 0 && emergencyLimit > 0 && enabledRules.length >= 1;
 
   async function handleSubmit() {
@@ -45,7 +48,7 @@ export function RoundCreatePage() {
       initialSeed: seed,
       emergencyFundingLimit: emergencyLimit,
       rules: enabledRules.map(([type, rule]) => ({
-        ruleType: type as RuleType,
+        ruleType: type,
         thresholdValue: rule.value,
       })),
     });


### PR DESCRIPTION
## Summary

백엔드에 위반 판정 로직이 없는 손절·익절 원칙을 라운드 생성 화면에서 걷어낸다. 어겨도 복기에 0건으로 나와 사용자를 오도하던 원칙이 사라지고, 설정할 수 있는 원칙은 실제로 판정되는 것만 남는다.

---

## 주요 변경 사항

### 화면

- `InvestmentRulesSection` — `SelectableRuleType = Exclude<RuleType, "STOP_LOSS" | "TAKE_PROFIT">` 를 도입하고 `RULE_CONFIGS` 를 판정 가능한 3종으로 줄인다. 물타기 원칙 설명 문구를 실제 판정 기준에 맞게 고친다.
- `RoundCreatePage` — 줄어든 원칙 타입에 맞춰 설정 상태를 좁힌다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 원칙 자체를 지우지 않고 '설정 가능한 타입'만 좁힌다 | `RuleType` 은 백엔드 계약이라 그대로 두고, 화면에서 고를 수 있는 범위만 제한하는 편이 판정 로직이 생겼을 때 되돌리기 쉽다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 라운드 생성 화면에 손절·익절 원칙이 노출되지 않음

Closes #231