### PR TITLE
[#241] 코인 전환 직후 이전 주문 대상이 쓰이던 문제 수정

### DIFF
--- a/frontend/src/hooks/useExchangeCoins.ts
+++ b/frontend/src/hooks/useExchangeCoins.ts
@@ -2,36 +2,38 @@ import { useEffect, useState } from "react";
 import { getExchangeCoins } from "@/lib/api/exchange-api";
 import type { CoinData } from "@/lib/types/coins";
 
+// 아직 못 받아온 상태에서는 늘 같은 빈 배열을 돌려준다. 매번 새 배열을 만들면
+// 이 값을 지켜보는 쪽(시세 병합·검색 색인)이 헛되이 다시 계산한다.
+const EMPTY: CoinData[] = [];
+
 /**
  * 거래소 상장 코인 목록을 API에서 조회한다.
  * 초기 시세 스냅샷(가격/변동률/거래대금)이 포함되며, 이후 WebSocket으로 실시간 갱신된다.
  */
 export function useExchangeCoins(exchangeId: number): { coins: CoinData[]; loading: boolean } {
-  const [coins, setCoins] = useState<CoinData[]>([]);
-  const [loading, setLoading] = useState(true);
+  // 어느 거래소의 목록인지 함께 담아 둔다. 그래야 거래소를 막 바꾼 직후의 '아직 못 받은 상태'를
+  // 이펙트에서 setLoading(true) 로 알릴 필요 없이 렌더에서 그대로 판단할 수 있다.
+  const [loaded, setLoaded] = useState<{ exchangeId: number; coins: CoinData[] } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
 
     getExchangeCoins(exchangeId)
       .then((list) => {
         if (cancelled) return;
-        setCoins(
-          list.map((item) => ({
+        setLoaded({
+          exchangeId,
+          coins: list.map((item) => ({
             symbol: item.coinSymbol,
             name: item.coinName,
             currentPrice: item.price,
             changeRate: item.changeRate,
             volume: item.volume,
           })),
-        );
+        });
       })
       .catch(() => {
-        if (!cancelled) setCoins([]);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) setLoaded({ exchangeId, coins: [] });
       });
 
     return () => {
@@ -39,5 +41,7 @@ export function useExchangeCoins(exchangeId: number): { coins: CoinData[]; loadi
     };
   }, [exchangeId]);
 
-  return { coins, loading };
+  const current = loaded?.exchangeId === exchangeId ? loaded : null;
+
+  return { coins: current?.coins ?? EMPTY, loading: current === null };
 }

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -78,20 +78,23 @@ export function MarketPage() {
     return fromSelection ?? filteredCoins[0] ?? coins[0];
   }, [coins, filteredCoins, selectedSymbol]);
 
-  const [orderTarget, setOrderTarget] = useState<OrderTargetResult | null>(null);
+  // 해석 결과에 어느 코인의 것인지를 함께 담는다. 그래야 다른 코인으로 옮긴 직후
+  // 아직 해석이 끝나지 않은 사이에 이전 코인의 주문 대상이 그대로 쓰이는 일이 없다.
+  const [resolved, setResolved] = useState<{ target: string; result: OrderTargetResult } | null>(null);
   const selectedCoinSymbol = selectedCoin?.symbol ?? null;
+  const orderTargetKey = selectedCoinSymbol ? `${exchange.key}:${selectedCoinSymbol}` : null;
+
   useEffect(() => {
-    if (!selectedCoinSymbol) {
-      setOrderTarget(null);
-      return;
-    }
+    if (!selectedCoinSymbol || !orderTargetKey) return;
+
     let cancelled = false;
     void resolveOrderTargetIds(exchange.key, selectedCoinSymbol, getWalletId).then((result) => {
-      if (!cancelled) setOrderTarget(result);
+      if (!cancelled) setResolved({ target: orderTargetKey, result });
     });
     return () => { cancelled = true; };
-  }, [exchange.key, selectedCoinSymbol, getWalletId]);
+  }, [exchange.key, selectedCoinSymbol, orderTargetKey, getWalletId]);
 
+  const orderTarget = resolved?.target === orderTargetKey ? resolved.result : null;
   const orderTargetIds = orderTarget?.ok ? orderTarget.ids : null;
   const orderTargetFailure = orderTarget && !orderTarget.ok ? orderTarget.reason : null;
 

--- a/frontend/src/pages/SocialCallbackPage.tsx
+++ b/frontend/src/pages/SocialCallbackPage.tsx
@@ -8,8 +8,44 @@ import {
   OAUTH_VERIFIER_KEY,
   isSocialProvider,
   providerLabel,
+  type SocialProvider,
 } from "@/lib/auth/social";
 import { isApiClientError } from "@/lib/api/types";
