### PR TITLE
[#249] React 규칙 위반 정리 (Fast Refresh·렌더 부수효과·훅 의존성)

### DIFF
--- a/frontend/src/components/market/CandleChartPanel.tsx
+++ b/frontend/src/components/market/CandleChartPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { formatChangeRate, formatPrice, getCurrencySymbol } from "@/lib/formatters";
 import {
@@ -250,35 +250,43 @@ export function CandleChartPanel({
       )
     : 8;
 
-  function moveViewport(nextEndIndex: number) {
-    const safeVisibleCount = Math.min(visibleCount, candles.length);
-    const minEndIndex = safeVisibleCount;
-    const maxEndIndex = candles.length;
-    setEndIndex(clamp(nextEndIndex, minEndIndex, maxEndIndex));
-  }
+  // 휠 이벤트 리스너가 이 둘을 붙잡고 있다. 매 렌더마다 새로 만들면 리스너를 그때마다
+  // 다시 등록해야 하므로, 실제로 쓰는 값이 바뀔 때만 새로 만든다.
+  const moveViewport = useCallback(
+    (nextEndIndex: number) => {
+      const safeVisibleCount = Math.min(visibleCount, candles.length);
+      const minEndIndex = safeVisibleCount;
+      const maxEndIndex = candles.length;
+      setEndIndex(clamp(nextEndIndex, minEndIndex, maxEndIndex));
+    },
+    [visibleCount, candles.length],
+  );
 
-  function zoomTo(nextVisibleCount: number, anchorGlobalIndex?: number) {
-    const boundedVisibleCount = clamp(nextVisibleCount, MIN_VISIBLE_COUNT, candles.length);
-    const previousVisibleCount = Math.min(visibleCount, candles.length);
-    const previousStartIndex = Math.max(0, endIndex - previousVisibleCount);
-    const fallbackAnchor = previousStartIndex + Math.floor(previousVisibleCount / 2);
-    const anchorIndex = clamp(
-      anchorGlobalIndex ?? fallbackAnchor,
-      0,
-      Math.max(candles.length - 1, 0),
-    );
-    const ratio =
-      previousVisibleCount <= 1 ? 1 : (anchorIndex - previousStartIndex) / previousVisibleCount;
-    const nextStartIndex = clamp(
-      Math.round(anchorIndex - boundedVisibleCount * ratio),
-      0,
-      Math.max(candles.length - boundedVisibleCount, 0),
-    );
+  const zoomTo = useCallback(
+    (nextVisibleCount: number, anchorGlobalIndex?: number) => {
+      const boundedVisibleCount = clamp(nextVisibleCount, MIN_VISIBLE_COUNT, candles.length);
+      const previousVisibleCount = Math.min(visibleCount, candles.length);
+      const previousStartIndex = Math.max(0, endIndex - previousVisibleCount);
+      const fallbackAnchor = previousStartIndex + Math.floor(previousVisibleCount / 2);
+      const anchorIndex = clamp(
+        anchorGlobalIndex ?? fallbackAnchor,
+        0,
+        Math.max(candles.length - 1, 0),
+      );
+      const ratio =
+        previousVisibleCount <= 1 ? 1 : (anchorIndex - previousStartIndex) / previousVisibleCount;
+      const nextStartIndex = clamp(
+        Math.round(anchorIndex - boundedVisibleCount * ratio),
+        0,
+        Math.max(candles.length - boundedVisibleCount, 0),
+      );
 
-    setVisibleCount(boundedVisibleCount);
-    setEndIndex(nextStartIndex + boundedVisibleCount);
-    setHoveredIndex(null);
-  }
+      setVisibleCount(boundedVisibleCount);
+      setEndIndex(nextStartIndex + boundedVisibleCount);
+      setHoveredIndex(null);
+    },
+    [candles.length, visibleCount, endIndex],
+  );
 
   function handlePointerDown(event: React.PointerEvent<SVGSVGElement>) {
     dragStateRef.current = {
@@ -411,6 +419,8 @@ export function CandleChartPanel({
     candles.length,
     chartData,
     endIndex,
+    moveViewport,
+    zoomTo,
     visibleCandles.length,
     visibleCount,
     visibleStartIndex,

--- a/frontend/src/components/portfolio/DonutChart.tsx
+++ b/frontend/src/components/portfolio/DonutChart.tsx
@@ -78,7 +78,12 @@ export function DonutChart({ availableCash, holdings, baseCurrency }: DonutChart
   const cx = size / 2;
   const cy = size / 2;
 
-  let accumulated = 0;
+  // 조각이 시작하는 위치는 앞선 조각들의 비율 합이다. 그리면서 변수를 누적하면
+  // 렌더 도중 값을 바꾸는 셈이라, 그리기 전에 시작 위치를 미리 계산해 둔다. 조각은 많아야 7개다.
+  const arcs = segments.map((seg, i) => ({
+    ...seg,
+    start: segments.slice(0, i).reduce((sum, prev) => sum + prev.ratio, 0),
+  }));
 
   return (
     <div className="rounded-xl border border-border bg-card p-5">
@@ -97,10 +102,9 @@ export function DonutChart({ availableCash, holdings, baseCurrency }: DonutChart
               strokeWidth={strokeWidth}
             />
             {/* Segments */}
-            {segments.map((seg) => {
+            {arcs.map((seg) => {
               const dashLength = circumference * seg.ratio;
-              const dashOffset = circumference * (0.25 - accumulated);
-              accumulated += seg.ratio;
+              const dashOffset = circumference * (0.25 - seg.start);
               const isHovered = hoveredLabel === seg.label;
               const isOtherHovered = hoveredLabel !== null && hoveredLabel !== seg.label;
               return (

--- a/frontend/src/components/regret/RegretChart.tsx
+++ b/frontend/src/components/regret/RegretChart.tsx
@@ -106,7 +106,7 @@ export function RegretChart({
     }));
 
     return { actualPath, simPath, btcPath, yTicks, xLabels, markerPoints, hoverPoints };
-  }, [snapshots, markers, simulationLine, btcHoldValues]);
+  }, [snapshots, markers, simulationLine, btcHoldValues, totalDays]);
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent<SVGSVGElement>) => {

--- a/frontend/src/components/round/InvestmentRulesSection.tsx
+++ b/frontend/src/components/round/InvestmentRulesSection.tsx
@@ -1,73 +1,10 @@
 import { InvestmentRuleCard } from "./InvestmentRuleCard";
-import type { RuleType } from "@/lib/types/round";
-
-export interface RuleState {
-  enabled: boolean;
-  value: number;
-}
-
-/**
- * 손절(STOP_LOSS)·익절(TAKE_PROFIT)은 백엔드에 위반 판정 로직이 없어 설정해도 아무 위반도 기록되지 않는다.
- * 지키지 않아도 복기에 0건으로 나와 사용자를 오도하므로, 판정이 구현될 때까지 설정 대상에서 제외한다.
- */
-export type SelectableRuleType = Exclude<RuleType, "STOP_LOSS" | "TAKE_PROFIT">;
-
-export type RulesMap = Record<SelectableRuleType, RuleState>;
+import { RULE_CONFIGS, type RulesMap, type SelectableRuleType } from "./rules";
 
 interface InvestmentRulesSectionProps {
   rules: RulesMap;
   onRuleToggle: (type: SelectableRuleType, enabled: boolean) => void;
   onRuleValueChange: (type: SelectableRuleType, value: number) => void;
-}
-
-const RULE_CONFIGS: {
-  type: SelectableRuleType;
-  label: string;
-  description: string;
-  min: number;
-  max: number;
-  unit: string;
-  inputType: "slider" | "number";
-  defaultValue: number;
-}[] = [
-  {
-    type: "NO_CHASE_BUY",
-    label: "추격 매수 금지",
-    description: "급등 코인 매수를 방지",
-    min: 1,
-    max: 50,
-    unit: "%",
-    inputType: "slider",
-    defaultValue: 15,
-  },
-  {
-    type: "AVERAGING_LIMIT",
-    label: "물타기 제한",
-    description: "손실 중인 코인의 추가 매수 횟수 제한",
-    min: 1,
-    max: 10,
-    unit: "회",
-    inputType: "number",
-    defaultValue: 3,
-  },
-  {
-    type: "OVERTRADE_LIMIT",
-    label: "과매매 제한",
-    description: "하루 거래 횟수 제한",
-    min: 1,
-    max: 50,
-    unit: "회/일",
-    inputType: "number",
-    defaultValue: 10,
-  },
-];
-
-export function getDefaultRules(): RulesMap {
-  const map = {} as RulesMap;
-  for (const cfg of RULE_CONFIGS) {
-    map[cfg.type] = { enabled: false, value: cfg.defaultValue };
-  }
-  return map;
 }
 
 export function InvestmentRulesSection({

--- a/frontend/src/components/round/rules.ts
+++ b/frontend/src/components/round/rules.ts
@@ -1,0 +1,64 @@
+import type { RuleType } from "@/lib/types/round";
+
+export interface RuleState {
+  enabled: boolean;
+  value: number;
+}
+
+/**
+ * 손절(STOP_LOSS)·익절(TAKE_PROFIT)은 백엔드에 위반 판정 로직이 없어 설정해도 아무 위반도 기록되지 않는다.
+ * 지키지 않아도 복기에 0건으로 나와 사용자를 오도하므로, 판정이 구현될 때까지 설정 대상에서 제외한다.
+ */
+export type SelectableRuleType = Exclude<RuleType, "STOP_LOSS" | "TAKE_PROFIT">;
+
+export type RulesMap = Record<SelectableRuleType, RuleState>;
+
+export const RULE_CONFIGS: {
+  type: SelectableRuleType;
+  label: string;
+  description: string;
+  min: number;
+  max: number;
+  unit: string;
+  inputType: "slider" | "number";
+  defaultValue: number;
+}[] = [
+  {
+    type: "NO_CHASE_BUY",
+    label: "추격 매수 금지",
+    description: "급등 코인 매수를 방지",
+    min: 1,
+    max: 50,
+    unit: "%",
+    inputType: "slider",
+    defaultValue: 15,
+  },
+  {
+    type: "AVERAGING_LIMIT",
+    label: "물타기 제한",
+    description: "손실 중인 코인의 추가 매수 횟수 제한",
+    min: 1,
+    max: 10,
+    unit: "회",
+    inputType: "number",
+    defaultValue: 3,
+  },
+  {
+    type: "OVERTRADE_LIMIT",
+    label: "과매매 제한",
+    description: "하루 거래 횟수 제한",
+    min: 1,
+    max: 50,
+    unit: "회/일",
+    inputType: "number",
+    defaultValue: 10,
+  },
+];
+
+export function getDefaultRules(): RulesMap {
+  const map = {} as RulesMap;
+  for (const cfg of RULE_CONFIGS) {
+    map[cfg.type] = { enabled: false, value: cfg.defaultValue };
+  }
+  return map;
+}

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -45,4 +45,4 @@ function Badge({
   )
 }
 
-export { Badge, badgeVariants }
+export { Badge }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -61,4 +61,4 @@ function Button({
   )
 }
 
-export { Button, buttonVariants }
+export { Button }

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -88,4 +88,4 @@ function TabsContent({
   )
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,21 +1,15 @@
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-  useCallback,
-  type ReactNode,
-} from "react";
+import { createContext, useContext } from "react";
 import type { AuthUser } from "@/lib/types/user";
-import { logout as logoutApi } from "@/lib/api/auth-api";
-import { getUserProfile } from "@/lib/api/user-api";
 
-interface SocialLoginUser {
+// 컴포넌트(AuthProvider)는 같은 파일에 두지 않는다. 컴포넌트와 훅을 한 파일에서 함께 내보내면
+// 개발 중 파일을 고칠 때마다 화면이 통째로 새로고침되어 상태가 날아간다.
+
+export interface SocialLoginUser {
   userId: number;
   nickname: string;
 }
 
-interface AuthContextValue {
+export interface AuthContextValue {
   user: AuthUser | null;
   isAuthenticated: boolean;
   isAuthLoading: boolean;
@@ -24,65 +18,7 @@ interface AuthContextValue {
   updateUser: (updates: Partial<Pick<AuthUser, "nickname">>) => void;
 }
 
-const AuthContext = createContext<AuthContextValue | null>(null);
-
-export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<AuthUser | null>(null);
-  const [isAuthLoading, setIsAuthLoading] = useState(true);
-
-  // 새로고침하면 메모리의 인증 상태는 사라지지만 세션 쿠키는 남아 있다.
-  // 그 쿠키로 내 정보를 되물어 로그인 상태를 복구한다.
-  useEffect(() => {
-    let cancelled = false;
-
-    void (async () => {
-      try {
-        const profile = await getUserProfile();
-        if (!cancelled) setUser({ userId: profile.userId, nickname: profile.nickname });
-      } catch {
-        if (!cancelled) setUser(null);
-      } finally {
-        if (!cancelled) setIsAuthLoading(false);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const loginWithSocial = useCallback((result: SocialLoginUser) => {
-    setUser({ userId: result.userId, nickname: result.nickname });
-  }, []);
-
-  const logout = useCallback(async () => {
-    try {
-      await logoutApi();
-    } catch {
-      // 서버 세션 정리 실패와 무관하게 클라이언트 인증 상태는 반드시 비운다.
-    }
-    setUser(null);
-  }, []);
-
-  const updateUser = useCallback((updates: Partial<Pick<AuthUser, "nickname">>) => {
-    setUser((prev) => (prev ? { ...prev, ...updates } : prev));
-  }, []);
-
-  return (
-    <AuthContext.Provider
-      value={{
-        user,
-        isAuthenticated: user !== null,
-        isAuthLoading,
-        loginWithSocial,
-        logout,
-        updateUser,
-      }}
-    >
-      {children}
-    </AuthContext.Provider>
-  );
-}
+export const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function useAuth(): AuthContextValue {
   const ctx = useContext(AuthContext);

--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState, useCallback, type ReactNode } from "react";
+import type { AuthUser } from "@/lib/types/user";
+import { logout as logoutApi } from "@/lib/api/auth-api";
+import { getUserProfile } from "@/lib/api/user-api";
+import { AuthContext, type SocialLoginUser } from "./AuthContext";
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
+
+  // 새로고침하면 메모리의 인증 상태는 사라지지만 세션 쿠키는 남아 있다.
+  // 그 쿠키로 내 정보를 되물어 로그인 상태를 복구한다.
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const profile = await getUserProfile();
+        if (!cancelled) setUser({ userId: profile.userId, nickname: profile.nickname });
+      } catch {
+        if (!cancelled) setUser(null);
+      } finally {
+        if (!cancelled) setIsAuthLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const loginWithSocial = useCallback((result: SocialLoginUser) => {
+    setUser({ userId: result.userId, nickname: result.nickname });
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await logoutApi();
+    } catch {
+      // 서버 세션 정리 실패와 무관하게 클라이언트 인증 상태는 반드시 비운다.
+    }
+    setUser(null);
+  }, []);
+
+  const updateUser = useCallback((updates: Partial<Pick<AuthUser, "nickname">>) => {
+    setUser((prev) => (prev ? { ...prev, ...updates } : prev));
+  }, []);
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isAuthenticated: user !== null,
+        isAuthLoading,
+        loginWithSocial,
+        logout,
+        updateUser,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/frontend/src/contexts/RoundContext.tsx
+++ b/frontend/src/contexts/RoundContext.tsx
@@ -1,24 +1,11 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from "react";
+import { createContext, useContext } from "react";
 import type { InvestmentRound } from "@/lib/types/round";
-import { useAuth } from "@/contexts/AuthContext";
-import {
-  chargeEmergencyFunding as chargeEmergencyFundingApi,
-  createIdempotencyKey,
-  createRound as createRoundApi,
-  fetchActiveRound,
-  fetchTotalRoundCount,
-  type CreateRoundParams,
-} from "@/lib/api/round-api";
+import type { CreateRoundParams } from "@/lib/api/round-api";
 
-interface RoundContextValue {
+// 컴포넌트(RoundProvider)는 같은 파일에 두지 않는다. 컴포넌트와 훅을 한 파일에서 함께 내보내면
+// 개발 중 파일을 고칠 때마다 화면이 통째로 새로고침되어 상태가 날아간다.
+
+export interface RoundContextValue {
   activeRound: InvestmentRound | null;
   hasActiveRound: boolean;
   hasEverStartedRound: boolean;
@@ -30,133 +17,7 @@ interface RoundContextValue {
   getWalletId: (exchangeId: number) => number | null;
 }
 
-const RoundContext = createContext<RoundContextValue | null>(null);
-
-export function RoundProvider({ children }: { children: ReactNode }) {
-  const { user, isAuthLoading } = useAuth();
-  const [activeRound, setActiveRound] = useState<InvestmentRound | null>(null);
-  const [totalRoundCount, setTotalRoundCount] = useState(0);
-  const [isRoundLoading, setIsRoundLoading] = useState(true);
-
-  const refreshActiveRound = useCallback(async () => {
-    // 세션 복구가 끝나기 전에는 로그인 여부를 알 수 없으니 판단을 미룬다.
-    if (isAuthLoading) {
-      setIsRoundLoading(true);
-      return;
-    }
-
-    if (!user) {
-      setActiveRound(null);
-      setTotalRoundCount(0);
-      setIsRoundLoading(false);
-      return;
-    }
-
-    setIsRoundLoading(true);
-    try {
-      const [round, count] = await Promise.all([
-        fetchActiveRound(user.userId),
-        fetchTotalRoundCount(user.userId),
-      ]);
-      setActiveRound(round);
-      setTotalRoundCount(count);
-    } catch (error) {
-      console.error("Failed to load round state", error);
-      setActiveRound(null);
-      setTotalRoundCount(0);
-    } finally {
-      setIsRoundLoading(false);
-    }
-  }, [user, isAuthLoading]);
-
-  useEffect(() => {
-    void refreshActiveRound();
-  }, [refreshActiveRound]);
-
-  const createRound = useCallback(async (params: CreateRoundParams): Promise<InvestmentRound | null> => {
-    try {
-      const round = await createRoundApi(params);
-      setActiveRound(round);
-      setTotalRoundCount((prev) => Math.max(prev + 1, round.roundNumber));
-      return round;
-    } catch (error) {
-      console.error("Failed to create round", error);
-      return null;
-    }
-  }, []);
-
-  const clearRound = useCallback(() => {
-    setActiveRound(null);
-  }, []);
-
-  const getWalletId = useCallback(
-    (exchangeId: number): number | null => {
-      if (!activeRound) return null;
-      const wallet = activeRound.wallets.find((w) => w.exchangeId === exchangeId);
-      return wallet?.walletId ?? null;
-    },
-    [activeRound],
-  );
-
-  const chargeEmergencyFunding = useCallback(
-    async (amount: number, exchangeId: number): Promise<boolean> => {
-      if (!activeRound || !user) return false;
-      if (activeRound.status !== "ACTIVE") return false;
-      if (activeRound.emergencyChargeCount <= 0) return false;
-      if (amount <= 0 || amount > activeRound.emergencyFundingLimit) return false;
-
-      try {
-        const result = await chargeEmergencyFundingApi({
-          roundId: activeRound.roundId,
-          userId: user.userId,
-          exchangeId,
-          amount,
-          idempotencyKey: createIdempotencyKey(),
-        });
-
-        setActiveRound((prev) => {
-          if (!prev) return prev;
-          return {
-            ...prev,
-            emergencyChargeCount: result.remainingChargeCount,
-          };
-        });
-
-        return true;
-      } catch (error) {
-        console.error("Failed to charge emergency funding", error);
-        return false;
-      }
-    },
-    [activeRound, user],
-  );
-
-  const value = useMemo(
-    () => ({
-      activeRound,
-      hasActiveRound: activeRound !== null,
-      hasEverStartedRound: totalRoundCount > 0,
-      isRoundLoading,
-      createRound,
-      clearRound,
-      refreshActiveRound,
-      chargeEmergencyFunding,
-      getWalletId,
-    }),
-    [
-      activeRound,
-      totalRoundCount,
-      isRoundLoading,
-      createRound,
-      clearRound,
-      refreshActiveRound,
-      chargeEmergencyFunding,
-      getWalletId,
-    ],
-  );
-
-  return <RoundContext.Provider value={value}>{children}</RoundContext.Provider>;
-}
+export const RoundContext = createContext<RoundContextValue | null>(null);
 
 export function useRound(): RoundContextValue {
   const ctx = useContext(RoundContext);

--- a/frontend/src/contexts/RoundProvider.tsx
+++ b/frontend/src/contexts/RoundProvider.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import type { InvestmentRound } from "@/lib/types/round";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  chargeEmergencyFunding as chargeEmergencyFundingApi,
+  createIdempotencyKey,
+  createRound as createRoundApi,
+  fetchActiveRound,
+  fetchTotalRoundCount,
+  type CreateRoundParams,
+} from "@/lib/api/round-api";
+import { RoundContext } from "./RoundContext";
+
+export function RoundProvider({ children }: { children: ReactNode }) {
+  const { user, isAuthLoading } = useAuth();
+  const [activeRound, setActiveRound] = useState<InvestmentRound | null>(null);
+  const [totalRoundCount, setTotalRoundCount] = useState(0);
+  const [isRoundLoading, setIsRoundLoading] = useState(true);
+
+  const refreshActiveRound = useCallback(async () => {
+    // 세션 복구가 끝나기 전에는 로그인 여부를 알 수 없으니 판단을 미룬다.
+    if (isAuthLoading) {
+      setIsRoundLoading(true);
+      return;
+    }
+
+    if (!user) {
+      setActiveRound(null);
+      setTotalRoundCount(0);
+      setIsRoundLoading(false);
+      return;
+    }
+
+    setIsRoundLoading(true);
+    try {
+      const [round, count] = await Promise.all([
+        fetchActiveRound(user.userId),
+        fetchTotalRoundCount(user.userId),
+      ]);
+      setActiveRound(round);
+      setTotalRoundCount(count);
+    } catch (error) {
+      console.error("Failed to load round state", error);
+      setActiveRound(null);
+      setTotalRoundCount(0);
+    } finally {
+      setIsRoundLoading(false);
+    }
+  }, [user, isAuthLoading]);
+
+  useEffect(() => {
+    void refreshActiveRound();
+  }, [refreshActiveRound]);
+
+  const createRound = useCallback(async (params: CreateRoundParams): Promise<InvestmentRound | null> => {
+    try {
+      const round = await createRoundApi(params);
+      setActiveRound(round);
+      setTotalRoundCount((prev) => Math.max(prev + 1, round.roundNumber));
+      return round;
+    } catch (error) {
+      console.error("Failed to create round", error);
+      return null;
+    }
+  }, []);
+
+  const clearRound = useCallback(() => {
+    setActiveRound(null);
+  }, []);
+
+  const getWalletId = useCallback(
+    (exchangeId: number): number | null => {
+      if (!activeRound) return null;
+      const wallet = activeRound.wallets.find((w) => w.exchangeId === exchangeId);
+      return wallet?.walletId ?? null;
+    },
+    [activeRound],
+  );
+
+  const chargeEmergencyFunding = useCallback(
+    async (amount: number, exchangeId: number): Promise<boolean> => {
+      if (!activeRound || !user) return false;
+      if (activeRound.status !== "ACTIVE") return false;
+      if (activeRound.emergencyChargeCount <= 0) return false;
+      if (amount <= 0 || amount > activeRound.emergencyFundingLimit) return false;
+
+      try {
+        const result = await chargeEmergencyFundingApi({
+          roundId: activeRound.roundId,
+          userId: user.userId,
+          exchangeId,
+          amount,
+          idempotencyKey: createIdempotencyKey(),
+        });
+
+        setActiveRound((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            emergencyChargeCount: result.remainingChargeCount,
+          };
+        });
+
+        return true;
+      } catch (error) {
+        console.error("Failed to charge emergency funding", error);
+        return false;
+      }
+    },
+    [activeRound, user],
+  );
+
+  const value = useMemo(
+    () => ({
+      activeRound,
+      hasActiveRound: activeRound !== null,
+      hasEverStartedRound: totalRoundCount > 0,
+      isRoundLoading,
+      createRound,
+      clearRound,
+      refreshActiveRound,
+      chargeEmergencyFunding,
+      getWalletId,
+    }),
+    [
+      activeRound,
+      totalRoundCount,
+      isRoundLoading,
+      createRound,
+      clearRound,
+      refreshActiveRound,
+      chargeEmergencyFunding,
+      getWalletId,
+    ],
+  );
+
+  return <RoundContext.Provider value={value}>{children}</RoundContext.Provider>;
+}

--- a/frontend/src/hooks/useTickers.ts
+++ b/frontend/src/hooks/useTickers.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   connect,
   subscribeTickers,
@@ -12,15 +12,8 @@ interface UseTickersOptions {
   initialCoins: CoinData[];
 }
 
-interface MergeCacheEntry {
-  base: CoinData;
-  ticker: Ticker;
-  merged: CoinData;
-}
-
 export function useTickers({ exchangeId, initialCoins }: UseTickersOptions): CoinData[] {
   const [tickerMap, setTickerMap] = useState<Map<string, Ticker>>(new Map());
-  const mergeCache = useRef<Map<string, MergeCacheEntry>>(new Map());
 
   useEffect(() => {
     if (!isConnected()) {
@@ -56,36 +49,23 @@ export function useTickers({ exchangeId, initialCoins }: UseTickersOptions): Coi
     return () => {
       if (rafId !== null) cancelAnimationFrame(rafId);
       unsubscribe();
-      mergeCache.current.clear();
       setTickerMap(new Map());
     };
   }, [exchangeId]);
 
   return useMemo(() => {
-    if (tickerMap.size === 0) {
-      mergeCache.current.clear();
-      return initialCoins;
-    }
-    const cache = mergeCache.current;
+    if (tickerMap.size === 0) return initialCoins;
+
     return initialCoins.map((coin) => {
       const live = tickerMap.get(coin.symbol);
-      if (!live) {
-        cache.delete(coin.symbol);
-        return coin;
-      }
-      const cached = cache.get(coin.symbol);
-      if (cached && cached.base === coin && cached.ticker === live) {
-        return cached.merged;
-      }
-      const merged: CoinData = {
+      if (!live) return coin;
+      return {
         ...coin,
         currentPrice: live.price,
         changeRate: live.changeRate,
         volume: live.quoteTurnover,
         tickedAt: live.timestamp,
       };
-      cache.set(coin.symbol, { base: coin, ticker: live, merged });
-      return merged;
     });
   }, [initialCoins, tickerMap]);
 }

--- a/frontend/src/hooks/useUserEvents.ts
+++ b/frontend/src/hooks/useUserEvents.ts
@@ -12,8 +12,12 @@ interface UseUserEventsOptions {
 }
 
 export function useUserEvents({ userId, onOrderFilled }: UseUserEventsOptions): void {
+  // 콜백이 바뀔 때마다 구독을 다시 맺지 않으려고 ref 로 들고 있는다.
+  // 갱신은 렌더가 끝난 뒤에 한다. 렌더 도중 ref 를 건드리면 렌더가 순수하지 않게 된다.
   const onOrderFilledRef = useRef(onOrderFilled);
-  onOrderFilledRef.current = onOrderFilled;
+  useEffect(() => {
+    onOrderFilledRef.current = onOrderFilled;
+  }, [onOrderFilled]);
 
   useEffect(() => {
     if (!userId) return;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,8 +1,8 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
-import { AuthProvider } from './contexts/AuthContext'
-import { RoundProvider } from './contexts/RoundContext'
+import { AuthProvider } from './contexts/AuthProvider'
+import { RoundProvider } from './contexts/RoundProvider'
 import './index.css'
 import App from './App.tsx'
 

--- a/frontend/src/pages/RoundCreatePage.tsx
+++ b/frontend/src/pages/RoundCreatePage.tsx
@@ -5,13 +5,13 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useRound } from "@/contexts/RoundContext";
 import { RoundCreateHeader } from "@/components/round/RoundCreateHeader";
 import { SeedMoneyCard } from "@/components/round/SeedMoneyCard";
+import { InvestmentRulesSection } from "@/components/round/InvestmentRulesSection";
 import {
-  InvestmentRulesSection,
   getDefaultRules,
   type RulesMap,
   type RuleState,
   type SelectableRuleType,
-} from "@/components/round/InvestmentRulesSection";
+} from "@/components/round/rules";
 
 export function RoundCreatePage() {
   const { user } = useAuth();


### PR DESCRIPTION
## Summary

React 규칙을 어기던 세 부류를 정리한다. 동작이 바뀌는 곳은 훅 의존성 누락으로 갱신되지 않던 복기 차트 눈금뿐이다.

- **Fast Refresh** — Provider 컴포넌트와 훅·상수를 파일로 분리한다.
- **렌더 부수효과** — 렌더 도중 ref·변수를 바꾸던 코드를 걷어낸다.
- **훅 의존성** — 빠진 의존성을 채운다.

---

## 주요 변경 사항

### 컨텍스트 분리

- `AuthProvider.tsx`(신규) — `AuthContext.tsx` 에 있던 Provider 를 옮긴다. 세션 복구·`isAuthLoading` 로직은 그대로 따라간다.
- `RoundProvider.tsx`(신규) — `RoundContext.tsx` 에 있던 Provider 를 옮긴다. `totalRoundCount`·`hasEverStartedRound` 는 그대로 따라간다.
- `components/round/rules.ts`(신규) — `InvestmentRulesSection` 에 있던 `SelectableRuleType`·`RulesMap`·`RULE_CONFIGS` 를 옮긴다.
- `AuthContext.tsx`·`RoundContext.tsx` — 컨텍스트 정의와 소비 훅(`useAuth`/`useRound`)만 남긴다. 소비처 import 는 그대로 유지된다.
- `main.tsx` — Provider import 경로를 새 파일로 바꾼다.
- `ui/badge.tsx`, `ui/button.tsx`, `ui/tabs.tsx` — variants 상수를 컴포넌트 export 와 분리한다.

### 렌더 부수효과 제거

- `useTickers` — 렌더 중 갱신하던 병합 캐시 ref 를 없애고 순수 계산으로 바꾼다(체결 시각 `tickedAt` 전달은 그대로 유지).
- `DonutChart` — 렌더 중 누적 변수를 바꾸던 조각 계산을 정리한다.
- `useUserEvents` — 동일한 형태의 ref 갱신을 정리한다.

### 훅 의존성

- `RegretChart` — 의존성 배열에 `totalDays` 를 추가한다. 기간을 바꾸면 x축 눈금이 따라 갱신된다(동작 변화).
- `CandleChartPanel` — 누락된 의존성을 채운다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 소비 훅(`useAuth`/`useRound`)은 기존 파일에 남긴다 | 훅을 함께 옮기면 소비처 수십 곳의 import 를 모두 고쳐야 하는데, Fast Refresh 문제는 '컴포넌트와 비컴포넌트가 한 파일'인 것이 원인이라 Provider 만 떼면 해결된다 |
| 이 PR 은 기능을 바꾸지 않는다 | 세션 복구·라운드 개수·설정 가능 원칙 축소는 각각 앞선 PR 에서 이미 들어왔고, 여기서는 파일 위치만 옮긴다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 체결 시각(`tickedAt`) 전달 경로가 유지되어 시세 반짝임이 계속 동작함
- [x] 복기 차트에서 기간을 바꾸면 x축 눈금이 갱신됨

Closes #249