### PR TITLE
[#251] 위반이 없는 라운드의 복기 리포트가 생성되지 않던 문제 수정

### DIFF
--- a/api/docs/regretanalysis/regret-report-batch.md
+++ b/api/docs/regretanalysis/regret-report-batch.md
@@ -21,14 +21,22 @@ SnapshotJob 완료 직후
 ## 처리 절차
 
 1. ACTIVE 라운드의 거래소별로:
+   - 최신 스냅샷을 조회한다. 스냅샷이 없으면 해당 건은 생성하지 않고 건너뛴다
    - 투자 원칙, 위반 기록, 주문 체결 이력을 조회한다
    - 위반분 우선 매칭으로 `loss_amount`를 계산한다 ([business-rules.md](business-rules.md) 참조)
    - 규칙별 시나리오를 생성한다 (`impactGap` 계산)
    - 최신 스냅샷에서 `missedProfit`을 계산한다
 2. `REGRET_REPORT` + `RULE_IMPACT` + `VIOLATION_DETAIL`를 upsert한다
 
+## 생성 조건
+
+리포트 생성 여부는 위반 유무가 아니라 **스냅샷 유무**로 결정한다.
+
+- 위반이 0건이어도 스냅샷이 있으면 리포트를 생성한다. 이때 `totalViolations`, `missedProfit`은 0이고 `ruleFollowedProfitRate`는 `actualProfitRate`와 같으며, `RULE_IMPACT`와 `VIOLATION_DETAIL`은 빈 목록이다. 원칙을 모두 준수한 사용자도 복기 화면에서 자산 추이와 BTC 벤치마크를 확인할 수 있어야 하기 때문이다
+- 스냅샷이 없으면 리포트를 생성하지 않는다. 자산 추이를 그릴 근거가 없기 때문이다
+
 ## 갱신 정책
 
 - ACTIVE 라운드: 매일 갱신 (새로운 위반이 추가될 수 있으므로)
 - ENDED 라운드: 종료 시 1회 확정 생성 후 변하지 않음
-- 리포트가 없으면 (라운드 시작 당일) API 조회 시 REPORT_NOT_FOUND 에러를 반환한다. 배치 실행 후 조회 가능하다
+- 리포트가 없으면 (라운드 시작 당일, 스냅샷 미생성) API 조회 시 REPORT_NOT_FOUND 에러를 반환한다. 배치 실행 후 조회 가능하다

--- a/api/src/main/java/ksh/tryptobackend/regretanalysis/adapter/out/acl/RegretAnalysisAclPortfolioQueryAdapter.java
+++ b/api/src/main/java/ksh/tryptobackend/regretanalysis/adapter/out/acl/RegretAnalysisAclPortfolioQueryAdapter.java
@@ -1,8 +1,7 @@
 package ksh.tryptobackend.regretanalysis.adapter.out.acl;
 
 import java.util.List;
-import ksh.tryptobackend.common.exception.CustomException;
-import ksh.tryptobackend.common.exception.ErrorCode;
+import java.util.Optional;
 import ksh.tryptobackend.portfolio.application.port.in.FindSnapshotsUseCase;
 import ksh.tryptobackend.portfolio.application.port.in.dto.result.SnapshotInfoResult;
 import ksh.tryptobackend.regretanalysis.application.port.out.PortfolioQueryPort;
@@ -26,11 +25,10 @@ public class RegretAnalysisAclPortfolioQueryAdapter implements PortfolioQueryPor
     }
 
     @Override
