### PR TITLE
[#235] 자산 구성 도넛 차트에 보유 원화를 포함

### DIFF
--- a/frontend/src/components/portfolio/DonutChart.tsx
+++ b/frontend/src/components/portfolio/DonutChart.tsx
@@ -4,6 +4,7 @@ import { getCoinColor } from "@/lib/types/coins";
 import type { HoldingData } from "@/lib/types/portfolio";
 
 interface DonutChartProps {
+  availableCash: number;
   holdings: HoldingData[];
   baseCurrency: string;
 }
@@ -16,38 +17,58 @@ interface Segment {
 }
 
 const OTHER_COLOR = "#8b949e";
+const CASH_COLOR = "#c2b8ab";
 
-function buildSegments(holdings: HoldingData[]): Segment[] {
-  const total = holdings.reduce((sum, h) => sum + h.currentPrice * h.quantity, 0);
+/** 보유 현금은 코인이 하나도 없어도 항상 한 조각으로 남는다. */
+function buildSegments(
+  availableCash: number,
+  holdings: HoldingData[],
+  baseCurrency: string,
+): Segment[] {
+  const total =
+    availableCash + holdings.reduce((sum, h) => sum + h.currentPrice * h.quantity, 0);
   if (total === 0) return [];
 
-  const items = holdings
+  const coins = holdings
     .map((h) => ({
       label: h.coinSymbol,
       value: h.currentPrice * h.quantity,
       ratio: (h.currentPrice * h.quantity) / total,
       color: getCoinColor(h.coinSymbol),
     }))
+    .filter((c) => c.value > 0)
     .sort((a, b) => b.value - a.value);
 
-  if (items.length <= 7) return items;
+  const shown = coins.length <= 6 ? coins : coins.slice(0, 5);
+  const rest = coins.slice(shown.length);
+  if (rest.length > 0) {
+    const otherValue = rest.reduce((s, r) => s + r.value, 0);
+    shown.push({
+      label: "기타",
+      value: otherValue,
+      ratio: otherValue / total,
+      color: OTHER_COLOR,
+    });
+  }
 
-  const top = items.slice(0, 6);
-  const rest = items.slice(6);
-  const otherValue = rest.reduce((s, r) => s + r.value, 0);
-  top.push({
-    label: "기타",
-    value: otherValue,
-    ratio: otherValue / total,
-    color: OTHER_COLOR,
-  });
-  return top;
+  if (availableCash <= 0) return shown;
+
+  return [
+    {
+      label: baseCurrency,
+      value: availableCash,
+      ratio: availableCash / total,
+      color: CASH_COLOR,
+    },
+    ...shown,
+  ];
 }
 
-export function DonutChart({ holdings, baseCurrency }: DonutChartProps) {
+export function DonutChart({ availableCash, holdings, baseCurrency }: DonutChartProps) {
   const [hoveredLabel, setHoveredLabel] = useState<string | null>(null);
-  const totalEval = holdings.reduce((sum, h) => sum + h.currentPrice * h.quantity, 0);
-  const segments = buildSegments(holdings);
+  const totalAsset =
+    availableCash + holdings.reduce((sum, h) => sum + h.currentPrice * h.quantity, 0);
+  const segments = buildSegments(availableCash, holdings, baseCurrency);
 
   const size = 180;
   const strokeWidth = 28;
@@ -104,9 +125,9 @@ export function DonutChart({ holdings, baseCurrency }: DonutChartProps) {
           </svg>
           {/* Center label */}
           <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
-            <span className="text-[10px] font-medium text-muted-foreground">총 평가</span>
+            <span className="text-[10px] font-medium text-muted-foreground">총 자산</span>
             <span className="font-mono text-sm font-bold tabular-nums">
-              {formatCurrency(totalEval, baseCurrency)}
+              {formatCurrency(totalAsset, baseCurrency)}
             </span>
           </div>
         </div>

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -124,6 +124,7 @@ export function PortfolioPage() {
                   baseCurrency={portfolio.baseCurrency}
                 />
                 <DonutChart
+                  availableCash={portfolio.availableCash}
                   holdings={portfolio.holdings}
                   baseCurrency={portfolio.baseCurrency}
                 />


### PR DESCRIPTION
## Summary

자산 구성 도넛 차트가 코인 평가액만 계산해, 원화만 보유한 사용자에게 빈 차트가 보이고 중앙 금액이 총자산과 어긋나던 문제를 고친다.

- **원화를 자산 구성에 포함** — 보유 원화를 하나의 조각으로 넣어 비중을 계산한다.
- **중앙 금액 일치** — 차트 중앙 금액이 총자산과 같아진다.

---

## 주요 변경 사항

### 화면

- `DonutChart` — 필수 prop `availableCash` 를 받아 조각 계산(`buildSegments`)에 포함한다.
- `PortfolioPage` — 포트폴리오 요약의 보유 원화를 차트로 넘긴다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| `availableCash` 를 선택 prop 이 아닌 필수 prop 으로 | 빠뜨리면 같은 버그가 조용히 되살아난다. 필수로 두면 타입 검사가 막아 준다 |
| 서버 응답을 바꾸지 않는다 | 보유 원화(`baseCurrencyBalance`)는 이미 포트폴리오 요약에 들어 있어 화면에서 쓰기만 하면 된다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 코인 없이 원화만 보유한 사용자에게 도넛 차트가 그려짐
- [x] 차트 중앙 금액이 총자산과 일치함

Closes #235