### PR TITLE
[#247] 진행 중인 라운드가 없으면 마켓에서 주문 패널을 숨김

### DIFF
--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -12,6 +12,7 @@ import { EmergencyFundingCard } from "@/components/round/EmergencyFundingCard";
 import { useRound } from "@/contexts/RoundContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { EXCHANGES } from "@/lib/types/coins";
+import { cn } from "@/lib/utils";
 import { isChosungQuery, toChosung, toJamo } from "@/lib/hangul";
 import { resolveOrderTargetIds, type OrderTargetResult } from "@/lib/api/id-mapping";
 import { useExchangeCoins } from "@/hooks/useExchangeCoins";
@@ -201,7 +202,13 @@ export function MarketPage() {
             코인 목록을 불러오는 중...
           </div>
         ) : (
-          <div className="animate-enter-delay-3 mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+          <div
+            className={cn(
+              "animate-enter-delay-3 mt-6 grid grid-cols-1 gap-6",
+              // 라운드가 없으면 옆 칸에 띄울 것이 없다. 빈 열을 남기지 않고 차트와 목록이 폭을 다 쓰게 한다.
+              activeRound && "lg:grid-cols-[minmax(0,1fr)_360px]",
+            )}
+          >
             <div className="space-y-5">
               {selectedCoin && (
                 <CandleChartPanel
@@ -225,26 +232,26 @@ export function MarketPage() {
             </div>
 
             {/* Side panel */}
-            <div className="space-y-5">
-              {activeRound && (
+            {activeRound && (
+              <div className="space-y-5">
                 <EmergencyFundingCard
                   round={activeRound}
                   onCharge={(amount) => chargeEmergencyFunding(amount, exchange.id)}
                 />
-              )}
-              {selectedCoin && (
-                <OrderPanel
-                  baseCurrency={exchange.baseCurrency}
-                  coinSymbol={selectedCoin.symbol}
-                  coinName={selectedCoin.name}
-                  currentPrice={selectedCoin.currentPrice}
-                  feeRate={0.0005}
-                  orderTargetIds={orderTargetIds}
-                  orderTargetFailure={orderTargetFailure}
-                  orderFilledEvent={orderFilledEvent}
-                />
-              )}
-            </div>
+                {selectedCoin && (
+                  <OrderPanel
+                    baseCurrency={exchange.baseCurrency}
+                    coinSymbol={selectedCoin.symbol}
+                    coinName={selectedCoin.name}
+                    currentPrice={selectedCoin.currentPrice}
+                    feeRate={0.0005}
+                    orderTargetIds={orderTargetIds}
+                    orderTargetFailure={orderTargetFailure}
+                    orderFilledEvent={orderFilledEvent}
+                  />
+                )}
+              </div>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

진행 중인 라운드가 없으면 아무것도 할 수 없는 주문 패널과 긴급 자금 카드를 마켓 화면에서 숨긴다. 빈 칸으로 남던 오른쪽 컬럼이 사라지고 차트가 넓게 보인다.

---

## 주요 변경 사항

### 화면

- `MarketPage` — 활성 라운드가 있을 때만 사이드 패널(주문·긴급 자금)을 렌더한다. 라운드가 없으면 그리드를 1단으로 바꾼다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 패널을 비활성화하지 않고 아예 렌더하지 않는다 | 비활성 패널은 여전히 자리를 차지하고, 사용자는 눌러 보고 나서야 안 된다는 것을 알게 된다 |
| 라운드가 없을 때 그리드를 1단으로 | 사이드 패널이 빠진 자리가 빈 칸으로 남으면 화면이 어색하다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 라운드가 없으면 마켓 화면에 주문 패널이 보이지 않고 차트가 전체 폭을 씀
- [x] 라운드가 있으면 기존과 동일하게 2단으로 렌더됨

Closes #247