-    public AssetSnapshot getLatestSnapshot(Long roundId, Long exchangeId) {
+    public Optional<AssetSnapshot> findLatestSnapshot(Long roundId, Long exchangeId) {
         return findSnapshotsUseCase
                 .findLatestByRoundIdAndExchangeId(roundId, exchangeId)
-                .map(this::toAssetSnapshot)
-                .orElseThrow(() -> new CustomException(ErrorCode.SNAPSHOT_NOT_FOUND));
+                .map(this::toAssetSnapshot);
     }
 
     private AssetSnapshot toAssetSnapshot(SnapshotInfoResult result) {

--- a/api/src/main/java/ksh/tryptobackend/regretanalysis/application/port/out/PortfolioQueryPort.java
+++ b/api/src/main/java/ksh/tryptobackend/regretanalysis/application/port/out/PortfolioQueryPort.java
@@ -1,5 +1,6 @@
 package ksh.tryptobackend.regretanalysis.application.port.out;
 
+import java.util.Optional;
 import ksh.tryptobackend.regretanalysis.domain.model.AssetSnapshot;
 import ksh.tryptobackend.regretanalysis.domain.vo.AssetTimeline;
 
@@ -7,5 +8,5 @@ public interface PortfolioQueryPort {
 
     AssetTimeline getAssetTimeline(Long roundId, Long exchangeId);
 
-    AssetSnapshot getLatestSnapshot(Long roundId, Long exchangeId);
+    Optional<AssetSnapshot> findLatestSnapshot(Long roundId, Long exchangeId);
 }

--- a/api/src/main/java/ksh/tryptobackend/regretanalysis/application/service/GenerateRegretReportService.java
+++ b/api/src/main/java/ksh/tryptobackend/regretanalysis/application/service/GenerateRegretReportService.java
@@ -29,18 +29,19 @@ public class GenerateRegretReportService implements GenerateRegretReportUseCase 
 
     @Override
     public Optional<RegretReport> generateReport(GenerateRegretReportCommand command) {
+        return portfolioQueryPort
+                .findLatestSnapshot(command.roundId(), command.exchangeId())
+                .map(snapshot -> generateReport(command, snapshot));
+    }
+
+    private RegretReport generateReport(GenerateRegretReportCommand command, AssetSnapshot snapshot) {
         ViolatedOrders violations =
                 tradingQueryPort.findViolatedOrders(command.roundId(), command.exchangeId(), command.walletId());
-        if (violations.isEmpty()) {
-            return Optional.empty();
-        }
-
         CurrentPrices currentPrices = marketDataQueryPort.findCurrentPrices(violations.exchangeCoinIds());
         List<ViolationDetail> details = violations.calculateDetails(currentPrices);
-        AssetSnapshot snapshot = portfolioQueryPort.getLatestSnapshot(command.roundId(), command.exchangeId());
         List<RuleImpact> impacts = new ViolationDetails(details).toRuleImpacts(snapshot.getTotalInvestment());
 
-        return Optional.of(RegretReport.generate(
+        return RegretReport.generate(
                 command.userId(),
                 command.roundId(),
                 command.exchangeId(),
@@ -48,6 +49,6 @@ public class GenerateRegretReportService implements GenerateRegretReportUseCase 
                 impacts,
                 details,
                 command.startedAt().toLocalDate(),
-                clock));
+                clock);
     }
 }

--- a/api/src/test/java/ksh/tryptobackend/regretanalysis/application/service/GenerateRegretReportServiceTest.java
+++ b/api/src/test/java/ksh/tryptobackend/regretanalysis/application/service/GenerateRegretReportServiceTest.java
@@ -1,0 +1,106 @@
+package ksh.tryptobackend.regretanalysis.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import ksh.tryptobackend.regretanalysis.application.port.in.dto.command.GenerateRegretReportCommand;
+import ksh.tryptobackend.regretanalysis.application.port.out.MarketDataQueryPort;
+import ksh.tryptobackend.regretanalysis.application.port.out.PortfolioQueryPort;
+import ksh.tryptobackend.regretanalysis.application.port.out.TradingQueryPort;
+import ksh.tryptobackend.regretanalysis.domain.model.AssetSnapshot;
+import ksh.tryptobackend.regretanalysis.domain.model.RegretReport;
+import ksh.tryptobackend.regretanalysis.domain.model.ViolatedOrders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GenerateRegretReportServiceTest {
+
+    private static final Long ROUND_ID = 1L;
+    private static final Long USER_ID = 10L;
+    private static final Long EXCHANGE_ID = 100L;
+    private static final Long WALLET_ID = 1000L;
+
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-07-14T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+    private static final GenerateRegretReportCommand COMMAND = new GenerateRegretReportCommand(
+            ROUND_ID, USER_ID, EXCHANGE_ID, WALLET_ID, LocalDateTime.of(2026, 7, 1, 9, 0));
+
+    private TradingQueryPort tradingQueryPort;
+    private MarketDataQueryPort marketDataQueryPort;
+    private PortfolioQueryPort portfolioQueryPort;
+    private GenerateRegretReportService generateRegretReportService;
+
+    @BeforeEach
+    void setUp() {
+        tradingQueryPort = mock(TradingQueryPort.class);
+        marketDataQueryPort = mock(MarketDataQueryPort.class);
+        portfolioQueryPort = mock(PortfolioQueryPort.class);
+        generateRegretReportService =
+                new GenerateRegretReportService(tradingQueryPort, marketDataQueryPort, portfolioQueryPort, FIXED_CLOCK);
+    }
+
+    @Test
+    @DisplayName("위반이 없어도 스냅샷이 있으면 위반 0건짜리 리포트를 생성한다")
+    void generateReport_noViolations_returnsEmptyReport() {
+        when(portfolioQueryPort.findLatestSnapshot(ROUND_ID, EXCHANGE_ID)).thenReturn(Optional.of(snapshot()));
+        when(tradingQueryPort.findViolatedOrders(ROUND_ID, EXCHANGE_ID, WALLET_ID))
+                .thenReturn(new ViolatedOrders(List.of()));
+
+        Optional<RegretReport> report = generateRegretReportService.generateReport(COMMAND);
+
+        assertThat(report).isPresent();
+        assertThat(report.get().getTotalViolations()).isZero();
+        assertThat(report.get().getMissedProfit()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(report.get().getRuleImpacts()).isEmpty();
+        assertThat(report.get().getViolationDetails().toList()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("위반이 없으면 원칙 준수 수익률은 실제 수익률과 같다")
+    void generateReport_noViolations_ruleFollowedRateEqualsActualRate() {
+        when(portfolioQueryPort.findLatestSnapshot(ROUND_ID, EXCHANGE_ID)).thenReturn(Optional.of(snapshot()));
+        when(tradingQueryPort.findViolatedOrders(ROUND_ID, EXCHANGE_ID, WALLET_ID))
+                .thenReturn(new ViolatedOrders(List.of()));
+
+        RegretReport report =
+                generateRegretReportService.generateReport(COMMAND).orElseThrow();
+
+        assertThat(report.getRuleFollowedProfitRate()).isEqualByComparingTo(report.getActualProfitRate());
+    }
+
+    @Test
+    @DisplayName("스냅샷이 없으면 리포트를 생성하지 않는다")
+    void generateReport_noSnapshot_returnsEmpty() {
+        when(portfolioQueryPort.findLatestSnapshot(ROUND_ID, EXCHANGE_ID)).thenReturn(Optional.empty());
+
+        Optional<RegretReport> report = generateRegretReportService.generateReport(COMMAND);
+
+        assertThat(report).isEmpty();
+        verify(tradingQueryPort, never()).findViolatedOrders(any(), any(), any());
+    }
+
+    private AssetSnapshot snapshot() {
+        return AssetSnapshot.reconstitute(
+                1L,
+                ROUND_ID,
+                EXCHANGE_ID,
+                new BigDecimal("5200000"),
+                new BigDecimal("5000000"),
+                new BigDecimal("4.00"),
+                LocalDate.of(2026, 7, 14));
+    }
+}


### PR DESCRIPTION
## Summary

복기 리포트 배치가 '원칙 위반이 있을 때'만 리포트를 만들어, 원칙을 모두 지킨 사용자는 복기 리포트 자체가 없던 문제를 고친다. 생성 조건을 '자산 스냅샷 유무'로 바꿔, 거래를 한 사용자는 위반이 없어도 리포트를 갖는다.

---

## 핵심 흐름

```
복기 리포트 배치
  └─ 라운드별로
       ├─ (기존) 위반 목록이 비어 있으면 → 생성 건너뜀   ← 결함
       └─ (변경) 자산 스냅샷이 있으면    → 리포트 생성
                 스냅샷이 없으면(거래 없음) → 생성 안 함
```

---

## 주요 변경 사항

### 애플리케이션 계층

- `GenerateRegretReportService` — 생성 조건을 위반 유무에서 스냅샷 유무로 바꾼다.
- `PortfolioQueryPort` — `getLatestSnapshot` → `findLatestSnapshot` 으로 바꿔 스냅샷 부재를 `Optional` 로 표현한다(부재는 오류가 아니라 정상 상태다).

### 어댑터 계층

- `RegretAnalysisAclPortfolioQueryAdapter` — 바뀐 포트 시그니처를 구현한다.

### 문서

- `api/docs/regretanalysis/regret-report-batch.md` — 리포트 생성 조건을 명시한다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 생성 조건을 '스냅샷 유무'로 | 복기의 목적은 위반을 세는 것이 아니라 투자를 돌아보는 것이다. 거래가 있었다면(스냅샷이 있다면) 위반이 0건이어도 볼 것이 있다 |
| 스냅샷 부재를 예외가 아닌 `Optional` 로 | 거래를 한 번도 하지 않은 라운드는 오류가 아니라 정상 상태다 |

---

## Test Plan

### 도메인 단위 테스트

- [x] 위반이 0건이어도 스냅샷이 있으면 리포트를 생성한다
- [x] 스냅샷이 없으면 리포트를 생성하지 않는다
- [x] `GenerateRegretReportServiceTest` 통과

Closes #251