### PR TITLE
[#237] 시세가 갱신되면 현재가에 방향별 테두리를 잠깐 두른다

### DIFF
--- a/frontend/src/components/market/CoinTable.tsx
+++ b/frontend/src/components/market/CoinTable.tsx
@@ -5,6 +5,7 @@ import { SortIcon } from "@/components/ui/SortIcon";
 import { useSort } from "@/hooks/useSort";
 import type { SortDir } from "@/hooks/useSort";
 import { useVirtualList, virtualRowStyle } from "@/hooks/useVirtualList";
+import { usePriceFlash } from "@/hooks/usePriceFlash";
 import { CoinIcon } from "./CoinIcon";
 import type { CoinData } from "@/lib/types/coins";
 
@@ -45,6 +46,7 @@ const CoinRow = memo(function CoinRow({
   onSelect,
 }: CoinRowProps) {
   const handleClick = () => onSelect?.(coin.symbol);
+  const flash = usePriceFlash(coin.currentPrice, coin.tickedAt);
 
   return (
     <div
@@ -66,13 +68,25 @@ const CoinRow = memo(function CoinRow({
       </div>
 
       <div className={cn(
-        "text-right font-mono text-sm font-semibold tabular-nums",
+        "relative text-right font-mono text-sm font-semibold tabular-nums",
         coin.changeRate > 0 && "text-positive",
         coin.changeRate < 0 && "text-negative",
       )}>
         {coin.currentPrice > 0
           ? <>{currencySymbol}{formatPrice(coin.currentPrice, baseCurrency)}</>
           : <span className="text-muted-foreground">-</span>}
+        {flash && (
+          // 글자색이나 배경을 건드리면 정작 읽어야 할 숫자가 흔들린다. 테두리만 잠깐 두른다.
+          <span
+            aria-hidden
+            className={cn(
+              "pointer-events-none absolute left-0 -right-2 -inset-y-2.5 rounded-md border",
+              flash === "up" && "border-positive",
+              flash === "down" && "border-negative",
+              flash === "same" && "border-muted-foreground/40",
+            )}
+          />
+        )}
       </div>
 
       <div className="flex justify-end">

--- a/frontend/src/hooks/usePriceFlash.ts
+++ b/frontend/src/hooks/usePriceFlash.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+
+export type FlashDirection = "up" | "down" | "same";
+
+// 서서히 사라지게 하면 잔상이 다음 체결과 겹쳐 어느 행이 방금 바뀌었는지 오히려 흐려진다.
+// 켰다가 그냥 끈다.
+const FLASH_MS = 100;
+
+interface FlashState {
+  price: number;
+  tickedAt?: number;
+  direction: FlashDirection | null;
+}
+
+/**
+ * 체결이 들어올 때마다 짧게 방향을 알린다. 가격이 오르면 up, 내리면 down,
+ * 가격은 그대로인데 체결만 일어났으면 same 이다.
+ *
+ * 가격만 비교하면 같은 가격에 체결된 경우를 놓치므로 체결 시각으로 새 체결인지를 판정한다.
+ * 시세를 다시 받아와도 체결 시각이 그대로면 반짝이지 않는다.
+ */
+export function usePriceFlash(price: number, tickedAt?: number): FlashDirection | null {
+  const [seen, setSeen] = useState<FlashState>({ price, tickedAt, direction: null });
+
+  // 방향은 직전 체결과 비교해야만 나오므로 화면에 그린 마지막 시세를 기억한다.
+  // 목록이 가상화되어 있어 행이 다시 그려질 때는 그 시점의 시세로 시작한다 — 스크롤만으로는 반짝이지 않는다.
+  if (tickedAt !== seen.tickedAt) {
+    const isFirstTick = seen.tickedAt === undefined || tickedAt === undefined;
+    setSeen({
+      price,
+      tickedAt,
+      direction: isFirstTick
+        ? null
+        : price > seen.price ? "up"
+        : price < seen.price ? "down"
+        : "same",
+    });
+  }
+
+  const { direction } = seen;
+  useEffect(() => {
+    if (direction === null) return;
+    const timer = window.setTimeout(
+      () => setSeen((prev) => ({ ...prev, direction: null })),
+      FLASH_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [direction, tickedAt]);
+
+  return direction;
+}

--- a/frontend/src/hooks/useTickers.ts
+++ b/frontend/src/hooks/useTickers.ts
@@ -82,6 +82,7 @@ export function useTickers({ exchangeId, initialCoins }: UseTickersOptions): Coi
         currentPrice: live.price,
         changeRate: live.changeRate,
         volume: live.quoteTurnover,
+        tickedAt: live.timestamp,
       };
       cache.set(coin.symbol, { base: coin, ticker: live, merged });
       return merged;

--- a/frontend/src/lib/types/coins.ts
+++ b/frontend/src/lib/types/coins.ts
@@ -4,6 +4,8 @@ export interface CoinData {
   currentPrice: number;
   changeRate: number;
   volume: number;
+  /** 이 시세를 만든 체결의 거래소 시각(ms). 실시간 시세로 갱신된 코인에만 있다. */
+  tickedAt?: number;
 }
 
 const COIN_COLORS: Record<string, string> = {


### PR DESCRIPTION
## Summary

시세가 갱신된 행을 눈에 띄게 만든다. 현재가 칸에 상승/하락 방향별 테두리가 잠깐 둘러진다.

- **체결 시각 전달** — 실시간 시세에 체결 시각(`tickedAt`)을 함께 싣는다.
- **반짝임 훅** — `usePriceFlash` 가 체결 시각 변화를 트리거로 방향을 계산해 잠깐 테두리를 준다.

---

## 주요 변경 사항

### 타입 및 훅

- `lib/types/coins.ts` — `CoinData.tickedAt` 추가.
- `useTickers` — 실시간 시세를 병합할 때 체결 시각(`live.timestamp`)을 함께 채운다.
- `usePriceFlash` — 체결 시각이 바뀐 경우에만 방향(상승/하락)을 계산해 잠깐 표시한다(신규).

### 화면

- `CoinTable` — 현재가 칸에 방향별 테두리를 렌더한다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 가격이 아니라 체결 시각을 트리거로 | 같은 가격에 다시 체결되면 가격 비교로는 갱신을 감지할 수 없다. 체결 시각이 바뀌면 갱신으로 본다 |
| 두 커밋을 한 PR 로 | `usePriceFlash` 가 `CoinData.tickedAt` 을 읽으므로 필드 추가 없이는 타입 검사가 깨지고, 필드만 추가하면 아무도 읽지 않는 죽은 필드가 된다 |
| 스크롤 재렌더 시 반짝이지 않는다 | 가상화로 행이 재사용되므로, 재마운트가 아니라 체결 시각 변화만 트리거로 삼는다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 시세가 들어온 행의 현재가에 방향별 테두리가 잠깐 표시됨
- [x] 목록을 스크롤해도 반짝이지 않음

Closes #237