### PR TITLE
[#233] 시세·보유 자산 목록에 자체 스크롤과 가상화 적용

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@stomp/stompjs": "^7.3.0",
         "@tailwindcss/vite": "^4.2.1",
+        "@tanstack/react-virtual": "^3.14.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.575.0",
@@ -3830,6 +3831,33 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.6.tgz",
+      "integrity": "sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.4.tgz",
+      "integrity": "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@ts-morph/common": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@stomp/stompjs": "^7.3.0",
     "@tailwindcss/vite": "^4.2.1",
+    "@tanstack/react-virtual": "^3.14.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",

--- a/frontend/src/components/market/CoinTable.tsx
+++ b/frontend/src/components/market/CoinTable.tsx
@@ -1,9 +1,10 @@
-import { memo, useCallback } from "react";
+import { memo, useCallback, type CSSProperties } from "react";
 import { cn } from "@/lib/utils";
 import { formatPrice, formatVolume, formatChangeRate, getCurrencySymbol } from "@/lib/formatters";
 import { SortIcon } from "@/components/ui/SortIcon";
 import { useSort } from "@/hooks/useSort";
 import type { SortDir } from "@/hooks/useSort";
+import { useVirtualList, virtualRowStyle } from "@/hooks/useVirtualList";
 import { CoinIcon } from "./CoinIcon";
 import type { CoinData } from "@/lib/types/coins";
 
@@ -18,12 +19,19 @@ type SortKey = "name" | "price" | "change" | "volume";
 
 const GRID_COLS = "grid-cols-[2fr_minmax(100px,140px)_minmax(80px,100px)_minmax(160px,1fr)]";
 
+// 가상화는 행 높이를 미리 알아야 스크롤 높이를 계산할 수 있다. 행은 높이를 고정한다.
+const ROW_HEIGHT = 68;
+const VISIBLE_ROWS = 8;
+const LIST_HEIGHT = ROW_HEIGHT * VISIBLE_ROWS;
+const LIST_PADDING_X = 20; // px-5
+
 interface CoinRowProps {
   coin: CoinData;
   baseCurrency: string;
   currencySymbol: string;
   isSelected: boolean;
   isLast: boolean;
+  style: CSSProperties;
   onSelect?: (symbol: string) => void;
 }
 
@@ -33,6 +41,7 @@ const CoinRow = memo(function CoinRow({
   currencySymbol,
   isSelected,
   isLast,
+  style,
   onSelect,
 }: CoinRowProps) {
   const handleClick = () => onSelect?.(coin.symbol);
@@ -40,8 +49,9 @@ const CoinRow = memo(function CoinRow({
   return (
     <div
       onClick={handleClick}
+      style={style}
       className={cn(
-        "group grid cursor-pointer items-center px-5 py-[18px] transition-colors hover:bg-primary/[0.03]",
+        "group grid cursor-pointer items-center px-5 transition-colors hover:bg-primary/[0.03]",
         GRID_COLS,
         !isLast && "border-b border-border/30",
         isSelected && "bg-primary/[0.04]",
@@ -108,6 +118,11 @@ export function CoinTable({ coins, baseCurrency, selectedSymbol, onSelect }: Coi
     comparator,
   });
 
+  const { scrollRef, virtualizer, scrollbarWidth } = useVirtualList({
+    count: sortedCoins.length,
+    rowHeight: ROW_HEIGHT,
+  });
+
   const currencySymbol = getCurrencySymbol(baseCurrency);
 
   const columns: { key: SortKey; label: string; sortable: boolean }[] = [
@@ -119,7 +134,13 @@ export function CoinTable({ coins, baseCurrency, selectedSymbol, onSelect }: Coi
 
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-card">
-      <div className={cn("grid items-center bg-secondary/30 px-5 py-3.5", GRID_COLS)}>
+      <div
+        className={cn("grid items-center bg-secondary/30 py-3.5", GRID_COLS)}
+        style={{
+          paddingLeft: LIST_PADDING_X,
+          paddingRight: LIST_PADDING_X + scrollbarWidth,
+        }}
+      >
         {columns.map((col) => (
           <button
             key={col.key}
@@ -138,25 +159,37 @@ export function CoinTable({ coins, baseCurrency, selectedSymbol, onSelect }: Coi
         ))}
       </div>
 
-      <div>
-        {sortedCoins.length === 0 ? (
-          <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
-            검색 결과가 없습니다.
+      {sortedCoins.length === 0 ? (
+        <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
+          검색 결과가 없습니다.
+        </div>
+      ) : (
+        // 페이지가 아니라 이 상자 안에서 스크롤한다. 스크롤바 자리는 항상 비워 두어야
+        // 목록 길이가 바뀌어도 헤더와 본문의 열이 어긋나지 않는다.
+        <div
+          ref={scrollRef}
+          className="overflow-y-auto [scrollbar-gutter:stable]"
+          style={{ height: Math.min(LIST_HEIGHT, sortedCoins.length * ROW_HEIGHT) }}
+        >
+          <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
+            {virtualizer.getVirtualItems().map((item) => {
+              const coin = sortedCoins[item.index];
+              return (
+                <CoinRow
+                  key={coin.symbol}
+                  coin={coin}
+                  baseCurrency={baseCurrency}
+                  currencySymbol={currencySymbol}
+                  isSelected={selectedSymbol === coin.symbol}
+                  isLast={item.index === sortedCoins.length - 1}
+                  style={virtualRowStyle(item, ROW_HEIGHT)}
+                  onSelect={onSelect}
+                />
+              );
+            })}
           </div>
-        ) : (
-          sortedCoins.map((coin, i) => (
-            <CoinRow
-              key={coin.symbol}
-              coin={coin}
-              baseCurrency={baseCurrency}
-              currencySymbol={currencySymbol}
-              isSelected={selectedSymbol === coin.symbol}
-              isLast={i === sortedCoins.length - 1}
-              onSelect={onSelect}
-            />
-          ))
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/wallet/WalletAssetTable.tsx
+++ b/frontend/src/components/wallet/WalletAssetTable.tsx
@@ -6,6 +6,7 @@ import { formatQuantity, formatCurrencyCompact, SMALL_AMOUNT_THRESHOLD } from "@
 import { SortIcon } from "@/components/ui/SortIcon";
 import { useSort } from "@/hooks/useSort";
 import type { SortDir } from "@/hooks/useSort";
+import { useVirtualList, virtualRowStyle } from "@/hooks/useVirtualList";
 import type { WalletCoinBalance } from "@/lib/types/wallet";
 
 interface WalletAssetTableProps {
@@ -34,6 +35,13 @@ function formatDisplayQuantity(quantity: number, symbol: string, baseCurrency: s
 }
 
 const GRID_COLS = "grid-cols-[1.6fr_minmax(120px,1.2fr)_minmax(100px,1fr)_minmax(90px,0.8fr)]";
+
+// 가상화는 행 높이를 미리 알아야 스크롤 높이를 계산할 수 있다. 행은 높이를 고정한다.
+// 보유수량 칸은 수량과 환산액 두 줄이 들어가므로 시세 목록보다 한 행이 높다.
+const ROW_HEIGHT = 72;
+const VISIBLE_ROWS = 8;
+const LIST_HEIGHT = ROW_HEIGHT * VISIBLE_ROWS;
+const LIST_PADDING_X = 20; // px-5
 
 export function WalletAssetTable({ balances, baseCurrency, onSelectCoin, selectedCoin }: WalletAssetTableProps) {
   const [searchQuery, setSearchQuery] = useState("");
@@ -80,6 +88,11 @@ export function WalletAssetTable({ balances, baseCurrency, onSelectCoin, selecte
     comparator,
   });
 
+  const { scrollRef, virtualizer, scrollbarWidth } = useVirtualList({
+    count: sorted.length,
+    rowHeight: ROW_HEIGHT,
+  });
+
   const columns: { key: SortKey; label: string }[] = [
     { key: "name", label: "코인" },
     { key: "total", label: "보유수량" },
@@ -118,7 +131,11 @@ export function WalletAssetTable({ balances, baseCurrency, onSelectCoin, selecte
 
       <div className="overflow-x-auto">
         {/* Header */}
-        <div className={cn("grid min-w-[640px] items-center bg-secondary/30 px-5 py-3.5", GRID_COLS)} role="row">
+        <div
+          className={cn("grid min-w-[640px] items-center bg-secondary/30 py-3.5", GRID_COLS)}
+          style={{ paddingLeft: LIST_PADDING_X, paddingRight: LIST_PADDING_X + scrollbarWidth }}
+          role="row"
+        >
           {columns.map((col) => (
             <button
               key={col.key}
@@ -136,73 +153,80 @@ export function WalletAssetTable({ balances, baseCurrency, onSelectCoin, selecte
           ))}
         </div>
 
-        {/* Body */}
-        <div>
-          {sorted.length === 0 ? (
-            <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
-              보유 중인 자산이 없습니다.
-            </div>
-          ) : (
-            sorted.map((b, i) => {
-              const isSelected = selectedCoin === b.coinSymbol;
-              const isBase = b.coinSymbol === baseCurrency;
-              const hasBalance = isBase || b.total > 0;
-              return (
-                <div
-                  key={b.coinSymbol}
-                  onClick={() => onSelectCoin?.(isSelected ? null : b)}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(e) => { if (e.key === "Enter") onSelectCoin?.(isSelected ? null : b); }}
-                  className={cn(
-                    "grid min-w-[640px] cursor-pointer items-center px-5 py-[18px] transition-colors",
-                    GRID_COLS,
-                    isSelected ? "bg-primary/[0.06]" : "hover:bg-primary/[0.03]",
-                    i !== sorted.length - 1 && "border-b border-border/30",
-                  )}
-                >
-                  {/* Coin info */}
-                  <div className="flex items-center gap-3">
-                    <CoinIcon symbol={b.coinSymbol} size={36} />
-                    <div className="flex flex-col leading-tight">
-                      <span className="text-[13px] font-semibold tracking-wide">{b.coinSymbol}</span>
-                      <span className="text-[11px] text-muted-foreground">{b.coinName}</span>
-                    </div>
-                  </div>
-
-                  {/* Total amount */}
-                  <div className="text-right">
-                    <div className={cn("font-mono text-sm tabular-nums", hasBalance ? "font-semibold" : "text-muted-foreground/40")}>
-                      {hasBalance ? formatDisplayQuantity(b.total, b.coinSymbol, baseCurrency) : "—"}
-                    </div>
-                    {!isBase && hasBalance && (
-                      <div className="mt-0.5 font-mono text-[11px] tabular-nums text-muted-foreground">
-                        ≈ {formatCurrencyCompact(b.totalValue, baseCurrency)}
-                      </div>
+        {/* Body: 페이지가 아니라 이 상자 안에서 스크롤하고, 보이는 구간의 행만 그린다. */}
+        {sorted.length === 0 ? (
+          <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
+            보유 중인 자산이 없습니다.
+          </div>
+        ) : (
+          <div
+            ref={scrollRef}
+            className="min-w-[640px] overflow-y-auto [scrollbar-gutter:stable]"
+            style={{ height: Math.min(LIST_HEIGHT, sorted.length * ROW_HEIGHT) }}
+          >
+            <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
+              {virtualizer.getVirtualItems().map((item) => {
+                const b = sorted[item.index];
+                const isSelected = selectedCoin === b.coinSymbol;
+                const isBase = b.coinSymbol === baseCurrency;
+                const hasBalance = isBase || b.total > 0;
+                return (
+                  <div
+                    key={b.coinSymbol}
+                    onClick={() => onSelectCoin?.(isSelected ? null : b)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => { if (e.key === "Enter") onSelectCoin?.(isSelected ? null : b); }}
+                    style={virtualRowStyle(item, ROW_HEIGHT)}
+                    className={cn(
+                      "grid cursor-pointer items-center px-5 transition-colors",
+                      GRID_COLS,
+                      isSelected ? "bg-primary/[0.06]" : "hover:bg-primary/[0.03]",
+                      item.index !== sorted.length - 1 && "border-b border-border/30",
                     )}
-                  </div>
+                  >
+                    {/* Coin info */}
+                    <div className="flex items-center gap-3">
+                      <CoinIcon symbol={b.coinSymbol} size={36} />
+                      <div className="flex flex-col leading-tight">
+                        <span className="text-[13px] font-semibold tracking-wide">{b.coinSymbol}</span>
+                        <span className="text-[11px] text-muted-foreground">{b.coinName}</span>
+                      </div>
+                    </div>
 
-                  {/* Available */}
-                  <div className={cn("text-right font-mono text-sm tabular-nums", !hasBalance && "text-muted-foreground/40")}>
-                    {hasBalance ? formatDisplayQuantity(b.available, b.coinSymbol, baseCurrency) : "—"}
-                  </div>
+                    {/* Total amount */}
+                    <div className="text-right">
+                      <div className={cn("font-mono text-sm tabular-nums", hasBalance ? "font-semibold" : "text-muted-foreground/40")}>
+                        {hasBalance ? formatDisplayQuantity(b.total, b.coinSymbol, baseCurrency) : "—"}
+                      </div>
+                      {!isBase && hasBalance && (
+                        <div className="mt-0.5 font-mono text-[11px] tabular-nums text-muted-foreground">
+                          ≈ {formatCurrencyCompact(b.totalValue, baseCurrency)}
+                        </div>
+                      )}
+                    </div>
 
-                  {/* Locked */}
-                  <div className={cn(
-                    "flex items-center justify-end gap-1 text-right font-mono text-sm tabular-nums",
-                    b.locked > 0 ? "text-chart-4" : "text-muted-foreground/40",
-                  )}>
-                    {b.locked > 0 && <Lock className="h-3 w-3 shrink-0" />}
-                    {b.locked > 0
-                      ? formatDisplayQuantity(b.locked, b.coinSymbol, baseCurrency)
-                      : "—"}
-                  </div>
+                    {/* Available */}
+                    <div className={cn("text-right font-mono text-sm tabular-nums", !hasBalance && "text-muted-foreground/40")}>
+                      {hasBalance ? formatDisplayQuantity(b.available, b.coinSymbol, baseCurrency) : "—"}
+                    </div>
 
-                </div>
-              );
-            })
-          )}
-        </div>
+                    {/* Locked */}
+                    <div className={cn(
+                      "flex items-center justify-end gap-1 text-right font-mono text-sm tabular-nums",
+                      b.locked > 0 ? "text-chart-4" : "text-muted-foreground/40",
+                    )}>
+                      {b.locked > 0 && <Lock className="h-3 w-3 shrink-0" />}
+                      {b.locked > 0
+                        ? formatDisplayQuantity(b.locked, b.coinSymbol, baseCurrency)
+                        : "—"}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/hooks/useVirtualList.ts
+++ b/frontend/src/hooks/useVirtualList.ts
@@ -1,0 +1,54 @@
+import { useLayoutEffect, useRef, useState, type CSSProperties } from "react";
+import { useVirtualizer, type VirtualItem } from "@tanstack/react-virtual";
+
+interface UseVirtualListOptions {
+  count: number;
+  rowHeight: number;
+  overscan?: number;
+}
+
+/**
+ * 목록을 페이지가 아니라 자체 스크롤 상자 안에서 스크롤시키고, 그 안에서도 보이는 구간의 행만 그린다.
+ * 상장 코인이 거래소당 최대 600개를 넘어 전부 그리면 DOM 이 수천 노드가 되고, 실시간 시세가 들어올
+ * 때마다 React 가 그 전부를 다시 훑는다.
+ *
+ * 행 높이가 고정이어야 전체 스크롤 높이를 계산할 수 있으므로 rowHeight 를 받는다.
+ */
+export function useVirtualList({ count, rowHeight, overscan = 6 }: UseVirtualListOptions) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => rowHeight,
+    overscan,
+  });
+
+  // 헤더는 스크롤 상자 밖에 있어 스크롤바 폭만큼 본문보다 넓다. 그만큼 헤더 오른쪽을 비워야 열이 맞는다.
+  // 목록이 비면 상자가 사라지므로, 다시 생겼을 때 재측정하도록 존재 여부를 의존성에 둔다.
+  const [scrollbarWidth, setScrollbarWidth] = useState(0);
+  const hasRows = count > 0;
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const measure = () => setScrollbarWidth(el.offsetWidth - el.clientWidth);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasRows]);
+
+  return { scrollRef, virtualizer, scrollbarWidth };
+}
+
+/** 가상화된 행은 전체 높이를 잡아둔 상자 위에 제자리로 얹는다. */
+export function virtualRowStyle(item: VirtualItem, rowHeight: number): CSSProperties {
+  return {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    width: "100%",
+    height: rowHeight,
+    transform: `translateY(${item.start}px)`,
+  };
+}


### PR DESCRIPTION
## Summary

수백 개 행을 전부 그리던 시세·보유 자산 목록에 자체 스크롤 영역과 가상화를 적용한다. 보이는 행만 렌더하므로 DOM 노드 수와 실시간 갱신 시 렌더 대상이 크게 줄어든다.

- **가상화 훅** — `useVirtualList` 를 신설한다(`@tanstack/react-virtual` 기반).
- **적용** — 마켓 시세 목록(`CoinTable`)과 지갑 보유 자산 목록(`WalletAssetTable`).

---

## 주요 변경 사항

### 훅

- `useVirtualList` — 고정 행 높이(`ROW_HEIGHT`) 기준으로 보이는 구간만 계산한다.

### 화면

- `CoinTable` — 자체 스크롤 컨테이너 + 가상 행 렌더. 스크롤바 폭만큼 헤더 padding 을 보정해 헤더와 본문 열이 어긋나지 않게 한다.
- `WalletAssetTable` — 동일하게 적용한다.

### 의존성

- `@tanstack/react-virtual` 추가.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 고정 행 높이 | 시세·자산 행은 높이가 일정해 측정 없이 계산만으로 위치가 나온다. 동적 측정보다 스크롤이 매끄럽다 |
| 헤더 padding 을 style 로 계산 | 스크롤 컨테이너가 생기면 스크롤바 폭만큼 본문이 좁아져, 고정 padding 으로는 헤더와 열이 어긋난다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 마켓 시세 목록이 자체 스크롤되고 보이는 행만 렌더됨
- [x] 지갑 보유 자산 목록이 동일하게 동작함

Closes #233