### PR TITLE
[#255] 투자 원칙을 카드 어디를 눌러도 켜고 끌 수 있게 변경

### DIFF
--- a/frontend/src/components/round/InvestmentRuleCard.tsx
+++ b/frontend/src/components/round/InvestmentRuleCard.tsx
@@ -1,4 +1,3 @@
-import { Switch } from "@/components/ui/switch";
 import { Slider } from "@/components/ui/slider";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -31,30 +30,40 @@ export function InvestmentRuleCard({
   return (
     <div
       className={cn(
-        "rounded-xl border px-4 py-3.5 transition-all duration-200",
-        enabled ? "border-border bg-card" : "border-transparent bg-secondary/30",
+        "rounded-xl border transition-all duration-200",
+        enabled ? "border-primary/50 bg-card" : "border-transparent bg-secondary/30",
       )}
     >
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <p className={cn(
-            "text-sm font-bold transition-colors",
-            !enabled && "text-muted-foreground",
-          )}>
-            {label}
-          </p>
-          <p className={cn(
-            "text-[11px] transition-colors",
-            enabled ? "text-muted-foreground" : "text-muted-foreground/60",
-          )}>
-            {description}
-          </p>
-        </div>
-        <Switch checked={enabled} onCheckedChange={onToggle} />
+      <div
+        role="switch"
+        aria-checked={enabled}
+        aria-label={label}
+        tabIndex={0}
+        onClick={() => onToggle(!enabled)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle(!enabled);
+          }
+        }}
+        className="cursor-pointer select-none rounded-xl px-4 py-3.5 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+      >
+        <p className={cn(
+          "text-sm font-bold transition-colors",
+          !enabled && "text-muted-foreground",
+        )}>
+          {label}
+        </p>
+        <p className={cn(
+          "text-[11px] transition-colors",
+          enabled ? "text-muted-foreground" : "text-muted-foreground/60",
+        )}>
+          {description}
+        </p>
       </div>
 
       {enabled && (
-        <div className="mt-3 flex items-center gap-3">
+        <div className="flex items-center gap-3 px-4 pb-3.5">
           {inputType === "slider" ? (
             <>
               <Slider


### PR DESCRIPTION
## Summary

오른쪽 끝 스위치로만 조작할 수 있던 투자 원칙 카드를, 카드 어디를 눌러도 켜고 끌 수 있게 바꾼다.

---

## 주요 변경 사항

### 화면

- `InvestmentRuleCard` — 별도 `Switch` 컴포넌트를 없애고 카드 본체에 `role="switch"`·`aria-checked`·`tabIndex`·클릭/키보드 핸들러를 부여한다. 스위치 모양은 시각적 표시로만 남는다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 카드에 `role="switch"` 를 부여한다 | 클릭 영역만 넓히고 시맨틱을 두지 않으면 키보드·스크린 리더 사용자가 원칙을 조작할 수 없게 된다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 카드 본문을 눌러 원칙이 켜지고 꺼짐
- [x] 키보드(Tab → Space/Enter)로 조작 가능

Closes #255