### PR TITLE
[#239] 새로고침하면 로그인 화면으로 튕기던 문제 수정

### DIFF
--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -3,9 +3,10 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useRound } from "@/contexts/RoundContext";
 
 export function ProtectedRoute() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isAuthLoading } = useAuth();
   const { hasActiveRound, hasEverStartedRound, isRoundLoading } = useRound();
 
+  if (isAuthLoading) return null;
   if (!isAuthenticated) return <Navigate to="/login" replace />;
   if (isRoundLoading) return null;
   if (!hasActiveRound && !hasEverStartedRound) return <Navigate to="/round/new" replace />;

--- a/frontend/src/components/auth/PublicRoute.tsx
+++ b/frontend/src/components/auth/PublicRoute.tsx
@@ -2,8 +2,9 @@ import { Navigate, Outlet } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 
 export function PublicRoute() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isAuthLoading } = useAuth();
 
+  if (isAuthLoading) return null;
   if (isAuthenticated) return <Navigate to="/market" replace />;
 
   return <Outlet />;

--- a/frontend/src/components/auth/RoundGuard.tsx
+++ b/frontend/src/components/auth/RoundGuard.tsx
@@ -3,9 +3,10 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useRound } from "@/contexts/RoundContext";
 
 export function RoundGuard() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isAuthLoading } = useAuth();
   const { hasActiveRound, isRoundLoading } = useRound();
 
+  if (isAuthLoading) return null;
   if (!isAuthenticated) return <Navigate to="/login" replace />;
   if (isRoundLoading) return null;
   if (hasActiveRound) return <Navigate to="/market" replace />;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,14 @@
-import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+  type ReactNode,
+} from "react";
 import type { AuthUser } from "@/lib/types/user";
 import { logout as logoutApi } from "@/lib/api/auth-api";
+import { getUserProfile } from "@/lib/api/user-api";
 
 interface SocialLoginUser {
   userId: number;
@@ -10,6 +18,7 @@ interface SocialLoginUser {
 interface AuthContextValue {
   user: AuthUser | null;
   isAuthenticated: boolean;
+  isAuthLoading: boolean;
   loginWithSocial: (result: SocialLoginUser) => void;
   logout: () => Promise<void>;
   updateUser: (updates: Partial<Pick<AuthUser, "nickname">>) => void;
@@ -19,6 +28,28 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
+
+  // 새로고침하면 메모리의 인증 상태는 사라지지만 세션 쿠키는 남아 있다.
+  // 그 쿠키로 내 정보를 되물어 로그인 상태를 복구한다.
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const profile = await getUserProfile();
+        if (!cancelled) setUser({ userId: profile.userId, nickname: profile.nickname });
+      } catch {
+        if (!cancelled) setUser(null);
+      } finally {
+        if (!cancelled) setIsAuthLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const loginWithSocial = useCallback((result: SocialLoginUser) => {
     setUser({ userId: result.userId, nickname: result.nickname });
@@ -39,7 +70,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ user, isAuthenticated: user !== null, loginWithSocial, logout, updateUser }}
+      value={{
+        user,
+        isAuthenticated: user !== null,
+        isAuthLoading,
+        loginWithSocial,
+        logout,
+        updateUser,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/frontend/src/contexts/RoundContext.tsx
+++ b/frontend/src/contexts/RoundContext.tsx
@@ -33,12 +33,18 @@ interface RoundContextValue {
 const RoundContext = createContext<RoundContextValue | null>(null);
 
 export function RoundProvider({ children }: { children: ReactNode }) {
-  const { user } = useAuth();
+  const { user, isAuthLoading } = useAuth();
   const [activeRound, setActiveRound] = useState<InvestmentRound | null>(null);
   const [totalRoundCount, setTotalRoundCount] = useState(0);
   const [isRoundLoading, setIsRoundLoading] = useState(true);
 
   const refreshActiveRound = useCallback(async () => {
+    // 세션 복구가 끝나기 전에는 로그인 여부를 알 수 없으니 판단을 미룬다.
+    if (isAuthLoading) {
+      setIsRoundLoading(true);
+      return;
+    }
+
     if (!user) {
       setActiveRound(null);
       setTotalRoundCount(0);
@@ -61,7 +67,7 @@ export function RoundProvider({ children }: { children: ReactNode }) {
     } finally {
       setIsRoundLoading(false);
     }
-  }, [user]);
+  }, [user, isAuthLoading]);
 
   useEffect(() => {
     void refreshActiveRound();


### PR DESCRIPTION
## Summary

인증 상태가 메모리에만 있어 새로고침하면 세션 쿠키가 살아 있는데도 로그인 화면으로 튕기던 문제를 고친다.

- **세션 복구** — 앱이 시작되면 서버에 사용자 정보를 물어 인증 상태를 되살린다.
- **판정 보류** — 복구가 끝나기 전(`isAuthLoading`)에는 라우트 가드가 판정을 미룬다.

---

## 핵심 흐름

```
앱 시작
  └─ AuthContext: isAuthLoading = true
       └─ GET /api/users/me
            ├─ 200 → 인증 상태 복구 → isAuthLoading = false
            └─ 401 → 미인증 확정      → isAuthLoading = false

라우트 가드(ProtectedRoute / PublicRoute / RoundGuard)
  └─ isAuthLoading 인 동안에는 리다이렉트하지 않고 대기
```

---

## 주요 변경 사항

### 인증

- `AuthContext` — `isAuthLoading` 상태를 두고, 앱 시작 시 세션을 복구한다.

### 라우트 가드

- `ProtectedRoute`, `PublicRoute`, `RoundGuard` — 복구가 끝나기 전에는 판정을 보류한다.
- `RoundContext` — 인증 복구가 끝난 뒤에 라운드를 조회하도록 보류 가드를 둔다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 인증 상태를 로컬 스토리지에 저장하지 않고 서버에 묻는다 | 클라이언트가 들고 있는 인증 표시는 서버 세션이 만료돼도 살아 있어 더 나쁜 상태(로그인된 척하는 화면)를 만든다 |
| '확인 중'을 '미인증'과 구분한다 | 두 상태를 합치면 복구가 끝나기 전에 가드가 먼저 판정해, 결국 같은 튕김이 남는다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 로그인 후 새로고침해도 화면이 유지됨
- [x] 세션이 없는 상태로 보호 화면에 접근하면 로그인 화면으로 이동함

Closes #239