### PR TITLE
[#257] 소셜 인가를 팝업으로 처리해 로그인 후 뒤로 가기 갇힘 수정

### DIFF
--- a/frontend/src/hooks/useSocialLogin.ts
+++ b/frontend/src/hooks/useSocialLogin.ts
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { socialLogin } from "@/lib/api/auth-api";
+import { isApiClientError } from "@/lib/api/types";
+import {
+  beginSocialLogin,
+  clearSocialSecrets,
+  openSocialPopup,
+  providerLabel,
+  sendSocialPopup,
+  subscribeSocialCallback,
+  verifySocialCallback,
+  type SocialCallbackMessage,
+  type SocialProvider,
+} from "@/lib/auth/social";
+
+/** 사용자가 팝업을 그냥 닫았는지 확인하는 주기. 닫힘은 이벤트로 알 수 없어 들여다보는 수밖에 없다. */
+const POPUP_POLL_INTERVAL_MS = 500;
+
+export interface SocialLogin {
+  /** 인가가 진행 중인 제공자. null 이면 진행 중이 아니다. */
+  pendingProvider: SocialProvider | null;
+  error: string;
+  start: (provider: SocialProvider) => void;
+}
+
+/**
+ * 소셜 로그인 진행 상태.
+ *
+ * 인가는 팝업에 맡기고 주 창은 제자리에 남는다. 팝업이 code 를 넘겨주면 주 창이 state 를 대조하고
+ * 백엔드와 교환한다. 로그인에 성공하면 인증 상태가 바뀌므로 화면 이동은 PublicRoute 가 맡는다.
+ * 팝업이 차단되면 주 창을 통째로 제공자에게 보내는 예전 방식으로 물러선다.
+ */
+export function useSocialLogin(): SocialLogin {
+  const { loginWithSocial } = useAuth();
+  const [pendingProvider, setPendingProvider] = useState<SocialProvider | null>(null);
+  const [error, setError] = useState("");
+  const popupRef = useRef<Window | null>(null);
+  // 팝업이 결과를 넘기고 닫힌 것인지, 사용자가 그냥 닫은 것인지 가른다.
+  const answeredRef = useRef(false);
+
+  const finish = useCallback(
+    async (message: SocialCallbackMessage) => {
+      answeredRef.current = true;
+      popupRef.current?.close();
+      popupRef.current = null;
+
+      const result = verifySocialCallback(message);
+      clearSocialSecrets();
+
+      if (!result.ok) {
+        setError(result.message);
+        setPendingProvider(null);
+        return;
+      }
+
+      try {
+        const login = await socialLogin(result.provider, result.code, result.verifier);
+        // pendingProvider 는 비우지 않는다. 인증 상태가 바뀌면 곧 이 화면이 사라지므로,
+        // 그 사이에 버튼이 다시 눌리지 않게 잠가둔 채로 둔다.
+        loginWithSocial({ userId: login.userId, nickname: login.nickname });
+      } catch (e: unknown) {
+        setError(isApiClientError(e) ? e.message : "로그인 처리 중 오류가 발생했습니다.");
+        setPendingProvider(null);
+      }
+    },
+    [loginWithSocial],
+  );
+
+  useEffect(() => subscribeSocialCallback((message) => void finish(message)), [finish]);
+
+  // 사용자가 인가를 마치지 않고 팝업을 닫으면 버튼을 되돌려 다시 시도할 수 있게 한다.
+  useEffect(() => {
+    const popup = popupRef.current;
+    if (!pendingProvider || !popup) return;
+
+    const timer = window.setInterval(() => {
+      if (!popup.closed) return;
+      window.clearInterval(timer);
+      if (answeredRef.current) return;
+
+      popupRef.current = null;
+      setPendingProvider(null);
+    }, POPUP_POLL_INTERVAL_MS);
+
+    return () => window.clearInterval(timer);
+  }, [pendingProvider]);
+
+  // 로그인을 마치거나 화면을 떠날 때 열어둔 팝업을 남기지 않는다.
+  useEffect(() => () => popupRef.current?.close(), []);
+
+  const start = useCallback((provider: SocialProvider) => {
+    setError("");
+    answeredRef.current = false;
+
+    const popup = openSocialPopup();
+    setPendingProvider(provider);
+
+    if (!popup) {
+      // 팝업이 차단됐다. 주 창을 통째로 보낸다. 성공하면 제공자로 떠나므로 이 아래는 실행되지 않는다.
+      beginSocialLogin(provider).catch(() => {
+        setError(`${providerLabel(provider)} 로그인 설정이 완료되지 않았습니다.`);
+        setPendingProvider(null);
+      });
+      return;
+    }
+
+    popupRef.current = popup;
+    sendSocialPopup(popup, provider).catch(() => {
+      popup.close();
+      popupRef.current = null;
+      setError(`${providerLabel(provider)} 로그인 설정이 완료되지 않았습니다.`);
+      setPendingProvider(null);
+    });
+  }, []);
+
+  return { pendingProvider, error, start };
+}

--- a/frontend/src/lib/auth/social.ts
+++ b/frontend/src/lib/auth/social.ts
@@ -1,15 +1,28 @@
 import { generateCodeChallenge, generateCodeVerifier, generateState } from "./pkce";
 
 /**
- * 소셜 인가 시작. PKCE 값과 state 를 sessionStorage 에 저장한 뒤 제공자 인가 URL 로 브라우저를 보낸다.
- * 콜백 페이지에서 state 를 대조하고 code_verifier 를 백엔드로 넘긴다.
- * 제공자별로 다른 것은 인가 URL·클라이언트 ID·추가 파라미터뿐이고 절차는 동일하다.
+ * 소셜 인가 시작. PKCE 값과 state 를 sessionStorage 에 저장한 뒤 제공자 인가 화면을 띄운다.
+ *
+ * 인가 화면은 팝업으로 띄우는 것이 기본이다. 주 창을 통째로 제공자에게 보내면 제공자의 로그인·동의
+ * 페이지가 주 창의 히스토리에 쌓이는데, 다른 출처가 남긴 히스토리 항목은 우리가 지울 수 없다.
+ * 로그인을 마친 뒤 뒤로 가기를 누르면 카카오 화면이 나오는 이유가 이것이다. 팝업에서 왕복하면
+ * 주 창의 문서와 히스토리는 손대지 않은 채로 남는다.
+ *
+ * 팝업이 차단되면 주 창을 보내는 방식(beginSocialLogin)으로 물러선다.
  */
 
 export type SocialProvider = "kakao" | "google";
 
 export const OAUTH_VERIFIER_KEY = "oauth_code_verifier";
 export const OAUTH_STATE_KEY = "oauth_state";
+
+/** 콜백 페이지가 팝업 안인지 판별하는 표시. 팝업을 열기 직전에 남긴다. */
+export const OAUTH_POPUP_KEY = "oauth_popup";
+
+const OAUTH_CHANNEL_NAME = "trypto-social-callback";
+const POPUP_NAME = "trypto-social-login";
+const POPUP_WIDTH = 480;
+const POPUP_HEIGHT = 640;
 
 interface ProviderConfig {
   /** 사용자에게 보여줄 이름 */
@@ -41,6 +54,18 @@ const PROVIDER_CONFIGS: Record<SocialProvider, ProviderConfig> = {
   },
 };
 
+/** 팝업이 주 창에 넘기는 인가 결과. 검증은 하지 않고 받아온 그대로 넘긴다. */
+export interface SocialCallbackMessage {
+  provider: SocialProvider;
+  code: string | null;
+  state: string | null;
+  error: string | null;
+}
+
+export type SocialCallbackResult =
+  | { ok: true; provider: SocialProvider; code: string; verifier: string }
+  | { ok: false; message: string };
+
 export function isSocialProvider(value: string | undefined): value is SocialProvider {
   return value === "kakao" || value === "google";
 }
@@ -55,7 +80,13 @@ export function isSocialConfigured(provider: SocialProvider): boolean {
   return Boolean(config.clientId && config.redirectUri);
 }
 
-export async function beginSocialLogin(provider: SocialProvider): Promise<void> {
+function isSocialCallbackMessage(value: unknown): value is SocialCallbackMessage {
+  if (typeof value !== "object" || value === null) return false;
+  const message = value as Record<string, unknown>;
+  return typeof message.provider === "string" && isSocialProvider(message.provider);
+}
+
+async function buildAuthUrl(provider: SocialProvider): Promise<string> {
   const config = PROVIDER_CONFIGS[provider];
   if (!config.clientId || !config.redirectUri) {
     throw new Error(`${config.label} 로그인 환경변수(클라이언트 ID / redirect URI)가 설정되지 않았습니다.`);
@@ -65,6 +96,7 @@ export async function beginSocialLogin(provider: SocialProvider): Promise<void> 
   const challenge = await generateCodeChallenge(verifier);
   const state = generateState();
 
+  // 팝업이 아니라 주 창에 저장한다. 팝업은 결과를 전달만 하고, 검증과 교환은 주 창이 한다.
   sessionStorage.setItem(OAUTH_VERIFIER_KEY, verifier);
   sessionStorage.setItem(OAUTH_STATE_KEY, state);
 
@@ -78,5 +110,109 @@ export async function beginSocialLogin(provider: SocialProvider): Promise<void> 
     ...config.extraParams,
   });
 
-  window.location.href = `${config.authUrl}?${params.toString()}`;
+  return `${config.authUrl}?${params.toString()}`;
+}
+
+/**
+ * 빈 팝업을 연다. 차단되면 null.
+ *
+ * 인가 URL 을 만들려면 PKCE 해시 계산을 기다려야 하는데, 그 사이에 창을 열면 브라우저가 클릭과
+ * 무관한 팝업으로 보고 막는다. 그래서 클릭 처리 안에서 빈 창을 먼저 열고 주소는 나중에 넣는다.
+ */
+export function openSocialPopup(): Window | null {
+  const left = window.screenX + Math.max(0, (window.outerWidth - POPUP_WIDTH) / 2);
+  const top = window.screenY + Math.max(0, (window.outerHeight - POPUP_HEIGHT) / 2);
+
+  // 세션 저장소는 창이 열리는 시점에 복사되므로 표시를 먼저 남긴다.
+  // 주 창에 남겨두면 팝업이 막혀 주 창이 콜백을 받을 때 자기를 팝업으로 착각하므로 곧바로 지운다.
+  sessionStorage.setItem(OAUTH_POPUP_KEY, "1");
+  const popup = window.open(
+    "about:blank",
+    POPUP_NAME,
+    `popup=yes,width=${POPUP_WIDTH},height=${POPUP_HEIGHT},left=${Math.round(left)},top=${Math.round(top)}`,
+  );
+  sessionStorage.removeItem(OAUTH_POPUP_KEY);
+
+  return popup;
+}
+
+/** 열어둔 팝업을 제공자 인가 화면으로 보낸다. */
+export async function sendSocialPopup(popup: Window, provider: SocialProvider): Promise<void> {
+  popup.location.href = await buildAuthUrl(provider);
+}
+
+/** 팝업이 막혔을 때의 폴백. 주 창을 통째로 제공자에게 보낸다. */
+export async function beginSocialLogin(provider: SocialProvider): Promise<void> {
+  window.location.replace(await buildAuthUrl(provider));
+}
+
+/**
+ * 팝업이 받아온 인가 결과를 주 창으로 보낸다.
+ *
+ * opener 로 직접 보내지 않는다. 제공자 페이지가 COOP 헤더로 창 사이의 연결을 끊어버리면
+ * 팝업에서 opener 가 null 이 되기 때문이다. BroadcastChannel 은 창 관계와 무관하게
+ * 같은 출처끼리만 오가므로, 연결이 끊겨도 결과가 전달되고 다른 출처는 들을 수 없다.
+ */
+export function publishSocialCallback(message: SocialCallbackMessage): void {
+  const channel = new BroadcastChannel(OAUTH_CHANNEL_NAME);
+  channel.postMessage(message);
+  channel.close();
+}
+
+/** 주 창에서 팝업이 보내는 인가 결과를 듣는다. 반환한 함수를 부르면 구독을 끊는다. */
+export function subscribeSocialCallback(
+  listener: (message: SocialCallbackMessage) => void,
+): () => void {
+  const channel = new BroadcastChannel(OAUTH_CHANNEL_NAME);
+  channel.onmessage = (event: MessageEvent<unknown>) => {
+    if (isSocialCallbackMessage(event.data)) listener(event.data);
+  };
+  return () => channel.close();
+}
+
+/** 콜백 URL 의 질의 문자열에서 인가 결과를 읽는다. */
+export function readSocialCallbackParams(
+  provider: SocialProvider,
+  search: string,
+): SocialCallbackMessage {
+  const params = new URLSearchParams(search);
+  return {
+    provider,
+    code: params.get("code"),
+    state: params.get("state"),
+    error: params.get("error"),
+  };
+}
+
+/**
+ * 되돌아온 인가 결과를 저장해둔 state·verifier 와 대조한다.
+ * 읽기만 하므로 렌더 중에 불러도 안전하다. 쓴 값을 지우는 것은 clearSocialSecrets 로 따로 한다.
+ */
+export function verifySocialCallback(message: SocialCallbackMessage): SocialCallbackResult {
+  const savedState = sessionStorage.getItem(OAUTH_STATE_KEY);
+  const verifier = sessionStorage.getItem(OAUTH_VERIFIER_KEY);
+
+  if (message.error) {
+    return {
+      ok: false,
+      message: `${providerLabel(message.provider)} 로그인이 취소되었거나 실패했습니다.`,
+    };
+  }
+  if (!message.code || !message.state) {
+    return { ok: false, message: "인가 정보가 올바르지 않습니다." };
+  }
+  if (!savedState || savedState !== message.state) {
+    return { ok: false, message: "보안 검증(state)에 실패했습니다. 다시 시도해주세요." };
+  }
+  if (!verifier) {
+    return { ok: false, message: "로그인 검증값이 없습니다. 다시 시도해주세요." };
+  }
+
+  return { ok: true, provider: message.provider, code: message.code, verifier };
+}
+
+/** 한 번 쓴 state·verifier 는 성공이든 실패든 남겨두지 않는다. */
+export function clearSocialSecrets(): void {
+  sessionStorage.removeItem(OAUTH_STATE_KEY);
+  sessionStorage.removeItem(OAUTH_VERIFIER_KEY);
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,32 +1,27 @@
-import { useState } from "react";
+import { useEffect } from "react";
 import { Activity, MessageCircle } from "lucide-react";
-import {
-  beginSocialLogin,
-  isSocialConfigured,
-  providerLabel,
-  type SocialProvider,
-} from "@/lib/auth/social";
+import { useSocialLogin } from "@/hooks/useSocialLogin";
+import { isSocialConfigured } from "@/lib/auth/social";
 
 const IS_DEV = import.meta.env.DEV;
 
 export function LoginPage() {
-  const [error, setError] = useState("");
-  const [loadingProvider, setLoadingProvider] = useState<SocialProvider | null>(null);
+  const { pendingProvider, error, start } = useSocialLogin();
 
   const kakaoReady = isSocialConfigured("kakao");
   const googleReady = isSocialConfigured("google");
 
-  async function handleSocialLogin(provider: SocialProvider) {
-    setError("");
-    setLoadingProvider(provider);
-    try {
-      await beginSocialLogin(provider);
-      // 성공 시 제공자로 리다이렉트되므로 이 아래는 실행되지 않는다.
-    } catch {
-      setError(`${providerLabel(provider)} 로그인 설정이 완료되지 않았습니다.`);
-      setLoadingProvider(null);
+  // 팝업이 차단되어 주 창이 제공자를 다녀오는 경우에만 해당한다. 그렇게 떠난 화면이 뒤로 가기로
+  // 되살아나면(bfcache) "로그인 중…"에 멈춘 버튼과 로그인 여부를 모르는 인증 상태를 그대로 들고
+  // 온다. 새로 부팅시켜 둘 다 다시 정하게 한다. 팝업으로 로그인하면 이 화면은 떠나지 않는다.
+  useEffect(() => {
+    function handlePageShow(event: PageTransitionEvent) {
+      if (event.persisted) window.location.reload();
     }
-  }
+
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, []);
 
   return (
     <div className="flex min-h-dvh items-center justify-center bg-background px-4">
@@ -49,17 +44,17 @@ export function LoginPage() {
           {/* 소셜 로그인 (주 로그인) */}
           <button
             type="button"
-            onClick={() => handleSocialLogin("kakao")}
-            disabled={!kakaoReady || loadingProvider !== null}
+            onClick={() => start("kakao")}
+            disabled={!kakaoReady || pendingProvider !== null}
             className="flex h-12 w-full items-center justify-center gap-2 rounded-lg bg-[#FEE500] text-sm font-semibold text-[#191600] transition-all duration-150 hover:brightness-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
           >
             <MessageCircle className="h-4 w-4 fill-current" />
-            {loadingProvider === "kakao" ? "카카오로 이동 중…" : "카카오로 로그인"}
+            {pendingProvider === "kakao" ? "카카오로 로그인 중…" : "카카오로 로그인"}
           </button>
           <button
             type="button"
-            onClick={() => handleSocialLogin("google")}
-            disabled={!googleReady || loadingProvider !== null}
+            onClick={() => start("google")}
+            disabled={!googleReady || pendingProvider !== null}
             className="mt-3 flex h-12 w-full items-center justify-center gap-2 rounded-lg border border-border bg-white text-sm font-semibold text-[#1f1f1f] transition-all duration-150 hover:bg-neutral-50 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
           >
             <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
@@ -80,7 +75,7 @@ export function LoginPage() {
                 d="M12 4.77c1.76 0 3.34.61 4.59 1.8l3.44-3.44C17.95 1.19 15.24 0 12 0A12 12 0 0 0 1.27 6.61l4.01 3.11C6.22 6.88 8.87 4.77 12 4.77Z"
               />
             </svg>
-            {loadingProvider === "google" ? "구글로 이동 중…" : "구글로 로그인"}
+            {pendingProvider === "google" ? "구글로 로그인 중…" : "구글로 로그인"}
           </button>
           {IS_DEV && (!kakaoReady || !googleReady) && (
             <p className="mt-2 text-center text-xs text-muted-foreground">

--- a/frontend/src/pages/SocialCallbackPage.tsx
+++ b/frontend/src/pages/SocialCallbackPage.tsx
@@ -1,62 +1,83 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Activity, Loader2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { socialLogin } from "@/lib/api/auth-api";
 import {
-  OAUTH_STATE_KEY,
-  OAUTH_VERIFIER_KEY,
+  OAUTH_POPUP_KEY,
+  clearSocialSecrets,
   isSocialProvider,
   providerLabel,
+  publishSocialCallback,
+  readSocialCallbackParams,
+  verifySocialCallback,
   type SocialProvider,
 } from "@/lib/auth/social";
 import { isApiClientError } from "@/lib/api/types";
 
-type AuthAttempt =
-  | { ok: true; provider: SocialProvider; code: string; verifier: string }
-  | { ok: false; message: string };
-
 /**
- * 되돌아온 인가 정보를 검사한다. URL 과 세션 저장소를 읽기만 하므로 렌더 중에 불러도 안전하다.
- * 세션 값을 지우는 것은 부수 효과라 이펙트에서 따로 한다.
+ * 소셜 인가 콜백. 제공자가 ?code=&state= 를 붙여 되돌린 페이지 (/auth/:provider/callback).
+ *
+ * 이 페이지가 열리는 창은 둘 중 하나다.
+ * - 팝업: 결과를 주 창에 넘기고 스스로 닫는다. 검증도 교환도 하지 않는다 (state·verifier 는 주 창에 있다).
+ * - 주 창: 팝업이 차단되어 주 창이 제공자를 다녀온 경우. 여기서 검증하고 교환한다.
  */
-function readAuthAttempt(provider: string | undefined): AuthAttempt {
+export function SocialCallbackPage() {
+  const { provider } = useParams();
+  const [isPopup] = useState(isPopupWindow);
+
   if (!isSocialProvider(provider)) {
-    return { ok: false, message: "지원하지 않는 소셜 제공자입니다." };
+    return (
+      <CallbackShell>
+        <CallbackError message="지원하지 않는 소셜 제공자입니다." />
+      </CallbackShell>
+    );
   }
 
-  const params = new URLSearchParams(window.location.search);
-  const code = params.get("code");
-  const returnedState = params.get("state");
-  const savedState = sessionStorage.getItem(OAUTH_STATE_KEY);
-  const verifier = sessionStorage.getItem(OAUTH_VERIFIER_KEY);
-
-  if (params.get("error")) {
-    return { ok: false, message: `${providerLabel(provider)} 로그인이 취소되었거나 실패했습니다.` };
-  }
-  if (!code || !returnedState) {
-    return { ok: false, message: "인가 정보가 올바르지 않습니다." };
-  }
-  if (!savedState || savedState !== returnedState) {
-    return { ok: false, message: "보안 검증(state)에 실패했습니다. 다시 시도해주세요." };
-  }
-  if (!verifier) {
-    return { ok: false, message: "로그인 검증값이 없습니다. 다시 시도해주세요." };
-  }
-
-  return { ok: true, provider, code, verifier };
+  return (
+    <CallbackShell>
+      {isPopup ? <PopupRelay provider={provider} /> : <MainWindowExchange provider={provider} />}
+    </CallbackShell>
+  );
 }
 
 /**
- * 소셜 인가 콜백. 제공자가 ?code=&state= 를 붙여 되돌린 페이지 (/auth/:provider/callback).
- * state 대조 → 백엔드 로그인 호출 → 성공 시 /market 이동.
+ * 이 창이 인가용 팝업인지 판별한다.
+ *
+ * 팝업은 열릴 때 주 창의 세션 저장소를 복사해 오므로 열기 직전에 남긴 표시가 들어 있다.
+ * 제공자 페이지가 COOP 헤더로 창 사이의 연결을 끊어버리면 window.opener 가 null 이 되므로
+ * 그것만으로는 판별할 수 없다. 표시를 먼저 보고, 없으면 opener 로 확인한다.
  */
-export function SocialCallbackPage() {
+function isPopupWindow(): boolean {
+  if (sessionStorage.getItem(OAUTH_POPUP_KEY) === "1") return true;
+  return window.opener !== null && window.opener !== window;
+}
+
+/** 팝업. 받아온 인가 결과를 주 창에 넘기고 닫는다. */
+function PopupRelay({ provider }: { provider: SocialProvider }) {
+  useEffect(() => {
+    sessionStorage.removeItem(OAUTH_POPUP_KEY);
+    publishSocialCallback(readSocialCallbackParams(provider, window.location.search));
+    window.close();
+  }, [provider]);
+
+  // 창을 닫는 데 실패하더라도 사용자가 막히지 않도록 안내를 남긴다.
+  return (
+    <div className="flex flex-col items-center gap-3 text-muted-foreground">
+      <Loader2 className="h-6 w-6 animate-spin" />
+      <p className="text-sm">로그인 처리 중… 이 창은 닫으셔도 됩니다.</p>
+    </div>
+  );
+}
+
+/** 주 창. 팝업이 차단되어 주 창이 제공자를 다녀온 경우로, 검증과 교환을 직접 한다. */
+function MainWindowExchange({ provider }: { provider: SocialProvider }) {
   const navigate = useNavigate();
-  const { provider } = useParams();
   const { loginWithSocial } = useAuth();
   // 검증은 첫 렌더에 한 번만 한다. 읽기만 하므로 StrictMode 가 두 번 불러도 결과가 같다.
-  const [attempt] = useState(() => readAuthAttempt(provider));
+  const [attempt] = useState(() =>
+    verifySocialCallback(readSocialCallbackParams(provider, window.location.search)),
+  );
   const [submitError, setSubmitError] = useState<string | null>(null);
   // 인가 코드는 일회용이라 StrictMode 이중 실행 시 두 번째 교환이 실패한다. ref 로 한 번만 실행.
   const startedRef = useRef(false);
@@ -65,10 +86,7 @@ export function SocialCallbackPage() {
     if (startedRef.current) return;
     startedRef.current = true;
 
-    // 한 번 쓴 state·verifier 는 성공이든 실패든 남겨두지 않는다.
-    sessionStorage.removeItem(OAUTH_STATE_KEY);
-    sessionStorage.removeItem(OAUTH_VERIFIER_KEY);
-
+    clearSocialSecrets();
     if (!attempt.ok) return;
 
     socialLogin(attempt.provider, attempt.code, attempt.verifier)
@@ -77,14 +95,39 @@ export function SocialCallbackPage() {
         navigate("/market", { replace: true });
       })
       .catch((e: unknown) => {
-        setSubmitError(
-          isApiClientError(e) ? e.message : "로그인 처리 중 오류가 발생했습니다.",
-        );
+        setSubmitError(isApiClientError(e) ? e.message : "로그인 처리 중 오류가 발생했습니다.");
       });
   }, [attempt, navigate, loginWithSocial]);
 
   const error = attempt.ok ? submitError : attempt.message;
+  if (error) return <CallbackError message={error} />;
 
+  return (
+    <div className="flex flex-col items-center gap-3 text-muted-foreground">
+      <Loader2 className="h-6 w-6 animate-spin" />
+      <p className="text-sm">{providerLabel(provider)} 로그인 처리 중…</p>
+    </div>
+  );
+}
+
+function CallbackError({ message }: { message: string }) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-6">
+      <p className="text-sm font-medium text-destructive">{message}</p>
+      <button
+        type="button"
+        onClick={() => navigate("/login", { replace: true })}
+        className="mt-4 h-10 w-full rounded-lg bg-primary text-sm font-semibold text-white transition-all duration-150 hover:bg-primary/90 active:scale-[0.98]"
+      >
+        로그인 화면으로 돌아가기
+      </button>
+    </div>
+  );
+}
+
+function CallbackShell({ children }: { children: ReactNode }) {
   return (
     <div className="flex min-h-dvh items-center justify-center bg-background px-4">
       <div className="w-full max-w-[380px] text-center">
@@ -94,26 +137,7 @@ export function SocialCallbackPage() {
           </div>
           <span className="text-2xl font-extrabold tracking-tight">Trypto</span>
         </div>
-
-        {error ? (
-          <div className="rounded-xl border border-border bg-card p-6">
-            <p className="text-sm font-medium text-destructive">{error}</p>
-            <button
-              type="button"
-              onClick={() => navigate("/login", { replace: true })}
-              className="mt-4 h-10 w-full rounded-lg bg-primary text-sm font-semibold text-white transition-all duration-150 hover:bg-primary/90 active:scale-[0.98]"
-            >
-              로그인 화면으로 돌아가기
-            </button>
-          </div>
-        ) : (
-          <div className="flex flex-col items-center gap-3 text-muted-foreground">
-            <Loader2 className="h-6 w-6 animate-spin" />
-            <p className="text-sm">
-              {isSocialProvider(provider) ? `${providerLabel(provider)} 로그인 처리 중…` : "로그인 처리 중…"}
-            </p>
-          </div>
-        )}
+        {children}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

소셜 인가를 주 창 전체 리다이렉트로 처리해 제공자의 로그인·동의 페이지가 히스토리에 쌓이고, 로그인 후 뒤로 가기를 누르면 로그인 화면으로 되돌아가 갇히던 문제를 고친다. 인가를 팝업에서 처리하고 결과만 주 창으로 넘긴다.

---

## 핵심 흐름

```
주 창: 로그인 버튼
  └─ 팝업 열기 → 제공자 인가 페이지 (히스토리는 팝업 쪽에만 쌓임)
       └─ 팝업: 콜백 수신 → BroadcastChannel 로 인가 결과 발행 → 팝업 닫힘
            └─ 주 창: 결과 수신 → 토큰 교환 → 로그인 완료
                 (주 창 히스토리에는 로그인 화면과 서비스 화면만 남는다)
```

---

## 주요 변경 사항

### 인증

- `lib/auth/social.ts` — 팝업 열기, `BroadcastChannel` 발행/구독, 콜백 파라미터 검증(`verifySocialCallback`·`readSocialCallbackParams`), 비밀값 정리(`clearSocialSecrets`) 유틸을 둔다.
- `useSocialLogin`(신규) — 로그인 시작·진행 상태·오류를 한곳에서 다룬다.
- `SocialCallbackPage` — 팝업일 때는 결과를 발행만 하고(릴레이), 주 창일 때는 토큰을 교환한다.
- `LoginPage` — `useSocialLogin` 을 쓰도록 단순화하고, bfcache 복귀(`pageshow`)에 대응한다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 전체 리다이렉트 대신 팝업 | 주 창 히스토리에 제공자 페이지가 쌓이지 않으므로, 뒤로 가기 갇힘의 원인 자체가 사라진다 |
| `BroadcastChannel` 로 결과 전달 | `window.opener` 직접 참조는 브라우저 정책(COOP)에 따라 차단될 수 있다 |
| 토큰 교환은 주 창에서 | 팝업은 곧 닫히므로, 세션을 세우는 일은 살아남는 창이 해야 한다 |
| bfcache 복귀 대응 | 뒤로 가기로 로그인 화면이 복원될 때 진행 중 상태가 남아 있으면 버튼이 잠긴 채로 보인다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 소셜 로그인 성공 후 뒤로 가기를 눌러도 로그인 화면으로 되돌아가지 않음
- [x] 팝업을 닫으면 로그인 진행 상태가 해제됨

Closes #257