+
+type AuthAttempt =
+  | { ok: true; provider: SocialProvider; code: string; verifier: string }
+  | { ok: false; message: string };
+
+/**
+ * 되돌아온 인가 정보를 검사한다. URL 과 세션 저장소를 읽기만 하므로 렌더 중에 불러도 안전하다.
+ * 세션 값을 지우는 것은 부수 효과라 이펙트에서 따로 한다.
+ */
+function readAuthAttempt(provider: string | undefined): AuthAttempt {
+  if (!isSocialProvider(provider)) {
+    return { ok: false, message: "지원하지 않는 소셜 제공자입니다." };
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get("code");
+  const returnedState = params.get("state");
+  const savedState = sessionStorage.getItem(OAUTH_STATE_KEY);
+  const verifier = sessionStorage.getItem(OAUTH_VERIFIER_KEY);
+
+  if (params.get("error")) {
+    return { ok: false, message: `${providerLabel(provider)} 로그인이 취소되었거나 실패했습니다.` };
+  }
+  if (!code || !returnedState) {
+    return { ok: false, message: "인가 정보가 올바르지 않습니다." };
+  }
+  if (!savedState || savedState !== returnedState) {
+    return { ok: false, message: "보안 검증(state)에 실패했습니다. 다시 시도해주세요." };
+  }
+  if (!verifier) {
+    return { ok: false, message: "로그인 검증값이 없습니다. 다시 시도해주세요." };
+  }
+
+  return { ok: true, provider, code, verifier };
+}
 
 /**
  * 소셜 인가 콜백. 제공자가 ?code=&state= 를 붙여 되돌린 페이지 (/auth/:provider/callback).
@@ -19,7 +55,9 @@ export function SocialCallbackPage() {
   const navigate = useNavigate();
   const { provider } = useParams();
   const { loginWithSocial } = useAuth();
-  const [error, setError] = useState<string | null>(null);
+  // 검증은 첫 렌더에 한 번만 한다. 읽기만 하므로 StrictMode 가 두 번 불러도 결과가 같다.
+  const [attempt] = useState(() => readAuthAttempt(provider));
+  const [submitError, setSubmitError] = useState<string | null>(null);
   // 인가 코드는 일회용이라 StrictMode 이중 실행 시 두 번째 교환이 실패한다. ref 로 한 번만 실행.
   const startedRef = useRef(false);
 
@@ -27,49 +65,25 @@ export function SocialCallbackPage() {
     if (startedRef.current) return;
     startedRef.current = true;
 
-    if (!isSocialProvider(provider)) {
-      setError("지원하지 않는 소셜 제공자입니다.");
-      return;
-    }
-
-    const params = new URLSearchParams(window.location.search);
-    const errorParam = params.get("error");
-    const code = params.get("code");
-    const returnedState = params.get("state");
-
-    const savedState = sessionStorage.getItem(OAUTH_STATE_KEY);
-    const verifier = sessionStorage.getItem(OAUTH_VERIFIER_KEY);
+    // 한 번 쓴 state·verifier 는 성공이든 실패든 남겨두지 않는다.
     sessionStorage.removeItem(OAUTH_STATE_KEY);
     sessionStorage.removeItem(OAUTH_VERIFIER_KEY);
 
-    if (errorParam) {
-      setError(`${providerLabel(provider)} 로그인이 취소되었거나 실패했습니다.`);
-      return;
-    }
-    if (!code || !returnedState) {
-      setError("인가 정보가 올바르지 않습니다.");
-      return;
-    }
-    if (!savedState || savedState !== returnedState) {
-      setError("보안 검증(state)에 실패했습니다. 다시 시도해주세요.");
-      return;
-    }
-    if (!verifier) {
-      setError("로그인 검증값이 없습니다. 다시 시도해주세요.");
-      return;
-    }
+    if (!attempt.ok) return;
 
-    socialLogin(provider, code, verifier)
+    socialLogin(attempt.provider, attempt.code, attempt.verifier)
       .then((result) => {
         loginWithSocial({ userId: result.userId, nickname: result.nickname });
         navigate("/market", { replace: true });
       })
       .catch((e: unknown) => {
-        setError(
+        setSubmitError(
           isApiClientError(e) ? e.message : "로그인 처리 중 오류가 발생했습니다.",
         );
       });
-  }, [navigate, loginWithSocial, provider]);
+  }, [attempt, navigate, loginWithSocial]);
+
+  const error = attempt.ok ? submitError : attempt.message;
 
   return (
     <div className="flex min-h-dvh items-center justify-center bg-background px-4">


### PR DESCRIPTION
## Summary

코인·거래소를 바꾼 직후 아직 새 주문 대상 해석이 끝나기 전에 이전 코인의 주문 대상(지갑·코인 식별자)이 그대로 쓰여, 엉뚱한 코인에 주문이 나갈 수 있던 문제를 고친다.

- **해석 결과에 대상 키를 함께 담는다** — `{ target, result }` 형태로 저장해, 어떤 코인·거래소에 대한 해석인지 남긴다.
- **렌더 시점에 판단한다** — 현재 선택과 해석 대상이 일치할 때만 주문 대상으로 인정한다.

---

## 핵심 흐름

```
코인/거래소 선택 변경
  └─ orderTargetKey = `${exchange.key}:${selectedCoinSymbol}`
       └─ 렌더 시점: resolved?.target === orderTargetKey 일 때만 orderTarget 사용
            └─ 불일치(아직 해석 전) → 주문 대상 없음으로 취급 (이전 값 재사용 안 함)
```

---

## 주요 변경 사항

### 화면

- `MarketPage` — 주문 대상 해석 결과를 대상 키와 함께 보관하고, 렌더 시점에 현재 선택과 대조해 사용한다.
- `SocialCallbackPage` — 이펙트에서 곧바로 상태를 바꾸던 검증 흐름을 초기화 시점 계산으로 바꾼다.

### 훅

- `useExchangeCoins` — 로딩 상태를 이펙트에서 세우지 않고 렌더 시점에 판단한다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 이전 해석 결과를 지우는 대신 대상 키로 검증 | 지우는 방식은 '지우는 이펙트'가 한 박자 늦게 도는 같은 문제를 다시 만든다. 결과에 대상 키를 붙여 두면 렌더 시점에 즉시 무효로 판별된다 |
| 린트 정리와 분리해 별도 PR 로 | 이펙트 흐름 정리라는 형태는 같지만, 이건 잘못된 코인에 주문이 나갈 수 있는 정합성 결함이라 별개로 다룬다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 코인을 빠르게 전환한 직후 주문 패널이 이전 코인의 대상을 쓰지 않음
- [x] 소셜 로그인 콜백이 정상 동작함

Closes #241