### PR TITLE
[#265] 마이페이지에 피드백 보내기 UI 추가

### DIFF
--- a/frontend/src/components/feedback/FeedbackCard.tsx
+++ b/frontend/src/components/feedback/FeedbackCard.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { sendFeedback } from "@/lib/api/feedback-api";
+import { isApiClientError } from "@/lib/api/types";
+
+const MIN_LENGTH = 20;
+const MAX_LENGTH = 1000;
+
+export function FeedbackCard() {
+  const [content, setContent] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+
+  const length = content.trim().length;
+  const canSubmit = length >= MIN_LENGTH && length <= MAX_LENGTH && !submitting;
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      await sendFeedback(content.trim());
+      setContent("");
+      setSent(true);
+    } catch (e) {
+      setError(isApiClientError(e) ? e.message : "피드백 전송에 실패했습니다.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Card className="lg:col-span-2">
+      <CardHeader>
+        <CardTitle className="text-base">피드백 보내기</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          사용하면서 느낀 점이나 개선했으면 하는 부분을 알려주세요.
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <textarea
+          value={content}
+          onChange={(e) => {
+            setContent(e.target.value);
+            setSent(false);
+          }}
+          maxLength={MAX_LENGTH}
+          rows={5}
+          placeholder="어떤 점이 좋았고, 무엇이 아쉬웠나요?"
+          className="w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground/40 focus:border-primary/40 focus:ring-1 focus:ring-ring/50"
+        />
+
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs text-muted-foreground">
+            {length < MIN_LENGTH
+              ? `최소 ${MIN_LENGTH}자 이상 입력해주세요.`
+              : `${length} / ${MAX_LENGTH}자`}
+          </p>
+          <Button size="sm" onClick={handleSubmit} disabled={!canSubmit}>
+            {submitting ? "보내는 중..." : "보내기"}
+          </Button>
+        </div>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        {sent && (
+          <p className="text-xs text-muted-foreground">
+            피드백이 접수되었습니다. 소중한 의견 감사합니다.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/lib/api/feedback-api.ts
+++ b/frontend/src/lib/api/feedback-api.ts
@@ -1,0 +1,5 @@
+import { apiPost } from "./client";
+
+export function sendFeedback(content: string): Promise<void> {
+  return apiPost<void>("/api/feedbacks", { content });
+}

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Header } from "@/components/layout/Header";
+import { FeedbackCard } from "@/components/feedback/FeedbackCard";
 import { NoRoundNotice } from "@/components/round/NoRoundNotice";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRound } from "@/contexts/RoundContext";
@@ -273,6 +274,9 @@ export function MyPage() {
               )}
             </CardContent>
           </Card>
+
+          {/* 피드백 */}
+          <FeedbackCard />
         </div>
       </main>
 


### PR DESCRIPTION
## Summary

이미 서버에 있던 피드백 API 를 화면에 연결한다. 마이페이지에서 서비스 소감·개선 의견을 보낼 수 있다.

---

## 주요 변경 사항

### 화면

- `FeedbackCard`(신규) — 피드백 입력과 전송을 담당한다. 전송 중에는 제출을 잠그고, 성공·실패를 알린다.
- `MyPage` — 하단에 피드백 카드를 배치한다.

### API 클라이언트

- `lib/api/feedback-api.ts`(신규) — `POST /api/feedbacks` 호출.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 마이페이지에 둔다 | 별도 화면을 만들 만한 분량이 아니고, 사용자가 계정·라운드를 돌아보는 자리에서 의견을 남기는 흐름이 자연스럽다 |

---

## Test Plan

- [x] 프론트엔드 타입 검사 오류 0건
- [x] 피드백 전송 성공 시 안내가 뜨고 입력이 비워짐
- [x] 전송 중 중복 제출이 막힘

Closes #265