### PR TITLE
[#243] 코인 검색에 초성 일치를 지원하고 검색이 차트를 흔들지 않게 수정

### DIFF
--- a/frontend/src/components/market/CoinSearchInput.tsx
+++ b/frontend/src/components/market/CoinSearchInput.tsx
@@ -1,4 +1,4 @@
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 
 interface CoinSearchInputProps {
   value: string;
@@ -11,11 +11,24 @@ export function CoinSearchInput({ value, onChange }: CoinSearchInputProps) {
       <Search className="pointer-events-none absolute left-3.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
       <input
         type="text"
-        placeholder="코인명/심볼 검색"
+        placeholder="코인명/심볼 검색 (초성 가능)"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="h-10 w-full rounded-full border-0 bg-secondary/40 pl-9 pr-4 text-sm text-foreground placeholder:text-muted-foreground/60 outline-none transition-all focus:bg-white focus:shadow-[0_0_0_3px_rgba(118,69,217,0.1)] sm:w-64"
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onChange("");
+        }}
+        className="h-10 w-full rounded-full border-0 bg-secondary/40 pl-9 pr-10 text-sm text-foreground placeholder:text-muted-foreground/60 outline-none transition-all focus:bg-white focus:shadow-[0_0_0_3px_rgba(118,69,217,0.1)]"
       />
+      {value && (
+        <button
+          type="button"
+          onClick={() => onChange("")}
+          aria-label="검색어 지우기"
+          className="absolute right-2.5 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/market/CoinTable.tsx
+++ b/frontend/src/components/market/CoinTable.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, type CSSProperties } from "react";
+import { memo, useCallback, type CSSProperties, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { formatPrice, formatVolume, formatChangeRate, getCurrencySymbol } from "@/lib/formatters";
 import { SortIcon } from "@/components/ui/SortIcon";
@@ -14,6 +14,8 @@ interface CoinTableProps {
   baseCurrency: string;
   selectedSymbol?: string | null;
   onSelect?: (symbol: string) => void;
+  /** 목록 바로 위에 얹을 것 (검색창). 목록을 좁히는 도구는 목록과 같은 상자 안에 둔다. */
+  toolbar?: ReactNode;
 }
 
 type SortKey = "name" | "price" | "change" | "volume";
@@ -113,7 +115,7 @@ const CoinRow = memo(function CoinRow({
   );
 });
 
-export function CoinTable({ coins, baseCurrency, selectedSymbol, onSelect }: CoinTableProps) {
+export function CoinTable({ coins, baseCurrency, selectedSymbol, onSelect, toolbar }: CoinTableProps) {
   const comparator = useCallback((key: SortKey, dir: SortDir) => {
     return (a: CoinData, b: CoinData) => {
       let cmp = 0;
@@ -148,6 +150,8 @@ export function CoinTable({ coins, baseCurrency, selectedSymbol, onSelect }: Coi
 
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-card">
+      {toolbar && <div className="border-b border-border/40 px-5 py-3">{toolbar}</div>}
+
       <div
         className={cn("grid items-center bg-secondary/30 py-3.5", GRID_COLS)}
         style={{

--- a/frontend/src/lib/hangul.ts
+++ b/frontend/src/lib/hangul.ts
@@ -1,0 +1,92 @@
+/**
+ * 한글 검색용 문자열 변환.
+ *
+ * 완성형 한글(가~힣)은 코드값이 규칙적으로 배열되어 있다.
+ *   코드 = 0xAC00 + (초성 × 21 + 중성) × 28 + 종성
+ * 덕분에 사전이나 형태소 분석 없이 나눗셈만으로 자모를 얻는다.
+ */
+
+const HANGUL_FIRST = 0xac00; // '가'
+const HANGUL_LAST = 0xd7a3; // '힣'
+const JUNGSUNG_COUNT = 21;
+const JONGSUNG_COUNT = 28;
+
+const CHOSUNG = [
+  "ㄱ", "ㄲ", "ㄴ", "ㄷ", "ㄸ", "ㄹ", "ㅁ", "ㅂ", "ㅃ", "ㅅ",
+  "ㅆ", "ㅇ", "ㅈ", "ㅉ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ",
+];
+
+const JUNGSUNG = [
+  "ㅏ", "ㅐ", "ㅑ", "ㅒ", "ㅓ", "ㅔ", "ㅕ", "ㅖ", "ㅗ", "ㅘ",
+  "ㅙ", "ㅚ", "ㅛ", "ㅜ", "ㅝ", "ㅞ", "ㅟ", "ㅠ", "ㅡ", "ㅢ", "ㅣ",
+];
+
+const JONGSUNG = [
+  "", "ㄱ", "ㄲ", "ㄳ", "ㄴ", "ㄵ", "ㄶ", "ㄷ", "ㄹ", "ㄺ",
+  "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ", "ㅁ", "ㅂ", "ㅄ", "ㅅ",
+  "ㅆ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ",
+];
+
+// 겹자모는 자판에서 두 번에 나눠 눌린다. 분해할 때도 눌린 순서대로 풀어야
+// 조합 중인 글자가 완성된 이름의 앞부분과 맞아떨어진다.
+// 예: '비트' 를 치는 도중의 '빝' → ㅂㅣㅌ 이고, 이는 '비트'(ㅂㅣㅌㅡ)의 앞부분이다.
+const COMPOUND: Record<string, string> = {
+  "ㄲ": "ㄱㄱ", "ㄳ": "ㄱㅅ", "ㄵ": "ㄴㅈ", "ㄶ": "ㄴㅎ", "ㄸ": "ㄷㄷ",
+  "ㄺ": "ㄹㄱ", "ㄻ": "ㄹㅁ", "ㄼ": "ㄹㅂ", "ㄽ": "ㄹㅅ", "ㄾ": "ㄹㅌ",
+  "ㄿ": "ㄹㅍ", "ㅀ": "ㄹㅎ", "ㅃ": "ㅂㅂ", "ㅄ": "ㅂㅅ", "ㅆ": "ㅅㅅ",
+  "ㅉ": "ㅈㅈ", "ㅘ": "ㅗㅏ", "ㅙ": "ㅗㅐ", "ㅚ": "ㅗㅣ", "ㅝ": "ㅜㅓ",
+  "ㅞ": "ㅜㅔ", "ㅟ": "ㅜㅣ", "ㅢ": "ㅡㅣ",
+};
+
+const CONSONANTS_ONLY = /^[ㄱ-ㅎ]+$/;
+
+function split(jamo: string): string {
+  return COMPOUND[jamo] ?? jamo;
+}
+
+function isSyllable(code: number): boolean {
+  return code >= HANGUL_FIRST && code <= HANGUL_LAST;
+}
+
+/** '비트코인' → 'ㅂㅌㅋㅇ'. 한글이 아닌 글자는 그대로 둔다. */
+export function toChosung(text: string): string {
+  let result = "";
+  for (const char of text) {
+    const code = char.charCodeAt(0);
+    if (isSyllable(code)) {
+      const offset = code - HANGUL_FIRST;
+      result += CHOSUNG[Math.floor(offset / (JUNGSUNG_COUNT * JONGSUNG_COUNT))];
+    } else {
+      result += char;
+    }
+  }
+  return result;
+}
+
+/**
+ * '비트코인' → 'ㅂㅣㅌㅡㅋㅗㅇㅣㄴ'. 한글이 아닌 글자는 그대로 둔다.
+ *
+ * 조합 중인 글자도 같은 규칙으로 풀리므로, 타이핑 도중의 입력이 완성된 이름의
+ * 앞부분과 그대로 맞아떨어진다.
+ */
+export function toJamo(text: string): string {
+  let result = "";
+  for (const char of text) {
+    const code = char.charCodeAt(0);
+    if (isSyllable(code)) {
+      const offset = code - HANGUL_FIRST;
+      const chosung = CHOSUNG[Math.floor(offset / (JUNGSUNG_COUNT * JONGSUNG_COUNT))];
+      const jungsung = JUNGSUNG[Math.floor(offset / JONGSUNG_COUNT) % JUNGSUNG_COUNT];
+      const jongsung = JONGSUNG[offset % JONGSUNG_COUNT];
+      result += split(chosung) + split(jungsung) + split(jongsung);
+    } else {
+      result += split(char);
+    }
+  }
+  return result;
+}
+
+/** 자음만 입력했는지. 'ㅂㅌ' 처럼 자음뿐이면 이름 원문에는 없는 글자라 초성과 맞춰야 한다. */
+export function isChosungQuery(text: string): boolean {
+  return CONSONANTS_ONLY.test(text);
+}

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -12,6 +12,7 @@ import { EmergencyFundingCard } from "@/components/round/EmergencyFundingCard";
 import { useRound } from "@/contexts/RoundContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { EXCHANGES } from "@/lib/types/coins";
+import { isChosungQuery, toChosung, toJamo } from "@/lib/hangul";
 import { resolveOrderTargetIds, type OrderTargetResult } from "@/lib/api/id-mapping";
 import { useExchangeCoins } from "@/hooks/useExchangeCoins";
 import { useTickers } from "@/hooks/useTickers";
@@ -49,16 +50,37 @@ export function MarketPage() {
     initialCoins: staticCoins,
   });
 
+  // 코인 이름의 초성·자모는 시세가 갱신돼도 변하지 않는다. 목록을 받아올 때 한 번만 풀어 둔다.
+  const searchIndex = useMemo(() => {
+    const index = new Map<string, { chosung: string; jamo: string }>();
+    staticCoins.forEach((coin) => {
+      index.set(coin.symbol, {
+        chosung: toChosung(coin.name).toLowerCase(),
+        jamo: toJamo(coin.name).toLowerCase(),
+      });
+    });
+    return index;
+  }, [staticCoins]);
+
   const filteredCoins = useMemo(() => {
     let filtered = coins;
 
-    if (searchQuery.trim()) {
-      const query = searchQuery.trim().toLowerCase();
-      filtered = filtered.filter(
-        (coin) =>
-          coin.symbol.toLowerCase().includes(query) ||
-          coin.name.toLowerCase().includes(query),
-      );
+    const query = searchQuery.trim().toLowerCase();
+    if (query) {
+      const chosungQuery = isChosungQuery(query);
+      const jamoQuery = toJamo(query);
+      filtered = filtered.filter((coin) => {
+        if (coin.symbol.toLowerCase().includes(query)) return true;
+
+        const index = searchIndex.get(coin.symbol);
+        if (!index) return false;
+
+        // 자음만 친 'ㅂㅌ' 은 이름 원문에 없는 글자다. 초성을 앞에서부터 맞춘다.
+        // 그 밖의 입력은 조합 중이든 완성됐든 자모로 풀어서 부분 일치를 본다.
+        return chosungQuery
+          ? index.chosung.startsWith(query)
+          : index.jamo.includes(jamoQuery);
+      });
     }
 
     switch (filter) {
@@ -71,7 +93,7 @@ export function MarketPage() {
     }
 
     return filtered;
-  }, [coins, searchQuery, filter]);
+  }, [coins, searchIndex, searchQuery, filter]);
 
   const selectedCoin = useMemo(() => {
     const fromSelection = coins.find((coin) => coin.symbol === selectedSymbol);

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -95,10 +95,12 @@ export function MarketPage() {
     return filtered;
   }, [coins, searchIndex, searchQuery, filter]);
 
+  // 검색은 목록만 좁힌다. 차트가 걸러진 목록의 첫 코인을 따라가면 글자를 칠 때마다 차트가 바뀐다.
+  // 아무것도 고르지 않았을 때만 첫 코인을 보여주고, 그 뒤로는 행을 눌러 고른 코인만 따른다.
   const selectedCoin = useMemo(() => {
     const fromSelection = coins.find((coin) => coin.symbol === selectedSymbol);
-    return fromSelection ?? filteredCoins[0] ?? coins[0];
-  }, [coins, filteredCoins, selectedSymbol]);
+    return fromSelection ?? coins[0];
+  }, [coins, selectedSymbol]);
 
   // 해석 결과에 어느 코인의 것인지를 함께 담는다. 그래야 다른 코인으로 옮긴 직후
   // 아직 해석이 끝나지 않은 사이에 이전 코인의 주문 대상이 그대로 쓰이는 일이 없다.
@@ -166,9 +168,6 @@ export function MarketPage() {
           />
           {EXCHANGES.length > 1 && <div className="h-6 w-px bg-border/60" />}
           <FilterChips selected={filter} onSelect={setFilter} />
-          <div className="ml-auto">
-            <CoinSearchInput value={searchQuery} onChange={setSearchQuery} />
-          </div>
         </div>
 
         {loading ? (
@@ -192,6 +191,7 @@ export function MarketPage() {
                 baseCurrency={exchange.baseCurrency}
                 selectedSymbol={selectedCoin?.symbol ?? null}
                 onSelect={setSelectedSymbol}
+                toolbar={<CoinSearchInput value={searchQuery} onChange={setSearchQuery} />}
               />
             </div>
 


### PR DESCRIPTION
## Summary

코인 검색을 하나의 완결된 흐름으로 만든다. 초성으로 찾을 수 있고, 검색어를 쳐도 차트가 흔들리지 않는다.

- **초성·자모 일치** — '비트코인'을 'ㅂㅌ'로 찾을 수 있다.
- **검색은 목록만 좁힌다** — 선택된 코인이 없을 때 걸러진 목록의 첫 코인을 차트로 띄우던 폴백을 없앤다.
- **검색창을 목록 안으로** — 페이지 컨트롤 바에 있던 검색창을 코인 목록 툴바로 옮기고 지우기 버튼을 단다.

---

## 주요 변경 사항

### 검색

- `lib/hangul.ts` — 한글 음절을 자모로 분해해 초성·자모 일치를 판정한다(신규).
- `MarketPage` — 검색어 필터에 초성 일치를 적용한다. `selectedCoin` 계산에서 `filteredCoins[0]` 폴백을 제거해 검색이 차트 선택에 영향을 주지 않게 한다.

### 화면

- `CoinTable` — `toolbar` prop 을 받아 목록 상단에 검색창을 렌더한다.
- `CoinSearchInput` — 지우기 버튼을 추가하고 placeholder 를 '코인명/심볼 검색 (초성 가능)' 으로 바꾼다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 두 변경을 한 PR 로 | 검색창 문구가 '초성 가능'이라고 알리므로 초성 일치 없이 나가면 거짓 안내가 된다 |
| 차트 폴백 제거로 흔들림을 잡는다 | 디바운스로 늦추는 방식은 흔들림을 느리게 만들 뿐 없애지 못한다. 검색이 차트 선택에 관여하지 않는 것이 옳다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 'ㅂㅌ' 로 비트코인이 검색됨
- [x] 검색어를 입력해도 차트가 다른 코인으로 바뀌지 않음

Closes #243