### PR TITLE
[#259] 라운드 종료 후 완료 안내를 거쳐 마켓으로 이동

### DIFF
--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -62,6 +62,7 @@ export function MyPage() {
   const [editingNickname, setEditingNickname] = useState(false);
   const [nicknameInput, setNicknameInput] = useState(user?.nickname ?? "");
   const [endDialogOpen, setEndDialogOpen] = useState(false);
+  const [endedDialogOpen, setEndedDialogOpen] = useState(false);
   const [joinedAt, setJoinedAt] = useState<string | null>(null);
 
   useEffect(() => {
@@ -98,11 +99,16 @@ export function MyPage() {
       await endRound(activeRound.roundId, user.userId);
       clearRound();
       setEndDialogOpen(false);
-      navigate("/round/new", { replace: true });
+      setEndedDialogOpen(true);
     } catch (error) {
       console.error("Failed to end round", error);
     }
-  }, [activeRound, user, clearRound, navigate]);
+  }, [activeRound, user, clearRound]);
+
+  const handleEndedConfirm = useCallback(() => {
+    setEndedDialogOpen(false);
+    navigate("/market", { replace: true });
+  }, [navigate]);
 
   return (
     <div className="min-h-screen bg-background">
@@ -269,6 +275,21 @@ export function MyPage() {
           </Card>
         </div>
       </main>
+
+      {/* 라운드 종료 완료 */}
+      <Dialog open={endedDialogOpen} onOpenChange={(open) => !open && handleEndedConfirm()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>수고하셨어요. 한 라운드를 마무리했습니다.</DialogTitle>
+            <DialogDescription>
+              시세는 계속 둘러보실 수 있어요. 준비되면 새 라운드를 시작해보세요.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button onClick={handleEndedConfirm}>확인</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

라운드를 종료하면 안내 없이 곧바로 라운드 생성 화면으로 튕기던 흐름을 바꾼다. 완료 안내를 보여주고, 확인하면 마켓으로 보낸다.

---

## 핵심 흐름

```
라운드 종료 버튼
  ├─ (기존) 종료 → 즉시 /round/new 로 이동
  └─ (변경) 종료 → 완료 안내 다이얼로그 → 확인 → /market 으로 이동
```

---

## 주요 변경 사항

### 화면

- `MyPage` — 라운드 종료 처리에서 이동을 떼어 내고 완료 안내 다이얼로그를 띄운다. 확인 시 마켓으로 이동한다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 목적지를 라운드 생성이 아니라 마켓으로 | 라운드를 끝낸 직후에 다음 라운드 설정을 강요할 이유가 없다. 새 라운드는 사용자가 원할 때 시작하면 된다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 라운드 종료 시 완료 안내가 뜨고, 확인하면 마켓으로 이동함

Closes #259