### PR TITLE
[#245] 코인 목록을 거래대금순으로 정렬하고 차트가 맨 위 코인을 따르도록 수정

### DIFF
--- a/frontend/src/components/market/CoinTable.tsx
+++ b/frontend/src/components/market/CoinTable.tsx
@@ -1,24 +1,27 @@
-import { memo, useCallback, type CSSProperties, type ReactNode } from "react";
+import { memo, type CSSProperties, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { formatPrice, formatVolume, formatChangeRate, getCurrencySymbol } from "@/lib/formatters";
 import { SortIcon } from "@/components/ui/SortIcon";
-import { useSort } from "@/hooks/useSort";
 import type { SortDir } from "@/hooks/useSort";
 import { useVirtualList, virtualRowStyle } from "@/hooks/useVirtualList";
 import { usePriceFlash } from "@/hooks/usePriceFlash";
 import { CoinIcon } from "./CoinIcon";
 import type { CoinData } from "@/lib/types/coins";
 
+export type CoinSortKey = "name" | "price" | "change" | "volume";
+
 interface CoinTableProps {
+  /** 이미 정렬을 마친 목록. 차트의 기본 코인도 같은 정렬을 따라야 하므로 정렬은 페이지가 쥔다. */
   coins: CoinData[];
   baseCurrency: string;
+  sortKey: CoinSortKey | null;
+  sortDir: SortDir;
+  onSort: (key: CoinSortKey) => void;
   selectedSymbol?: string | null;
   onSelect?: (symbol: string) => void;
   /** 목록 바로 위에 얹을 것 (검색창). 목록을 좁히는 도구는 목록과 같은 상자 안에 둔다. */
   toolbar?: ReactNode;
 }
-
-type SortKey = "name" | "price" | "change" | "volume";
 
 const GRID_COLS = "grid-cols-[2fr_minmax(100px,140px)_minmax(80px,100px)_minmax(160px,1fr)]";
 
@@ -115,34 +118,24 @@ const CoinRow = memo(function CoinRow({
   );
 });
 
-export function CoinTable({ coins, baseCurrency, selectedSymbol, onSelect, toolbar }: CoinTableProps) {
-  const comparator = useCallback((key: SortKey, dir: SortDir) => {
-    return (a: CoinData, b: CoinData) => {
-      let cmp = 0;
-      switch (key) {
-        case "name": cmp = a.symbol.localeCompare(b.symbol); break;
-        case "price": cmp = a.currentPrice - b.currentPrice; break;
-        case "change": cmp = a.changeRate - b.changeRate; break;
-        case "volume": cmp = a.volume - b.volume; break;
-      }
-      return dir === "asc" ? cmp : -cmp;
-    };
-  }, []);
-
-  const { sorted: sortedCoins, sortKey, sortDir, handleSort } = useSort<CoinData, SortKey>({
-    items: coins,
-    defaultKey: "volume",
-    comparator,
-  });
-
+export function CoinTable({
+  coins,
+  baseCurrency,
+  sortKey,
+  sortDir,
+  onSort,
+  selectedSymbol,
+  onSelect,
+  toolbar,
+}: CoinTableProps) {
   const { scrollRef, virtualizer, scrollbarWidth } = useVirtualList({
-    count: sortedCoins.length,
+    count: coins.length,
     rowHeight: ROW_HEIGHT,
   });
 
   const currencySymbol = getCurrencySymbol(baseCurrency);
 
-  const columns: { key: SortKey; label: string; sortable: boolean }[] = [
+  const columns: { key: CoinSortKey; label: string; sortable: boolean }[] = [
     { key: "name", label: "코인명", sortable: true },
     { key: "price", label: "현재가", sortable: true },
     { key: "change", label: "전일대비", sortable: true },
@@ -163,7 +156,7 @@ export function CoinTable({ coins, baseCurrency, selectedSymbol, onSelect, toolb
         {columns.map((col) => (
           <button
             key={col.key}
-            onClick={() => col.sortable && handleSort(col.key)}
+            onClick={() => col.sortable && onSort(col.key)}
             disabled={!col.sortable}
             className={cn(
               "flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors",
@@ -178,7 +171,7 @@ export function CoinTable({ coins, baseCurrency, selectedSymbol, onSelect, toolb
         ))}
       </div>
 
-      {sortedCoins.length === 0 ? (
+      {coins.length === 0 ? (
         <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
           검색 결과가 없습니다.
         </div>
@@ -188,11 +181,11 @@ export function CoinTable({ coins, baseCurrency, selectedSymbol, onSelect, toolb
         <div
           ref={scrollRef}
           className="overflow-y-auto [scrollbar-gutter:stable]"
-          style={{ height: Math.min(LIST_HEIGHT, sortedCoins.length * ROW_HEIGHT) }}
+          style={{ height: Math.min(LIST_HEIGHT, coins.length * ROW_HEIGHT) }}
         >
           <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
             {virtualizer.getVirtualItems().map((item) => {
-              const coin = sortedCoins[item.index];
+              const coin = coins[item.index];
               return (
                 <CoinRow
                   key={coin.symbol}
@@ -200,7 +193,7 @@ export function CoinTable({ coins, baseCurrency, selectedSymbol, onSelect, toolb
                   baseCurrency={baseCurrency}
                   currencySymbol={currencySymbol}
                   isSelected={selectedSymbol === coin.symbol}
-                  isLast={item.index === sortedCoins.length - 1}
+                  isLast={item.index === coins.length - 1}
                   style={virtualRowStyle(item, ROW_HEIGHT)}
                   onSelect={onSelect}
                 />

--- a/frontend/src/components/market/CoinTable.tsx
+++ b/frontend/src/components/market/CoinTable.tsx
@@ -131,6 +131,7 @@ export function CoinTable({ coins, baseCurrency, selectedSymbol, onSelect, toolb
 
   const { sorted: sortedCoins, sortKey, sortDir, handleSort } = useSort<CoinData, SortKey>({
     items: coins,
+    defaultKey: "volume",
     comparator,
   });
 

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -5,7 +5,7 @@ import { MarketOverviewCards } from "@/components/market/MarketOverviewCards";
 import { ExchangeTabs } from "@/components/market/ExchangeTabs";
 import { CoinSearchInput } from "@/components/market/CoinSearchInput";
 import { FilterChips } from "@/components/market/FilterChips";
-import { CoinTable } from "@/components/market/CoinTable";
+import { CoinTable, type CoinSortKey } from "@/components/market/CoinTable";
 import { CandleChartPanel } from "@/components/market/CandleChartPanel";
 import { OrderPanel } from "@/components/market/OrderPanel";
 import { EmergencyFundingCard } from "@/components/round/EmergencyFundingCard";
@@ -17,7 +17,9 @@ import { resolveOrderTargetIds, type OrderTargetResult } from "@/lib/api/id-mapp
 import { useExchangeCoins } from "@/hooks/useExchangeCoins";
 import { useTickers } from "@/hooks/useTickers";
 import { useUserEvents } from "@/hooks/useUserEvents";
+import { useSort, type SortDir } from "@/hooks/useSort";
 import type { UserEvent } from "@/lib/api/websocket";
+import type { CoinData } from "@/lib/types/coins";
 import type { FilterType } from "@/components/market/FilterChips";
 
 export function MarketPage() {
@@ -95,12 +97,36 @@ export function MarketPage() {
     return filtered;
   }, [coins, searchIndex, searchQuery, filter]);
 
-  // 검색은 목록만 좁힌다. 차트가 걸러진 목록의 첫 코인을 따라가면 글자를 칠 때마다 차트가 바뀐다.
-  // 아무것도 고르지 않았을 때만 첫 코인을 보여주고, 그 뒤로는 행을 눌러 고른 코인만 따른다.
+  const comparator = useCallback((key: CoinSortKey, dir: SortDir) => {
+    return (a: CoinData, b: CoinData) => {
+      let cmp = 0;
+      switch (key) {
+        case "name": cmp = a.symbol.localeCompare(b.symbol); break;
+        case "price": cmp = a.currentPrice - b.currentPrice; break;
+        case "change": cmp = a.changeRate - b.changeRate; break;
+        case "volume": cmp = a.volume - b.volume; break;
+      }
+      return dir === "asc" ? cmp : -cmp;
+    };
+  }, []);
+
+  const { sorted: sortedCoins, sortKey, sortDir, handleSort } = useSort<CoinData, CoinSortKey>({
+    items: filteredCoins,
+    defaultKey: "volume",
+    comparator,
+  });
+
+  // 아무것도 고르지 않았으면 목록 맨 위 코인의 차트를 보여준다. 다만 검색으로 좁혀진 목록을 따라가면
+  // 글자를 칠 때마다 차트가 바뀌므로, 걸러내기 전 전체 목록을 같은 기준으로 세워 그 첫 코인을 쓴다.
+  const topCoin = useMemo(() => {
+    if (!sortKey) return coins[0];
+    return [...coins].sort(comparator(sortKey, sortDir))[0];
+  }, [coins, sortKey, sortDir, comparator]);
+
   const selectedCoin = useMemo(() => {
     const fromSelection = coins.find((coin) => coin.symbol === selectedSymbol);
-    return fromSelection ?? coins[0];
-  }, [coins, selectedSymbol]);
+    return fromSelection ?? topCoin;
+  }, [coins, selectedSymbol, topCoin]);
 
   // 해석 결과에 어느 코인의 것인지를 함께 담는다. 그래야 다른 코인으로 옮긴 직후
   // 아직 해석이 끝나지 않은 사이에 이전 코인의 주문 대상이 그대로 쓰이는 일이 없다.
@@ -187,8 +213,11 @@ export function MarketPage() {
 
               {/* Coin table */}
               <CoinTable
-                coins={filteredCoins}
+                coins={sortedCoins}
                 baseCurrency={exchange.baseCurrency}
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onSort={handleSort}
                 selectedSymbol={selectedCoin?.symbol ?? null}
                 onSelect={setSelectedSymbol}
                 toolbar={<CoinSearchInput value={searchQuery} onChange={setSearchQuery} />}


### PR DESCRIPTION
## Summary

코인 목록을 거래대금 내림차순으로 기본 정렬하고, 차트가 그 정렬의 맨 위 코인을 따라가게 한다.

- **기본 정렬** — 첫 진입 시 거래대금 내림차순.
- **차트-목록 일치** — 차트가 '정렬 전 첫 코인'이 아니라 현재 정렬 기준의 맨 위 코인을 띄운다.

---

## 주요 변경 사항

### 화면

- `MarketPage` — 정렬 상태(`useSort`, `defaultKey: "volume"`)를 화면이 소유한다. 정렬된 첫 코인(`topCoin`)을 계산해 선택된 코인이 없을 때의 기본값으로 쓴다.
- `CoinTable` — 내부에 있던 정렬 로직을 걷어내고, 정렬 상태(`sortKey`/`sortDir`/`onSort`)를 prop 으로 받아 표시만 한다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 정렬 상태를 `CoinTable` 이 아니라 `MarketPage` 가 소유한다 | 차트도 같은 정렬 결과를 알아야 목록 맨 위와 일치한다. 목록 안에 정렬이 갇혀 있으면 차트는 정렬 전 순서를 볼 수밖에 없다 |
| `topCoin` 은 걸러진 목록이 아니라 전체 목록 기준 | 걸러진 목록을 쓰면 검색어를 칠 때마다 차트가 다시 흔들린다 |
| 두 커밋을 한 PR 로 | 기본 정렬만 먼저 올리면 '목록 맨 위와 차트가 어긋나는' 회귀가 그대로 main 에 올라간다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 첫 진입 시 목록이 거래대금 내림차순으로 정렬됨
- [x] 차트가 목록 맨 위 코인을 띄움
- [x] 검색어를 입력해도 차트가 흔들리지 않음

Closes #245