### PR TITLE
[#279] 모바일 화면 구현 (마켓·포트폴리오·입출금·랭킹·복기·마이)

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,17 +1,66 @@
-# trypto
+# Trypto Mobile
 
-A new Flutter project.
+코인 모의투자 플랫폼 trypto 의 Flutter 앱이다. 웹 프론트엔드의 9개 화면을 Android·iOS 네이티브로
+이식했다. Flutter Web 은 지원하지 않는다 — 서버에 CORS 설정이 없다.
 
-## Getting Started
+- 구현 계획서: [docs/plan.md](docs/plan.md) — 아키텍처 결정과 구현 순서. **결정문이다.**
+- 사양서: [docs/web-spec.md](docs/web-spec.md) — 웹·백엔드 실측 사양.
 
-This project is a starting point for a Flutter application.
+## 실행
 
-A few resources to get you started if this is your first Flutter project:
+자격증명과 서버 주소는 전부 `--dart-define` 으로 주입한다. 저장소에 키를 커밋하지 않는다.
 
-- [Learn Flutter](https://docs.flutter.dev/get-started/learn-flutter)
-- [Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Flutter learning resources](https://docs.flutter.dev/reference/learning-resources)
+```bash
+flutter pub get
+dart run build_runner build --delete-conflicting-outputs   # models/*.g.dart
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+flutter run \
+  --dart-define=API_BASE_URL=http://10.0.2.2:8080 \
+  --dart-define=WS_BASE_URL=ws://10.0.2.2:8080/ws \
+  --dart-define=KAKAO_CLIENT_ID=... \
+  --dart-define=GOOGLE_ANDROID_CLIENT_ID=... \
+  --dart-define=GOOGLE_IOS_CLIENT_ID=...
+```
+
+| 키 | 개발(에뮬레이터) | 운영 |
+|---|---|---|
+| `API_BASE_URL` | `http://10.0.2.2:8080` | `https://{도메인}` |
+| `WS_BASE_URL` | `ws://10.0.2.2:8080/ws` | `wss://{도메인}/ws` |
+| `KAKAO_CLIENT_ID` | 카카오 REST API 키 | 동일 |
+| `GOOGLE_ANDROID_CLIENT_ID` / `GOOGLE_IOS_CLIENT_ID` | 플랫폼별 OAuth 클라이언트 ID | 동일 |
+| `KAKAO_CALLBACK_SCHEME` / `GOOGLE_CALLBACK_SCHEME` | `trypto` (기본값) | 콘솔 정책에 따라 변경 |
+
+로컬 백엔드는 `SESSION_COOKIE_SECURE=false` 여야 세션 쿠키가 저장·전송된다.
+
+## 검증
+
+```bash
+flutter analyze          # 에러 0 이 커밋 조건이다
+flutter test             # 순수 로직 · 인터셉터 계약 · 티커 성능 계약 · 위젯 5종
+flutter build apk --debug
+```
+
+## 구조
+
+```
+lib/
+  core/      env · api(Dio + 인터셉터 3종) · auth(PKCE·세션) · realtime(STOMP·TickerStore)
+             format · json · router(가드) · theme · widgets
+  models/    서버 DTO 전량 (json_serializable)
+  features/  auth · round · market · portfolio · wallet · ranking · regret · mypage
+```
+
+이 앱의 뼈대는 셋이다.
+
+1. **티커는 Riverpod 그래프를 통과하지 않는다.** `TickerStore` 가 STOMP 프레임을 심볼별
+   `ValueNotifier` 로 접어 **프레임당 1회** flush 한다. 600행 × 초당 수백 틱을 provider 로
+   전파하면 selector 비교만 초당 수만 회가 된다.
+2. **세션은 `Set-Cookie` 에서 `SESSION` 값만 뽑아** 보안 저장소에 넣고 요청마다 헤더로 붙인다.
+   쿠키 자동 관리(`cookie_jar`)를 쓰지 않는다 — 7일 절대 만료를 그대로 물려받기 때문이다.
+3. **봉투 언랩과 401 판정은 인터셉터 한 곳에서만 한다.** 화면은 `ApiException` 하나만 안다.
+
+## 남은 작업
+
+`docs/plan.md` §9 의 외부 의존(제공자 콘솔 등록, 백엔드 자격증명 분기)과 폰트 에셋 반입이 남아
+있다. 폰트 파일이 없는 동안 `pubspec.yaml` 의 `fonts:` 선언은 주석 처리되어 있고 타이포그래피는
+시스템 폰트로 폴백된다.

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -3,12 +3,34 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'core/router/router.dart';
 import 'core/theme/theme.dart';
+import 'features/auth/auth_controller.dart';
+import 'features/market/market_controller.dart';
+import 'features/mypage/user_repository.dart';
+import 'features/portfolio/portfolio_repository.dart';
+import 'features/regret/regret_repository.dart';
+import 'features/wallet/wallet_assets.dart';
 
 class TryptoApp extends ConsumerWidget {
   const TryptoApp({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // 로그아웃·세션 만료·회원 탈퇴 시 사용자 경계를 넘는 캐시를 전부 비운다(계획서 §4.1.3).
+    // 세션은 SessionStore 가, 라운드는 RoundController 가(인증을 watch 한다), 티커 구독은 마켓
+    // 화면이 dispose 에서 끊는다. 남는 것이 아래 조회 캐시들이다 — autoDispose 가 아니라
+    // 리스너가 없어도 살아 있으므로 여기서 명시적으로 무효화한다.
+    ref.listen(authControllerProvider.select((auth) => auth.isAuthenticated), (
+      previous,
+      next,
+    ) {
+      if (previous != true || next) return;
+      ref.invalidate(marketCoinsProvider);
+      ref.invalidate(userProfileProvider);
+      ref.invalidate(portfolioProvider);
+      ref.invalidate(walletSnapshotProvider);
+      ref.invalidate(regretProvider);
+    });
+
     return MaterialApp.router(
       title: 'Trypto',
       debugShowCheckedModeBanner: false,

--- a/mobile/lib/core/format/formatters.dart
+++ b/mobile/lib/core/format/formatters.dart
@@ -107,6 +107,13 @@ String formatChangeRate(double rate) {
   return '$sign${percent.toStringAsFixed(2)}%';
 }
 
+/// 수익률. **입력은 퍼센트 값 그 자체다**(12.34 → `+12.34%`). 티커 [formatChangeRate] 의 입력이
+/// 비율(0.0234)인 것과 단위가 다르다(사양서 §1.8-5). 랭킹·복기가 이 함수를 쓴다.
+String formatProfitPercent(double percent) {
+  final sign = percent > 0 ? '+' : '';
+  return '$sign${percent.toStringAsFixed(2)}%';
+}
+
 /// 통화 기호. USDT 는 빈 문자열이다. §8.5.10
 String getCurrencySymbol(String baseCurrency) => switch (baseCurrency) {
   'KRW' => '₩',

--- a/mobile/lib/core/format/formatters.dart
+++ b/mobile/lib/core/format/formatters.dart
@@ -48,6 +48,10 @@ String formatKRWCompact(double value) {
   return _grp.format(value);
 }
 
+/// 천단위 구분만 넣은 정수 표기(웹 `toLocaleString`). 축약하면 안 되는 자리 —
+/// 라운드 생성 금액 입력, 마이페이지 라운드 카드 — 에서 쓴다.
+String formatGrouped(num value) => _int0.format(value);
+
 /// 통화별 금액, 단위 포함. §8.5.3
 ///
 /// USDT 는 템플릿이 `$${값}` 이라 음수에서 기호 뒤에 마이너스가 온다(`$-12.35`). 웹 동작 그대로다.

--- a/mobile/lib/core/format/server_time.dart
+++ b/mobile/lib/core/format/server_time.dart
@@ -25,6 +25,9 @@ class ServerTime {
 
   static String formatDateTime(DateTime at) => _dateTime.format(at);
 
+  /// 가입일·라운드 시작일. 웹의 `toLocaleDateString('ko-KR')` 대응(`2026년 7월 15일`).
+  static String formatKoreanDate(DateTime at) => _koreanDate.format(at);
+
   /// 거래내역·송금내역의 상대 시각. 24시간을 넘으면 절대 시각으로 떨어진다.
   static String relative(DateTime at, {DateTime? now}) {
     final minutes = (now ?? DateTime.now()).difference(at).inMinutes;
@@ -42,3 +45,6 @@ const String _locale = 'en_US';
 
 final DateFormat _dateTime = DateFormat('yyyy.MM.dd HH:mm', _locale);
 final DateFormat _date = DateFormat('yyyy-MM-dd', _locale);
+
+/// 한글 문자는 ICU 패턴 예약 문자가 아니므로 그대로 출력된다.
+final DateFormat _koreanDate = DateFormat('yyyy년 M월 d일', _locale);

--- a/mobile/lib/core/realtime/order_filled_event.dart
+++ b/mobile/lib/core/realtime/order_filled_event.dart
@@ -1,0 +1,39 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import '../json/converters.dart';
+
+part 'order_filled_event.g.dart';
+
+/// `/user/queue/events` — **구독하지 않는다**(사양서 R3).
+///
+/// 서버가 WebSocket 세션에 `Principal` 을 부착하지 않아 `convertAndSendToUser` 가 보낸
+/// 메시지는 전부 폐기된다. 웹에서도 동작하지 않으므로 기능 동등성에 영향이 없다.
+///
+/// 체결 반영은 REST 재조회로 확정한다(주문 제출·취소 직후, 화면 진입, 포그라운드 복귀,
+/// 당김 새로고침).
+///
+/// 서버가 (1) 핸드셰이크에서 `SESSION` 쿠키를 읽어 `Principal` 을 붙이고 (2) 페이로드에
+/// `walletId`/`coinId`/`side`/`fee` 를 추가하면, 목적지 `/user/queue/events`(리터럴
+/// `/user/{id}/...` 가 아니다) 구독 한 줄로 켠다. 필드는 서버가 **실제로 보내는 것**만 담는다.
+@JsonSerializable(createToJson: false)
+class OrderFilledEvent {
+  const OrderFilledEvent({
+    required this.eventType,
+    required this.orderId,
+    required this.executedPrice,
+    required this.quantity,
+    required this.executedAt,
+  });
+
+  factory OrderFilledEvent.fromJson(Map<String, dynamic> json) =>
+      _$OrderFilledEventFromJson(json);
+
+  /// 항상 `ORDER_FILLED`.
+  final String eventType;
+  final int orderId;
+  final double executedPrice;
+  final double quantity;
+
+  @KstDateTimeConverter()
+  final DateTime executedAt;
+}

--- a/mobile/lib/core/realtime/order_filled_event.g.dart
+++ b/mobile/lib/core/realtime/order_filled_event.g.dart
@@ -1,0 +1,18 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'order_filled_event.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+OrderFilledEvent _$OrderFilledEventFromJson(Map<String, dynamic> json) =>
+    OrderFilledEvent(
+      eventType: json['eventType'] as String,
+      orderId: (json['orderId'] as num).toInt(),
+      executedPrice: (json['executedPrice'] as num).toDouble(),
+      quantity: (json['quantity'] as num).toDouble(),
+      executedAt: const KstDateTimeConverter().fromJson(
+        json['executedAt'] as String,
+      ),
+    );

--- a/mobile/lib/core/realtime/stomp_service.dart
+++ b/mobile/lib/core/realtime/stomp_service.dart
@@ -1,0 +1,212 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:stomp_dart_client/stomp_dart_client.dart';
+
+import '../env.dart';
+
+typedef StompFrameHandler = void Function(String body);
+
+class _Registration {
+  _Registration(this.destination, this.handler);
+
+  final String destination;
+  final StompFrameHandler handler;
+
+  /// 소켓이 끊기면 무효화한다. 재연결 후 중복 구독이 생기지 않게 한다.
+  StompUnsubscribe? cancel;
+}
+
+/// 앱 전역 싱글톤(계획서 §4.2.1). raw WS + STOMP 1.2 이며 SockJS 가 아니다.
+///
+/// **수신 전용**이다 — 서버에 `@MessageMapping` 이 하나도 없다. 쓰기는 전부 REST 다.
+class StompService {
+  StompService({
+    String? url,
+    Stream<List<ConnectivityResult>>? connectivity,
+    bool observeLifecycle = true,
+  }) : _url = url ?? Env.wsBaseUrl {
+    if (observeLifecycle) {
+      _lifecycle = AppLifecycleListener(onStateChange: _onLifecycle);
+    }
+    _network = (connectivity ?? Connectivity().onConnectivityChanged).listen(
+      _onNetworkChanged,
+    );
+    _client = _build();
+  }
+
+  final String _url;
+  final List<_Registration> _registry = [];
+
+  late StompClient _client;
+  AppLifecycleListener? _lifecycle;
+  late final StreamSubscription<List<ConnectivityResult>> _network;
+
+  Timer? _retry;
+  Timer? _networkDebounce;
+  DateTime? _hiddenAt;
+  int _attempts = 0;
+  bool _intentionalClose = false;
+  bool _started = false;
+  bool _disposed = false;
+
+  bool get connected => _client.connected;
+
+  void connect() {
+    if (_started || _disposed) return;
+    _started = true;
+    _client.activate();
+  }
+
+  /// 아직 연결되지 않았으면 레지스트리에만 넣어 둔다. `onConnect` 가 전량 재구독한다.
+  VoidCallback subscribe(String destination, StompFrameHandler handler) {
+    connect();
+    final registration = _Registration(destination, handler);
+    _registry.add(registration);
+    _activate(registration);
+
+    return () {
+      _registry.remove(registration);
+      registration.cancel?.call();
+      registration.cancel = null;
+    };
+  }
+
+  /// 백오프 타이머를 취소하고 소켓을 즉시 버린다. `deactivate()` 의 정상 종료 절차는 좀비
+  /// 소켓에서 오래 걸리므로 기다리지 않는다.
+  void forceReconnect() {
+    if (!_started || _disposed) return;
+    _closeSocket();
+    _client = _build();
+    _attempts = 0;
+    _client.activate();
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _retry?.cancel();
+    _networkDebounce?.cancel();
+    _network.cancel();
+    _lifecycle?.dispose();
+    _registry.clear();
+    _intentionalClose = true;
+    _client.deactivate();
+  }
+
+  StompClient _build() {
+    late StompClient client;
+    client = StompClient(
+      config: StompConfig(
+        url: _url,
+        heartbeatIncoming: const Duration(seconds: 10),
+        // 서버 수신 기준은 10초다. 모바일은 OS 타이머 유예로 주기가 밀리므로 2초 마진을 둔다.
+        heartbeatOutgoing: const Duration(seconds: 8),
+        connectionTimeout: const Duration(seconds: 5),
+        // 내장 재연결은 고정 지연만 지원한다. 지수 백오프는 직접 건다.
+        reconnectDelay: Duration.zero,
+        onConnect: (_) => _onConnect(client),
+        onWebSocketDone: () => _onWebSocketDone(client),
+        onWebSocketError: (error) => debugPrint('[STOMP] socket error: $error'),
+        onStompError: (frame) =>
+            debugPrint('[STOMP] error frame: ${frame.headers['message']}'),
+      ),
+    );
+    return client;
+  }
+
+  void _onConnect(StompClient client) {
+    if (!identical(client, _client)) return;
+    _attempts = 0;
+    // 자동 복원되지 않는다. 레지스트리를 전량 재구독한다.
+    for (final registration in _registry) {
+      _activate(registration);
+    }
+  }
+
+  void _onWebSocketDone(StompClient client) {
+    // 폐기된 클라이언트가 뒤늦게 닫히는 경우가 있다. 그 done 으로 백오프를 무장하면 이중
+    // 연결이 생긴다.
+    if (!identical(client, _client) || _disposed) return;
+    _invalidate();
+    if (_intentionalClose) {
+      _intentionalClose = false;
+      return;
+    }
+    _attempts++;
+    // 첫 대기는 2초다(웹 구현과 동일).
+    final ms = math.min(1000 * math.pow(2, _attempts).toInt(), 30000);
+    _retry?.cancel();
+    _retry = Timer(Duration(milliseconds: ms), () {
+      if (!_disposed) _client.activate();
+    });
+  }
+
+  void _activate(_Registration registration) {
+    if (!_client.connected) return;
+    registration.cancel = _client.subscribe(
+      destination: registration.destination,
+      callback: (frame) {
+        final body = frame.body;
+        if (body != null) registration.handler(body);
+      },
+    );
+  }
+
+  void _invalidate() {
+    for (final registration in _registry) {
+      registration.cancel = null;
+    }
+  }
+
+  /// 백오프를 무장하지 않는 종료. `_intentionalClose` 는 동기 done 을, 클라이언트 동일성
+  /// 검사는 비동기 done 을 각각 막는다.
+  void _closeSocket() {
+    _retry?.cancel();
+    _intentionalClose = true;
+    _client.deactivate();
+    _invalidate();
+    _intentionalClose = false;
+  }
+
+  void _onLifecycle(AppLifecycleState state) {
+    if (_disposed) return;
+
+    // paused 만 본다. iOS 는 알림 센터를 살짝 내려도 inactive/hidden 이 뜬다.
+    if (state == AppLifecycleState.paused) {
+      _hiddenAt = DateTime.now();
+      if (_started) _closeSocket();
+      return;
+    }
+    if (state != AppLifecycleState.resumed) return;
+
+    final hiddenAt = _hiddenAt;
+    _hiddenAt = null;
+    if (!_started) return;
+
+    final elapsed = hiddenAt == null
+        ? Duration.zero
+        : DateTime.now().difference(hiddenAt);
+    // 하트비트 10초의 2배를 넘겼으면 서버가 이미 세션을 끊었다고 본다. connected 만 보면
+    // ERROR 프레임 처리 전이라 좀비 연결을 잡지 못한다.
+    if (elapsed > const Duration(seconds: 20) || !connected) forceReconnect();
+  }
+
+  /// Wi-Fi ↔ 셀룰러 전환 직후 소켓은 살아 보이지만 죽어 있다. resume 직후에도 이벤트가
+  /// 튀므로 디바운스가 없으면 재연결이 중복 발화한다.
+  void _onNetworkChanged(List<ConnectivityResult> results) {
+    if (_disposed || !_started) return;
+    if (results.every((result) => result == ConnectivityResult.none)) return;
+    _networkDebounce?.cancel();
+    _networkDebounce = Timer(const Duration(seconds: 1), forceReconnect);
+  }
+}
+
+final stompServiceProvider = Provider<StompService>((ref) {
+  final service = StompService();
+  ref.onDispose(service.dispose);
+  return service;
+});

--- a/mobile/lib/core/realtime/ticker_store.dart
+++ b/mobile/lib/core/realtime/ticker_store.dart
@@ -1,0 +1,240 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart' show SchedulerBinding;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../models/exchange_coin.dart';
+import '../../models/ticker.dart';
+
+/// 티커 배칭의 단일 지점(계획서 §4.2.4). 초당 수백 건 × 최대 600행이 들어온다.
+///
+/// **티커는 Riverpod 그래프를 통과하지 않는다.** 심볼별 [ValueNotifier] 로 해당 행만 갱신한다.
+/// 경로가 둘이다.
+///
+/// - **그리기**: 프레임당 1회 flush. 같은 프레임의 같은 심볼은 마지막 값만 남는다.
+/// - **접기**: [TickObserver.onTick] 이 **매 틱 동기 호출**된다. 프레임 버퍼로 캔들을 접으면
+///   한 프레임 안의 체결이 사라져 봉의 고가·저가가 실제보다 얕아진다(사양서 §4.3.5.2).
+enum FlashDir { up, down, same }
+
+/// 100ms 후 즉시 해제한다. 페이드하지 않는다(사양서 §3.3.3).
+const Duration kFlashDuration = Duration(milliseconds: 100);
+
+/// 숫자 3개만 담는다. `tickedAt` 을 넣지 않는다 — 넣으면 매 틱 `==` 가 거짓이 되어 동일가
+/// 재체결에서 숫자 위젯이 무의미하게 리빌드된다.
+///
+/// `==`/`hashCode` 는 성능 계약이다.
+@immutable
+class CoinRowState {
+  const CoinRowState(this.price, this.changeRate, this.volume);
+
+  final double price;
+  final double changeRate;
+  final double volume;
+
+  @override
+  bool operator ==(Object other) =>
+      other is CoinRowState &&
+      other.price == price &&
+      other.changeRate == changeRate &&
+      other.volume == volume;
+
+  @override
+  int get hashCode => Object.hash(price, changeRate, volume);
+}
+
+/// `hasListeners` 는 `ChangeNotifier` 의 protected 멤버다. 화면 밖 행을 건너뛰려면 공개 게터가
+/// 필요하다.
+class RowNotifier extends ValueNotifier<CoinRowState> {
+  RowNotifier(super.value);
+
+  int? lastTickedAt;
+
+  bool get isWatched => hasListeners;
+}
+
+class FlashNotifier extends ValueNotifier<FlashDir?> {
+  FlashNotifier() : super(null);
+
+  bool get isWatched => hasListeners;
+}
+
+/// 티커의 두 번째 소비자(캔들 차트)가 구현한다. 관찰자는 하나뿐이다 — 차트는 한 번에 하나만
+/// 열린다.
+abstract class TickObserver {
+  /// [TickerStore.ingest] 안에서 **매 틱** 동기 호출된다. 접기 전용이며 그리기를 하지 않는다.
+  void onTick(Ticker tick);
+
+  /// flush 안에서 **프레임당 1회** 호출된다. 그리기 알림은 여기서만 낸다.
+  void onFrame();
+}
+
+class TickerStore {
+  final Map<String, RowNotifier> _rows = {};
+  final Map<String, FlashNotifier> _flash = {};
+
+  /// 프레임 버퍼. 같은 심볼은 마지막 값이 이긴다.
+  final Map<String, Ticker> _pending = {};
+  final Map<String, int> _flashUntilMs = {};
+
+  TickObserver? _observer;
+  bool _scheduled = false;
+  int _frameId = 0;
+  bool _active = true;
+  bool _orderDirty = false;
+  bool _disposed = false;
+
+  RowNotifier? row(String symbol) => _rows[symbol];
+
+  FlashNotifier? flash(String symbol) => _flash[symbol];
+
+  /// 정렬·필터가 읽는 최신값. 목록 밖 심볼이면 null.
+  CoinRowState? quote(String symbol) => _rows[symbol]?.value;
+
+  /// 시세 변동에 의한 재정렬은 티커와 캐던스를 분리한다(1초 스로틀 + 스크롤 중 동결).
+  bool get orderDirty => _orderDirty;
+
+  void clearOrderDirty() => _orderDirty = false;
+
+  void setRawObserver(TickObserver observer) => _observer = observer;
+
+  /// 관찰자 교체 중에 옛 관찰자의 해제가 새 관찰자를 지우지 않게 한다.
+  void clearRawObserver(TickObserver observer) {
+    if (identical(_observer, observer)) _observer = null;
+  }
+
+  /// 마켓 탭이 비활성이면 flush 를 멈춘다. `indexedStack` 은 숨은 탭의 build 비용을 그대로
+  /// 청구하므로 구독 해제만으로는 부족하다(계획서 §4.2.3).
+  void setActive(bool active) {
+    if (_active == active || _disposed) return;
+    _active = active;
+    if (active) return;
+    _pending.clear();
+    // 잔여 플래시는 다음 프레임의 만료 스윕이 끈다. notifier 쓰기는 flush 안에서만 한다.
+    if (_flashUntilMs.isNotEmpty) _schedule(rescheduling: false);
+  }
+
+  /// 거래소 전환·스냅샷 재조회. 이전 거래소의 잔여 틱이 새 목록을 오염시키지 않게 한다
+  /// (사양서 §3.3.2-5).
+  ///
+  /// 옛 notifier 를 dispose 하지 않는다 — 아직 마운트된 행이 리스너를 떼는 중이다. 참조만
+  /// 끊으면 GC 가 가져간다.
+  void switchExchange(Iterable<ExchangeCoin> coins) {
+    _pending.clear();
+    _flashUntilMs.clear();
+    _rows.clear();
+    _flash.clear();
+    for (final coin in coins) {
+      _rows[coin.coinSymbol] = RowNotifier(
+        CoinRowState(coin.price, coin.changeRate, coin.volume),
+      );
+      _flash[coin.coinSymbol] = FlashNotifier();
+    }
+    _orderDirty = false;
+  }
+
+  /// STOMP 프레임마다 호출된다. 초당 수백 회. `setState` 를 절대 부르지 않는다.
+  void ingest(List<Ticker> ticks) {
+    if (!_active || _disposed) return;
+    var accepted = false;
+    for (final tick in ticks) {
+      // 상장 목록 밖 심볼은 버린다(사양서 §3.3.2-2).
+      if (!_rows.containsKey(tick.symbol)) continue;
+      _observer?.onTick(tick);
+      _pending[tick.symbol] = tick;
+      accepted = true;
+    }
+    if (accepted) _schedule(rescheduling: false);
+  }
+
+  void _schedule({required bool rescheduling}) {
+    if (_scheduled || _disposed) return;
+    _scheduled = true;
+    // Timer(16ms) 가 아니다. transient callback 은 같은 프레임의 build 보다 앞서 실행되므로
+    // flush 가 만든 dirty 마크가 그 프레임 안에서 처리된다.
+    _frameId = SchedulerBinding.instance.scheduleFrameCallback(
+      _flush,
+      rescheduling: rescheduling,
+    );
+  }
+
+  /// [timeStamp] 는 프레임의 시각이다. `DateTime.now()` 를 쓰지 않는다 — 프레임마다 시계를
+  /// 읽을 이유가 없고, 플래시 만료는 프레임 시간축에서 판정해야 일관된다.
+  void _flush(Duration timeStamp) {
+    _scheduled = false;
+    _frameId = 0;
+    if (_disposed) return;
+
+    final nowMs = timeStamp.inMilliseconds;
+
+    if (_pending.isNotEmpty) {
+      for (final tick in _pending.values) {
+        final row = _rows[tick.symbol];
+        if (row == null) continue;
+        final flash = _flash[tick.symbol]!;
+
+        // 화면 밖 행은 리스너가 0개다. 플래시를 계산하지 않는다.
+        if (flash.isWatched &&
+            row.lastTickedAt != null &&
+            tick.timestamp != row.lastTickedAt) {
+          flash.value = tick.price > row.value.price
+              ? FlashDir.up
+              : tick.price < row.value.price
+              ? FlashDir.down
+              : FlashDir.same;
+          _flashUntilMs[tick.symbol] = nowMs + kFlashDuration.inMilliseconds;
+        }
+        row.lastTickedAt = tick.timestamp;
+        // 값이 같으면 알림이 나가지 않는다(CoinRowState.== 계약).
+        row.value = CoinRowState(tick.price, tick.changeRate, tick.quoteTurnover);
+      }
+      _pending.clear();
+      _orderDirty = true;
+    }
+
+    // 심볼별 Timer 대신 flush 루프에서 만료를 쓸어 담는다. 타이머 수: 수백 → 0.
+    _flashUntilMs.removeWhere((symbol, until) {
+      if (nowMs < until) return false;
+      _flash[symbol]?.value = null;
+      return true;
+    });
+
+    _observer?.onFrame();
+
+    if (_flashUntilMs.isNotEmpty) _schedule(rescheduling: true);
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    if (_scheduled) {
+      SchedulerBinding.instance.cancelFrameCallbackWithId(_frameId);
+      _scheduled = false;
+    }
+    _pending.clear();
+    _flashUntilMs.clear();
+    _rows.clear();
+    _flash.clear();
+    _observer = null;
+  }
+}
+
+/// 페이로드는 JSON **배열**이다(사양서 §3.2.1). 파싱 실패·빈 배열은 조용히 무시한다.
+List<Ticker> decodeTickers(String body) {
+  try {
+    final decoded = jsonDecode(body);
+    if (decoded is! List || decoded.isEmpty) return const [];
+    return [
+      for (final item in decoded)
+        if (item is Map<String, dynamic>) Ticker.fromJson(item),
+    ];
+  } catch (_) {
+    return const [];
+  }
+}
+
+final tickerStoreProvider = Provider<TickerStore>((ref) {
+  final store = TickerStore();
+  ref.onDispose(store.dispose);
+  return store;
+});

--- a/mobile/lib/core/router/guard.dart
+++ b/mobile/lib/core/router/guard.dart
@@ -9,6 +9,14 @@ abstract final class Routes {
   static const String wallet = '/wallet';
   static const String ranking = '/ranking';
   static const String regret = '/regret';
+
+  /// 코인 상세는 마켓 브랜치 위로 push 된다(rootNavigator). 마켓 탭은 계속 선택 상태이므로
+  /// 티커 구독이 유지되고, 차트는 별도로 토픽을 구독하지 않는다.
+  static String coinDetail(String symbol, String exchangeKey) =>
+      '$market/coin/$symbol?exchange=$exchangeKey';
+
+  static String coinChart(String symbol, String exchangeKey, String interval) =>
+      '$market/coin/$symbol/chart?exchange=$exchangeKey&interval=$interval';
 }
 
 /// 웹의 가드 3종(사양서 §2.7.2)을 하나로 합친 순수 함수. 위젯 없이 표로 테스트한다.

--- a/mobile/lib/core/router/router.dart
+++ b/mobile/lib/core/router/router.dart
@@ -5,6 +5,8 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../../features/auth/auth_controller.dart';
 import '../../features/auth/login_page.dart';
+import '../../features/market/chart_fullscreen_page.dart';
+import '../../features/market/coin_detail_page.dart';
 import '../../features/market/market_page.dart';
 import '../../features/mypage/mypage_page.dart';
 import '../../features/portfolio/portfolio_page.dart';
@@ -13,11 +15,18 @@ import '../../features/regret/regret_page.dart';
 import '../../features/round/round_controller.dart';
 import '../../features/round/round_create_page.dart';
 import '../../features/wallet/wallet_page.dart';
+import '../../models/enums.dart';
 import '../../splash_page.dart';
 import 'guard.dart';
 import 'refresh.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
+
+/// 라우트 쿼리에서 오는 값이라 무엇이든 들어올 수 있다. 대소문자를 구분한다(`1M` 은 월봉).
+CandleInterval _intervalOf(String? wire) => CandleInterval.values.firstWhere(
+  (interval) => interval.wire == wire,
+  orElse: () => CandleInterval.day1,
+);
 
 /// 소셜 콜백 스킴은 라우터에 등록하지 않는다(계획서 §4.3.1). `flutter_web_auth_2` 가 콜백
 /// 인텐트를 자기 액티비티에서 소비해 `authenticate()` 의 반환값으로 준다. 라우터에도 스킴을
@@ -67,6 +76,28 @@ final routerProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: Routes.market,
                 builder: (context, state) => const MarketPage(),
+                routes: [
+                  GoRoute(
+                    path: 'coin/:symbol',
+                    // 탭바 위를 덮는다. 마켓 브랜치는 선택 상태로 남아 티커 구독이 유지된다.
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (context, state) => CoinDetailPage(
+                      symbol: state.pathParameters['symbol']!,
+                    ),
+                    routes: [
+                      GoRoute(
+                        path: 'chart',
+                        parentNavigatorKey: _rootNavigatorKey,
+                        builder: (context, state) => ChartFullscreenPage(
+                          symbol: state.pathParameters['symbol']!,
+                          interval: _intervalOf(
+                            state.uri.queryParameters['interval'],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
               ),
             ],
           ),

--- a/mobile/lib/core/widgets/async_view.dart
+++ b/mobile/lib/core/widgets/async_view.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../api/api_exception.dart';
+import 'empty_view.dart';
+
+/// `AsyncValue` → 로딩 / 오류+재시도 / 데이터. 실패를 조용히 넘기지 않는다(R9).
+class AsyncView<T> extends StatelessWidget {
+  const AsyncView({
+    super.key,
+    required this.value,
+    required this.builder,
+    this.onRetry,
+  });
+
+  final AsyncValue<T> value;
+  final Widget Function(T data) builder;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return value.when(
+      data: builder,
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, _) => EmptyView(
+        icon: LucideIcons.circleAlert,
+        message: error.asApiException.userMessage,
+        action: onRetry == null
+            ? null
+            : OutlinedButton(onPressed: onRetry, child: const Text('다시 시도')),
+      ),
+    );
+  }
+}

--- a/mobile/lib/core/widgets/no_round_notice.dart
+++ b/mobile/lib/core/widgets/no_round_notice.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../router/guard.dart';
+import 'empty_view.dart';
+
+/// 라운드가 없으면 지갑이 없고, 지갑이 없으면 조회할 것이 없다(사양서 §7.4.2).
+/// 포트폴리오·입출금·복기가 같은 안내를 쓴다.
+class NoRoundNotice extends StatelessWidget {
+  const NoRoundNotice({super.key, required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return EmptyView(
+      icon: LucideIcons.flag,
+      message: message,
+      action: FilledButton(
+        onPressed: () => context.go(Routes.roundNew),
+        child: const Text('새 라운드 시작'),
+      ),
+    );
+  }
+}

--- a/mobile/lib/core/widgets/numeric_text.dart
+++ b/mobile/lib/core/widgets/numeric_text.dart
@@ -7,6 +7,10 @@ import '../theme/theme.dart';
 ///
 /// 줄바꿈을 막고 넘치면 자른다. 티커 행의 숫자 셀은 고정 폭 제약 안에 들어가야 리레이아웃이
 /// 부모로 전파되지 않는다 (§4.2.5-4).
+///
+/// `softWrap: false` 를 주지 않는다. 그러면 `RenderParagraph` 가 제약을 무시하고 무한 폭으로
+/// 배치해 부모(등락률 배지·고정 폭 셀)를 밀어낸다. `maxLines: 1` 로 줄바꿈을 막고, 폭은
+/// 제약 안에서 자른다.
 class NumericText extends StatelessWidget {
   const NumericText(
     this.text, {
@@ -29,7 +33,6 @@ class NumericText extends StatelessWidget {
       text,
       textAlign: textAlign,
       maxLines: 1,
-      softWrap: false,
       overflow: TextOverflow.clip,
       style: TryptoText.numeric(size: size, weight: weight, color: color),
     );

--- a/mobile/lib/core/widgets/profit_badge.dart
+++ b/mobile/lib/core/widgets/profit_badge.dart
@@ -46,7 +46,9 @@ class TryptoBadge extends StatelessWidget {
             Icon(icon, size: 12, color: foreground),
             const SizedBox(width: 4),
           ],
-          text,
+          // Row 는 비-flex 자식에게 무한 폭을 준다. 감싸지 않으면 긴 라벨(+300.00%)이 배지를
+          // 가둔 고정 폭 셀 밖으로 그대로 밀고 나간다.
+          Flexible(child: text),
         ],
       ),
     );

--- a/mobile/lib/features/auth/auth_controller.dart
+++ b/mobile/lib/features/auth/auth_controller.dart
@@ -138,6 +138,32 @@ class AuthController extends Notifier<AuthState> {
     state = const AuthState.signedOut();
   }
 
+  /// 닉네임 변경 성공 후 로컬 신원을 갱신한다. 앱바·마이페이지가 이 값을 읽는다.
+  void updateNickname(String nickname) {
+    final user = state.user;
+    if (user == null) return;
+    state = AuthState(
+      status: state.status,
+      user: AuthUser(userId: user.userId, nickname: nickname),
+    );
+  }
+
+  /// 회원 탈퇴(사양서 R11). 성공하면 `null`, 실패하면 사용자에게 보일 메시지를 돌려준다.
+  ///
+  /// 서버가 전 기기 세션을 지우고 만료 쿠키를 내리므로 [SessionInterceptor] 가 로컬 세션도 함께
+  /// 폐기하지만, 쿠키가 오지 않는 경우를 대비해 여기서 한 번 더 지운다. 화면 이동은 하지 않는다 —
+  /// 인증 상태가 비면 redirect 가 `/login` 으로 보낸다.
+  Future<String?> deleteAccount() async {
+    try {
+      await ref.read(userRepositoryProvider).deleteAccount();
+    } on ApiException catch (error) {
+      return error.userMessage;
+    }
+    await ref.read(sessionStoreProvider).clear();
+    state = const AuthState.signedOut();
+    return null;
+  }
+
   /// 오류 배너를 닫는다.
   void dismissError() {
     if (state.status == AuthStatus.failed) state = const AuthState.signedOut();

--- a/mobile/lib/features/market/candle_chart.dart
+++ b/mobile/lib/features/market/candle_chart.dart
@@ -1,0 +1,349 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/format/formatters.dart';
+import '../../core/realtime/ticker_store.dart';
+import '../../core/theme/theme.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../models/candle.dart';
+import 'candle_painter.dart';
+import 'candle_repository.dart';
+import 'candle_scale.dart';
+import 'live_candles.dart';
+
+/// 실시간 봉의 소유자. **Riverpod 은 이 객체를 들고만 있고 틱은 통과하지 않는다** — 접기는
+/// `TickerStore` 가 매 틱 동기로 호출한다(계획서 §5.4 ②).
+///
+/// 관찰자는 하나뿐이다. 코인 상세와 가로 풀스크린이 같은 [CandleRequest] 를 쓰면 같은 폴더를
+/// 공유하고, 간격이 바뀌면 새 폴더가 관찰자 자리를 넘겨받는다.
+final liveCandleFolderProvider = Provider.autoDispose
+    .family<LiveCandleFolder, CandleRequest>((ref, request) {
+      final store = ref.watch(tickerStoreProvider);
+      final folder = LiveCandleFolder(request);
+      store.setRawObserver(folder);
+      ref.onDispose(() {
+        store.clearRawObserver(folder);
+        folder.dispose();
+      });
+      return folder;
+    });
+
+/// REST 캔들과 STOMP 티커를 함께 소비한다(사양서 §4.3.1). 정적 차트가 아니다.
+class CandleChart extends ConsumerStatefulWidget {
+  const CandleChart({
+    super.key,
+    required this.request,
+    required this.baseCurrency,
+  });
+
+  final CandleRequest request;
+  final String baseCurrency;
+
+  @override
+  ConsumerState<CandleChart> createState() => _CandleChartState();
+}
+
+class _CandleChartState extends ConsumerState<CandleChart> {
+  final ValueNotifier<int?> _crosshair = ValueNotifier(null);
+
+  late CandleViewport _viewport = CandleViewport(
+    visibleCount: widget.request.visibleCount,
+  );
+  late CandleViewport _gestureBase = _viewport;
+
+  List<Candle> _server = const [];
+  LiveCandleFolder? _folder;
+  Timer? _reconcile;
+  Size _size = Size.zero;
+  int _panAnchorEnd = 0;
+  double _panDx = 0;
+  bool _pinching = false;
+
+  @override
+  void dispose() {
+    _reconcile?.cancel();
+    _folder?.openedBucket.removeListener(_onBucketOpened);
+    _crosshair.dispose();
+    super.dispose();
+  }
+
+  MergedCandles get _merged =>
+      MergedCandles(_server, _folder?.live ?? const []);
+
+  void _bind(LiveCandleFolder folder) {
+    if (identical(_folder, folder)) return;
+    _folder?.openedBucket.removeListener(_onBucketOpened);
+    _folder = folder;
+    folder.openedBucket.addListener(_onBucketOpened);
+  }
+
+  /// 봉이 새로 열렸다 = 직전 봉이 닫혔다. 같은 봉 안에서 체결이 아무리 많이 들어와도
+  /// 재조회는 예약되지 않는다 — 타이머는 틱이 아니라 봉을 따라간다(사양서 §4.3.6).
+  void _onBucketOpened() {
+    _reconcile?.cancel();
+    if (_folder?.openedBucket.value == null) return;
+    _reconcile = Timer(kReconcileDelay, () {
+      if (mounted) ref.invalidate(candlesProvider(widget.request));
+    });
+  }
+
+  void _onScaleStart(ScaleStartDetails details) {
+    _gestureBase = _viewport;
+    _panAnchorEnd = _viewport.endIndexOf(_merged.length);
+    _panDx = 0;
+    _pinching = false;
+  }
+
+  void _onScaleUpdate(ScaleUpdateDetails details) {
+    final merged = _merged;
+    final total = merged.length;
+    if (total == 0) return;
+
+    if (details.pointerCount >= 2) {
+      _pinching = true;
+      final plotWidth = math.max(1.0, _size.width - kChartPadding.horizontal);
+      final ratio = ((details.localFocalPoint.dx - kChartPadding.left) /
+              plotWidth)
+          .clamp(0.0, 1.0);
+      final next = _gestureBase.zoom(
+        total: total,
+        scale: details.scale,
+        focusRatio: ratio,
+      );
+      _apply(next);
+      return;
+    }
+    if (_pinching) return;
+
+    _panDx += details.focalPointDelta.dx;
+    final scale = _scaleOf(merged, total);
+    _apply(
+      _viewport.withEnd(_panAnchorEnd - scale.movedCandles(_panDx), total),
+    );
+  }
+
+  void _apply(CandleViewport next) {
+    if (next.visibleCount == _viewport.visibleCount &&
+        next.anchorEndIndex == _viewport.anchorEndIndex &&
+        next.followingLatest == _viewport.followingLatest) {
+      return;
+    }
+    setState(() => _viewport = next);
+  }
+
+  CandleScale _scaleOf(MergedCandles merged, int total) => CandleScale.of(
+    _size,
+    kChartPadding,
+    merged.slice(_viewport.startIndexOf(total), _viewport.endIndexOf(total)),
+  );
+
+  void _moveCrosshair(Offset local) {
+    final merged = _merged;
+    final total = merged.length;
+    if (total == 0) return;
+
+    if (local.dy < kChartPadding.top - 8 ||
+        local.dy > _size.height - kChartPadding.bottom + 8) {
+      _crosshair.value = null;
+      return;
+    }
+
+    final start = _viewport.startIndexOf(total);
+    final hit = _scaleOf(merged, total).hitTest(local.dx);
+    _crosshair.value = hit == null ? null : start + hit;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final candles = ref.watch(candlesProvider(widget.request));
+    final data = candles.valueOrNull;
+    // 재조회가 실패하거나 빈 배열이면 아무것도 하지 않는다 — 실시간 봉이 자리를 지킨다.
+    if (data != null && data.isNotEmpty) _server = data;
+
+    _bind(ref.watch(liveCandleFolderProvider(widget.request)));
+    final theme = CandleChartTheme.of(context, widget.baseCurrency);
+    final empty = _server.isEmpty && _folder!.live.isEmpty;
+
+    return Column(
+      children: [
+        SizedBox(height: 44, child: _tooltip(context)),
+        Expanded(
+          child: empty
+              ? Center(
+                  child: candles.isLoading
+                      ? const CircularProgressIndicator()
+                      : Text(
+                          '캔들 데이터가 부족합니다',
+                          style: Theme.of(context).textTheme.labelMedium
+                              ?.copyWith(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                              ),
+                        ),
+                )
+              : _chart(theme),
+        ),
+      ],
+    );
+  }
+
+  Widget _chart(CandleChartTheme theme) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        _size = Size(constraints.maxWidth, constraints.maxHeight);
+
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onScaleStart: _onScaleStart,
+          onScaleUpdate: _onScaleUpdate,
+          onLongPressStart: (details) => _moveCrosshair(details.localPosition),
+          onLongPressMoveUpdate: (details) =>
+              _moveCrosshair(details.localPosition),
+          onLongPressEnd: (_) => _crosshair.value = null,
+          onLongPressCancel: () => _crosshair.value = null,
+          child: Stack(
+            children: [
+              RepaintBoundary(
+                child: ValueListenableBuilder<int>(
+                  valueListenable: _folder!.revision,
+                  builder: (context, revision, child) {
+                    final merged = _merged;
+                    final total = merged.length;
+                    final start = _viewport.startIndexOf(total);
+                    final end = _viewport.endIndexOf(total);
+                    return CustomPaint(
+                      size: _size,
+                      painter: CandlePainter(
+                        server: _server,
+                        visible: merged.slice(start, end),
+                        startIndex: start,
+                        endIndex: end,
+                        liveVisible: end > merged.liveFromIndex,
+                        revision: revision,
+                        interval: widget.request.interval,
+                        theme: theme,
+                      ),
+                    );
+                  },
+                ),
+              ),
+              // 크로스헤어가 움직여도 캔들 레이어는 다시 칠하지 않는다(그 반대도 마찬가지다).
+              RepaintBoundary(
+                child: ListenableBuilder(
+                  listenable: Listenable.merge([_folder!.revision, _crosshair]),
+                  builder: (context, child) {
+                    final index = _crosshair.value;
+                    final merged = _merged;
+                    final total = merged.length;
+                    final start = _viewport.startIndexOf(total);
+                    final end = _viewport.endIndexOf(total);
+                    return CustomPaint(
+                      size: _size,
+                      painter: CrosshairPainter(
+                        visible: index == null
+                            ? const []
+                            : merged.slice(start, end),
+                        index: index == null ? null : index - start,
+                        revision: _folder!.revision.value,
+                        theme: theme,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  /// 툴팁은 차트 위 **고정 패널**이다. 손가락이 가리는 자리에 띄우지 않는다.
+  Widget _tooltip(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ValueListenableBuilder<int?>(
+      valueListenable: _crosshair,
+      builder: (context, index, child) {
+        final merged = _merged;
+        if (index == null || index < 0 || index >= merged.length) {
+          return Align(
+            alignment: Alignment.centerLeft,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: TryptoSpacing.screen,
+              ),
+              child: Text(
+                '길게 눌러 시세를 확인하세요',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          );
+        }
+
+        final candle = merged[index];
+        return Container(
+          margin: const EdgeInsets.symmetric(horizontal: TryptoSpacing.screen),
+          padding: const EdgeInsets.symmetric(horizontal: TryptoSpacing.sm),
+          decoration: BoxDecoration(
+            color: TryptoPalette.secondary,
+            borderRadius: BorderRadius.circular(TryptoRadius.md),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                flex: 3,
+                child: Text(
+                  _stamp(candle.time),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.labelSmall,
+                ),
+              ),
+              for (final (label, value) in [
+                ('시', candle.open),
+                ('고', candle.high),
+                ('저', candle.low),
+                ('종', candle.close),
+              ])
+                Expanded(
+                  flex: 4,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Text(
+                        label,
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      const SizedBox(width: 2),
+                      Flexible(
+                        child: NumericText(
+                          formatCurrencyCompact(value, widget.baseCurrency),
+                          size: 11,
+                          weight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  String _stamp(DateTime time) {
+    String two(int value) => value.toString().padLeft(2, '0');
+    return '${two(time.year % 100)}.${two(time.month)}.${two(time.day)} '
+        '${two(time.hour)}:${two(time.minute)}';
+  }
+}

--- a/mobile/lib/features/market/candle_painter.dart
+++ b/mobile/lib/features/market/candle_painter.dart
@@ -1,0 +1,289 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../core/format/formatters.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../models/candle.dart';
+import '../../models/enums.dart';
+import 'candle_scale.dart';
+
+/// 페인터가 쓰는 색·서체. `BuildContext` 는 페인트 시점에 없다.
+@immutable
+class CandleChartTheme {
+  const CandleChartTheme({
+    required this.positive,
+    required this.negative,
+    required this.grid,
+    required this.label,
+    required this.crosshair,
+    required this.baseCurrency,
+  });
+
+  factory CandleChartTheme.of(BuildContext context, String baseCurrency) {
+    final colors = context.tryptoColors;
+    return CandleChartTheme(
+      positive: colors.positive,
+      negative: colors.negative,
+      grid: TryptoPalette.border,
+      label: TryptoPalette.mutedForeground,
+      crosshair: TryptoPalette.foreground,
+      baseCurrency: baseCurrency,
+    );
+  }
+
+  final Color positive;
+  final Color negative;
+  final Color grid;
+  final Color label;
+  final Color crosshair;
+  final String baseCurrency;
+
+  @override
+  bool operator ==(Object other) =>
+      other is CandleChartTheme &&
+      other.positive == positive &&
+      other.negative == negative &&
+      other.grid == grid &&
+      other.label == label &&
+      other.crosshair == crosshair &&
+      other.baseCurrency == baseCurrency;
+
+  @override
+  int get hashCode =>
+      Object.hash(positive, negative, grid, label, crosshair, baseCurrency);
+}
+
+/// 캔들·격자·축. 크로스헤어는 별개 레이어다 — 손가락이 움직여도 이 레이어는 다시 칠하지
+/// 않는다.
+class CandlePainter extends CustomPainter {
+  const CandlePainter({
+    required this.server,
+    required this.visible,
+    required this.startIndex,
+    required this.endIndex,
+    required this.liveVisible,
+    required this.revision,
+    required this.interval,
+    required this.theme,
+  });
+
+  /// 서버 캔들 배열의 **참조**. 재조회로 교체되면 다시 칠한다.
+  final List<Candle> server;
+  final List<Candle> visible;
+  final int startIndex;
+  final int endIndex;
+
+  /// 실시간 값이 반영된 봉이 표시 구간 안에 있는가.
+  final bool liveVisible;
+  final int revision;
+  final CandleInterval interval;
+  final CandleChartTheme theme;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (visible.isEmpty) return;
+    final scale = CandleScale.of(size, kChartPadding, visible);
+
+    _paintGrid(canvas, size, scale);
+    _paintCandles(canvas, scale);
+    _paintTimeAxis(canvas, size, scale);
+  }
+
+  void _paintGrid(Canvas canvas, Size size, CandleScale scale) {
+    final line = Paint()
+      ..color = theme.grid
+      ..strokeWidth = 1;
+    final step = (scale.paddedMax - scale.paddedMin) / 3;
+
+    for (var i = 0; i < 4; i++) {
+      final price = scale.paddedMax - step * i;
+      final y = scale.getY(price);
+      _dashedLine(
+        canvas,
+        Offset(kChartPadding.left, y),
+        Offset(size.width - kChartPadding.right, y),
+        line,
+        dash: 4,
+        gap: 6,
+      );
+      final label = _text(
+        formatCurrencyCompact(price, theme.baseCurrency),
+        theme.label,
+      );
+      label.paint(
+        canvas,
+        Offset(size.width - kChartPadding.right + 6, y - label.height / 2),
+      );
+    }
+  }
+
+  void _paintCandles(Canvas canvas, CandleScale scale) {
+    final wick = Paint()
+      ..strokeWidth = 1.6
+      ..strokeCap = StrokeCap.round;
+    final body = Paint()..style = PaintingStyle.fill;
+
+    for (var i = 0; i < visible.length; i++) {
+      final candle = visible[i];
+      final color = candle.close >= candle.open ? theme.positive : theme.negative;
+      wick.color = color;
+      body.color = color;
+
+      final x = scale.getX(i);
+      canvas.drawLine(
+        Offset(x, scale.getY(candle.high)),
+        Offset(x, scale.getY(candle.low)),
+        wick,
+      );
+
+      final openY = scale.getY(candle.open);
+      final closeY = scale.getY(candle.close);
+      final top = math.min(openY, closeY);
+      // 시가와 종가가 같아도 한 줄은 보여야 한다.
+      final height = math.max(2.0, (closeY - openY).abs());
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromLTWH(
+            x - scale.candleWidth / 2,
+            top,
+            scale.candleWidth,
+            height,
+          ),
+          const Radius.circular(2),
+        ),
+        body,
+      );
+    }
+  }
+
+  void _paintTimeAxis(Canvas canvas, Size size, CandleScale scale) {
+    final step = math.max(1, visible.length ~/ 4);
+    final y = size.height - kChartPadding.bottom + 4;
+
+    for (var i = 0; i < visible.length; i++) {
+      if (i % step != 0 && i != visible.length - 1) continue;
+      final label = _text(_timeLabel(visible[i].time), theme.label);
+      final x = (scale.getX(i) - label.width / 2).clamp(
+        0.0,
+        size.width - label.width,
+      );
+      label.paint(canvas, Offset(x, y));
+    }
+  }
+
+  String _timeLabel(DateTime time) {
+    String two(int value) => value.toString().padLeft(2, '0');
+    return switch (interval) {
+      CandleInterval.minute1 => '${two(time.hour)}:${two(time.minute)}',
+      CandleInterval.hour1 ||
+      CandleInterval.hour4 => '${time.month}/${time.day} ${time.hour}시',
+      CandleInterval.month1 => '${two(time.year % 100)}. ${time.month}',
+      CandleInterval.day1 || CandleInterval.week1 => '${time.month}/${time.day}',
+    };
+  }
+
+  @override
+  bool shouldRepaint(CandlePainter old) {
+    if (!identical(old.server, server) ||
+        old.startIndex != startIndex ||
+        old.endIndex != endIndex ||
+        old.interval != interval ||
+        old.liveVisible != liveVisible ||
+        old.theme != theme) {
+      return true;
+    }
+    // 실시간 봉이 표시 구간 밖이면 값이 바뀌어도 그림이 같다. y 스케일도 보이는 구간만으로
+    // 정해지므로 결과가 동일하다 — 초당 수백 틱에서 repaint 가 0이 된다.
+    if (!liveVisible) return false;
+    return old.revision != revision;
+  }
+}
+
+/// 크로스헤어. 캔들 레이어와 분리되어 있어 틱이 와도(값이 바뀌어도) 손가락이 없으면 아예
+/// 칠하지 않는다.
+class CrosshairPainter extends CustomPainter {
+  const CrosshairPainter({
+    required this.visible,
+    required this.index,
+    required this.revision,
+    required this.theme,
+  });
+
+  final List<Candle> visible;
+
+  /// 표시 구간 안의 인덱스. null 이면 아무것도 그리지 않는다.
+  final int? index;
+  final int revision;
+  final CandleChartTheme theme;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final i = index;
+    if (i == null || i < 0 || i >= visible.length) return;
+
+    final scale = CandleScale.of(size, kChartPadding, visible);
+    final candle = visible[i];
+    final x = scale.getX(i);
+    final y = scale.getY(candle.close);
+
+    final vertical = Paint()
+      ..color = theme.crosshair.withValues(alpha: 0.24)
+      ..strokeWidth = 1;
+    final horizontal = Paint()
+      ..color = theme.crosshair.withValues(alpha: 0.16)
+      ..strokeWidth = 1;
+
+    _dashedLine(
+      canvas,
+      Offset(x, kChartPadding.top),
+      Offset(x, size.height - kChartPadding.bottom),
+      vertical,
+      dash: 4,
+      gap: 4,
+    );
+    _dashedLine(
+      canvas,
+      Offset(kChartPadding.left, y),
+      Offset(size.width - kChartPadding.right, y),
+      horizontal,
+      dash: 4,
+      gap: 4,
+    );
+  }
+
+  @override
+  bool shouldRepaint(CrosshairPainter old) {
+    if (old.index != index || old.theme != theme) return true;
+    if (index == null) return false;
+    return old.revision != revision || old.visible.length != visible.length;
+  }
+}
+
+void _dashedLine(
+  Canvas canvas,
+  Offset from,
+  Offset to,
+  Paint paint, {
+  required double dash,
+  required double gap,
+}) {
+  final total = (to - from).distance;
+  if (total <= 0) return;
+  final unit = (to - from) / total;
+  var drawn = 0.0;
+  while (drawn < total) {
+    final end = math.min(drawn + dash, total);
+    canvas.drawLine(from + unit * drawn, from + unit * end, paint);
+    drawn = end + gap;
+  }
+}
+
+TextPainter _text(String value, Color color) => TextPainter(
+  text: TextSpan(
+    text: value,
+    style: TryptoText.numeric(size: 10, weight: FontWeight.w500, color: color),
+  ),
+  textDirection: TextDirection.ltr,
+)..layout();

--- a/mobile/lib/features/market/candle_repository.dart
+++ b/mobile/lib/features/market/candle_repository.dart
@@ -6,6 +6,7 @@ import '../../core/api/api_exception.dart';
 import '../../core/api/query.dart';
 import '../../models/candle.dart';
 import '../../models/enums.dart';
+import 'live_candles.dart';
 
 class CandleRepository {
   const CandleRepository(this._dio);
@@ -43,3 +44,20 @@ class CandleRepository {
 final candleRepositoryProvider = Provider<CandleRepository>(
   (ref) => CandleRepository(ref.watch(dioProvider)),
 );
+
+/// 서버 캔들만 담는다. 저빈도(진입·간격 변경·15초 재조정)이므로 Riverpod 그래프를 탄다 —
+/// 실시간 봉은 `LiveCandleFolder` 가 따로 들고 있다(계획서 §5.4 ①).
+///
+/// 키가 [CandleRequest] 이므로 코인·거래소·간격이 바뀌면 이전 캔들이 화면에 남지 않는다.
+final candlesProvider = FutureProvider.autoDispose
+    .family<List<Candle>, CandleRequest>((ref, request) async {
+      final candles = await ref
+          .watch(candleRepositoryProvider)
+          .getCandles(
+            exchange: request.exchangeCode,
+            coin: request.symbol,
+            interval: request.interval,
+            limit: request.limit,
+          );
+      return normalizeCandles(candles, request.interval);
+    });

--- a/mobile/lib/features/market/candle_scale.dart
+++ b/mobile/lib/features/market/candle_scale.dart
@@ -1,0 +1,159 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+
+import '../../models/candle.dart';
+import 'live_candles.dart';
+
+/// 오른쪽은 y축 가격 라벨 자리다. 웹의 124px 은 960px 캔버스 기준이며 모바일 폭에서는 화면의
+/// 1/3 을 먹는다.
+const EdgeInsets kChartPadding = EdgeInsets.only(
+  left: 20,
+  top: 16,
+  right: 60,
+  bottom: 22,
+);
+
+/// 스케일·히트테스트를 위젯 없이 테스트하기 위한 순수 함수 묶음(사양서 §4.3.3).
+///
+/// 서버 캔들이 아니라 **합성 결과의 표시 구간**에 대해 매번 다시 계산한다 — 실시간 봉의
+/// 고가·저가가 바뀌면 y 스케일도 함께 바뀐다.
+class CandleScale {
+  factory CandleScale.of(Size size, EdgeInsets padding, List<Candle> visible) {
+    var minPrice = double.infinity;
+    var maxPrice = -double.infinity;
+    for (final candle in visible) {
+      if (candle.low < minPrice) minPrice = candle.low;
+      if (candle.high > maxPrice) maxPrice = candle.high;
+    }
+    if (visible.isEmpty) {
+      minPrice = 0;
+      maxPrice = 1;
+    }
+
+    // range = (max - min) || (max × 0.02) || 1 — 웹의 falsy 연쇄를 그대로 옮긴다.
+    var range = maxPrice - minPrice;
+    if (range <= 0) range = maxPrice * 0.02;
+    if (range <= 0) range = 1;
+
+    final plotWidth = math.max(1.0, size.width - padding.horizontal);
+    final plotHeight = math.max(1.0, size.height - padding.vertical);
+    final count = visible.length;
+    final slotWidth = count == 0 ? plotWidth : plotWidth / count;
+
+    return CandleScale._(
+      padding: padding,
+      count: count,
+      plotWidth: plotWidth,
+      plotHeight: plotHeight,
+      slotWidth: slotWidth,
+      candleWidth: (slotWidth * 0.62).clamp(6.0, 16.0),
+      paddedMin: math.max(0, minPrice - range * 0.08),
+      paddedMax: maxPrice + range * 0.08,
+    );
+  }
+
+  const CandleScale._({
+    required this.padding,
+    required this.count,
+    required this.plotWidth,
+    required this.plotHeight,
+    required this.slotWidth,
+    required this.candleWidth,
+    required this.paddedMin,
+    required this.paddedMax,
+  });
+
+  final EdgeInsets padding;
+  final int count;
+  final double plotWidth;
+  final double plotHeight;
+  final double slotWidth;
+  final double candleWidth;
+  final double paddedMin;
+  final double paddedMax;
+
+  double getX(int index) => padding.left + (index + 0.5) * slotWidth;
+
+  double getY(double price) {
+    final span = paddedMax - paddedMin;
+    if (span <= 0) return padding.top + plotHeight;
+    return padding.top + (1 - (price - paddedMin) / span) * plotHeight;
+  }
+
+  /// 표시 구간 안의 인덱스. 허용 오차는 `candleWidth` 가 아니라 **`slotWidth`** 다 — 손가락이
+  /// 캔들을 가리므로 웹보다 넓혀야 한다(계획서 §5.4).
+  int? hitTest(double x) {
+    if (count == 0) return null;
+    final index = ((x - padding.left) / slotWidth - 0.5).round();
+    if (index < 0 || index >= count) return null;
+    if ((x - getX(index)).abs() > slotWidth) return null;
+    return index;
+  }
+
+  /// 드래그 거리를 캔들 개수로 바꾼다.
+  int movedCandles(double dx) => (dx / slotWidth).round();
+}
+
+/// 표시 구간(사양서 §4.3.8). 최신 봉 추종은 여기서 결정된다.
+@immutable
+class CandleViewport {
+  const CandleViewport({
+    required this.visibleCount,
+    this.anchorEndIndex = 0,
+    this.followingLatest = true,
+  });
+
+  final int visibleCount;
+  final int anchorEndIndex;
+
+  /// 참이면 오른쪽 끝은 항상 마지막 봉이다. 새 봉이 열리면 화면이 저절로 따라간다.
+  final bool followingLatest;
+
+  /// `min` 이 재조정으로 서버 캔들 수가 줄어드는 경우를 막는다.
+  int endIndexOf(int total) =>
+      followingLatest ? total : math.min(anchorEndIndex, total);
+
+  int countOf(int total) => math.min(visibleCount, total);
+
+  int startIndexOf(int total) =>
+      math.max(0, endIndexOf(total) - countOf(total));
+
+  /// 오른쪽 끝까지 되밀면 추종이 자동으로 재개된다.
+  CandleViewport withEnd(int end, int total) {
+    final count = countOf(total);
+    final bounded = end.clamp(count, math.max(count, total)).toInt();
+    return CandleViewport(
+      visibleCount: visibleCount,
+      anchorEndIndex: bounded,
+      followingLatest: bounded >= total,
+    );
+  }
+
+  /// 앵커가 화면에서 차지하던 비율을 유지한 채 확대·축소한다. [scale] > 1 이면 확대(표시
+  /// 개수 감소)다. [focusRatio] 는 플롯 폭 안에서의 손가락 위치 비율이다.
+  CandleViewport zoom({
+    required int total,
+    required double scale,
+    required double focusRatio,
+  }) {
+    if (total == 0 || scale <= 0) return this;
+
+    final minVisible = math.min(kMinVisibleCount, total);
+    final nextCount = (visibleCount / scale).round().clamp(minVisible, total);
+    final start = startIndexOf(total);
+    final count = countOf(total);
+    final anchor = start + focusRatio * count;
+
+    var end = (anchor - focusRatio * nextCount).round() + nextCount;
+    if (end > total) end = total;
+    if (end < nextCount) end = nextCount;
+
+    return CandleViewport(
+      visibleCount: nextCount,
+      anchorEndIndex: end,
+      followingLatest: end >= total,
+    );
+  }
+}

--- a/mobile/lib/features/market/chart_fullscreen_page.dart
+++ b/mobile/lib/features/market/chart_fullscreen_page.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/constants/exchanges.dart';
+import '../../core/theme/theme.dart';
+import '../../models/enums.dart';
+import 'candle_chart.dart';
+import 'coin_detail_page.dart';
+import 'live_candles.dart';
+
+/// 가로 풀스크린. 같은 [CandleRequest] 를 쓰면 코인 상세와 **같은 `LiveCandleFolder`** 를
+/// 공유하므로 진행 중인 봉이 끊기지 않는다.
+class ChartFullscreenPage extends ConsumerStatefulWidget {
+  const ChartFullscreenPage({
+    super.key,
+    required this.symbol,
+    required this.interval,
+  });
+
+  final String symbol;
+  final CandleInterval interval;
+
+  @override
+  ConsumerState<ChartFullscreenPage> createState() =>
+      _ChartFullscreenPageState();
+}
+
+class _ChartFullscreenPageState extends ConsumerState<ChartFullscreenPage> {
+  late CandleInterval _interval = widget.interval;
+
+  @override
+  void initState() {
+    super.initState();
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.landscapeLeft,
+      DeviceOrientation.landscapeRight,
+    ]);
+  }
+
+  @override
+  void dispose() {
+    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final exchange = ExchangeIds.byKey(
+      GoRouterState.of(context).uri.queryParameters['exchange'],
+    );
+    final request = CandleRequest(
+      exchangeCode: exchange.candleCode,
+      symbol: widget.symbol,
+      interval: _interval,
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('${widget.symbol} · ${exchange.name}'),
+        titleTextStyle: Theme.of(context).textTheme.titleMedium,
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            IntervalChips(
+              interval: _interval,
+              onChanged: (interval) => setState(() => _interval = interval),
+            ),
+            const SizedBox(height: TryptoSpacing.xs),
+            Expanded(
+              child: RepaintBoundary(
+                child: CandleChart(
+                  key: ValueKey(request),
+                  request: request,
+                  baseCurrency: exchange.baseCurrency,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/market/coin_detail_page.dart
+++ b/mobile/lib/features/market/coin_detail_page.dart
@@ -14,9 +14,13 @@ import '../../core/widgets/empty_view.dart';
 import '../../core/widgets/numeric_text.dart';
 import '../../core/widgets/profit_badge.dart';
 import '../../models/enums.dart';
+import '../round/round_controller.dart';
 import 'candle_chart.dart';
 import 'live_candles.dart';
 import 'market_controller.dart';
+import 'order_history_tab.dart';
+import 'order_sheet.dart';
+import 'order_target.dart';
 
 /// 마켓 셸 브랜치 **위로** push 된다. 마켓 탭은 계속 선택 상태이므로 `TickerStore` 가 살아
 /// 있고 차트는 별도로 토픽을 구독하지 않는다(계획서 §5.4).
@@ -32,12 +36,21 @@ class CoinDetailPage extends ConsumerStatefulWidget {
 class _CoinDetailPageState extends ConsumerState<CoinDetailPage> {
   CandleInterval _interval = CandleInterval.day1;
 
+  /// 주문이 나갈 때마다 올린다. 거래내역 탭이 이 값을 보고 다시 읽는다 — 체결 이벤트 큐는
+  /// 서버에서 동작하지 않으므로(사양서 R3) 반영은 전부 REST 재조회다.
+  int _revision = 0;
+
+  void _refresh() => setState(() => _revision++);
+
   @override
   Widget build(BuildContext context) {
     final exchange = ExchangeIds.byKey(
       GoRouterState.of(context).uri.queryParameters['exchange'],
     );
     final coins = ref.watch(marketCoinsProvider(exchange.id));
+    final walletId = ref.watch(
+      roundControllerProvider.select((round) => round.walletIdOf(exchange.id)),
+    );
 
     return Scaffold(
       appBar: AppBar(
@@ -66,41 +79,205 @@ class _CoinDetailPageState extends ConsumerState<CoinDetailPage> {
             );
           }
 
-          final request = CandleRequest(
-            exchangeCode: exchange.candleCode,
+          final resolution = resolveOrderTarget(
+            exchange: exchange,
             symbol: entry.symbol,
-            interval: _interval,
+            walletId: walletId,
+            coins: data,
           );
 
-          return Column(
-            children: [
-              // 헤더는 티커가 올 때마다 갱신되고 캔들 레이어는 실시간 봉이 보일 때만 다시
-              // 칠해진다. 경계가 없으면 헤더 한 줄이 200개 캔들을 다시 칠한다.
-              RepaintBoundary(
-                child: CoinDetailHeader(
-                  entry: entry,
-                  row: ref.watch(tickerStoreProvider).row(entry.symbol),
-                  baseCurrency: exchange.baseCurrency,
-                ),
-              ),
-              IntervalChips(
-                interval: _interval,
-                onChanged: (interval) => setState(() => _interval = interval),
-              ),
-              Expanded(
-                child: RepaintBoundary(
-                  child: CandleChart(
-                    key: ValueKey(request),
-                    request: request,
+          return DefaultTabController(
+            length: 2,
+            child: Column(
+              children: [
+                // 헤더는 티커가 올 때마다 갱신되고 캔들 레이어는 실시간 봉이 보일 때만 다시
+                // 칠해진다. 경계가 없으면 헤더 한 줄이 200개 캔들을 다시 칠한다.
+                RepaintBoundary(
+                  child: CoinDetailHeader(
+                    entry: entry,
+                    row: ref.watch(tickerStoreProvider).row(entry.symbol),
                     baseCurrency: exchange.baseCurrency,
                   ),
                 ),
-              ),
-            ],
+                const TabBar(tabs: [Tab(text: '차트'), Tab(text: '거래내역')]),
+                Expanded(
+                  child: TabBarView(
+                    children: [
+                      _ChartTab(
+                        entry: entry,
+                        exchange: exchange,
+                        interval: _interval,
+                        onInterval: (interval) =>
+                            setState(() => _interval = interval),
+                      ),
+                      if (resolution.target case final target?)
+                        OrderHistoryTab(
+                          target: target,
+                          symbol: entry.symbol,
+                          revision: _revision,
+                        )
+                      else
+                        _TargetFailureView(failure: resolution.failure!),
+                    ],
+                  ),
+                ),
+                _OrderCta(
+                  target: resolution.target,
+                  failure: resolution.failure,
+                  entry: entry,
+                  onPlaced: _refresh,
+                ),
+              ],
+            ),
           );
         },
       ),
     );
+  }
+}
+
+class _ChartTab extends StatelessWidget {
+  const _ChartTab({
+    required this.entry,
+    required this.exchange,
+    required this.interval,
+    required this.onInterval,
+  });
+
+  final CoinEntry entry;
+  final Exchange exchange;
+  final CandleInterval interval;
+  final ValueChanged<CandleInterval> onInterval;
+
+  @override
+  Widget build(BuildContext context) {
+    final request = CandleRequest(
+      exchangeCode: exchange.candleCode,
+      symbol: entry.symbol,
+      interval: interval,
+    );
+
+    return Column(
+      children: [
+        IntervalChips(interval: interval, onChanged: onInterval),
+        Expanded(
+          child: RepaintBoundary(
+            child: CandleChart(
+              key: ValueKey(request),
+              request: request,
+              baseCurrency: exchange.baseCurrency,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// 하단 고정 CTA 2개(계획서 §4.6.1). 주문 대상이 해석되지 않으면 사유를 알리고 비활성한다 —
+/// 라운드가 없어도 시세 조회는 계속되고 **주문만** 막힌다.
+class _OrderCta extends StatelessWidget {
+  const _OrderCta({
+    required this.target,
+    required this.failure,
+    required this.entry,
+    required this.onPlaced,
+  });
+
+  final OrderTarget? target;
+  final OrderTargetFailure? failure;
+  final CoinEntry entry;
+  final VoidCallback onPlaced;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+    final resolved = target;
+
+    Widget button(Side side) {
+      final buy = side == Side.buy;
+      final color = buy ? colors.positive : colors.negative;
+
+      return Expanded(
+        child: SizedBox(
+          height: 48,
+          child: FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: color,
+              foregroundColor: Colors.white,
+              disabledBackgroundColor: color.withValues(alpha: 0.4),
+              disabledForegroundColor: Colors.white,
+            ),
+            onPressed: resolved == null
+                ? null
+                : () => showOrderSheet(
+                    context,
+                    target: resolved,
+                    entry: entry,
+                    side: side,
+                    onPlaced: onPlaced,
+                  ),
+            child: Text(buy ? '매수' : '매도'),
+          ),
+        ),
+      );
+    }
+
+    return SafeArea(
+      top: false,
+      child: Container(
+        padding: const EdgeInsets.all(TryptoSpacing.screen),
+        decoration: const BoxDecoration(
+          color: TryptoPalette.card,
+          border: Border(top: BorderSide(color: TryptoPalette.border)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (failure != null) ...[
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      failure!.message,
+                      style: theme.textTheme.labelMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                  if (failure == OrderTargetFailure.noRound)
+                    TextButton(
+                      style: TryptoButtons.link,
+                      onPressed: () => context.go(Routes.roundNew),
+                      child: const Text('라운드 시작하기'),
+                    ),
+                ],
+              ),
+              const SizedBox(height: TryptoSpacing.sm),
+            ],
+            Row(
+              children: [
+                button(Side.buy),
+                const SizedBox(width: TryptoSpacing.sm),
+                button(Side.sell),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TargetFailureView extends StatelessWidget {
+  const _TargetFailureView({required this.failure});
+
+  final OrderTargetFailure failure;
+
+  @override
+  Widget build(BuildContext context) {
+    return EmptyView(icon: LucideIcons.receipt, message: failure.message);
   }
 }
 

--- a/mobile/lib/features/market/coin_detail_page.dart
+++ b/mobile/lib/features/market/coin_detail_page.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../core/constants/exchanges.dart';
+import '../../core/format/formatters.dart';
+import '../../core/realtime/ticker_store.dart';
+import '../../core/router/guard.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/async_view.dart';
+import '../../core/widgets/empty_view.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../core/widgets/profit_badge.dart';
+import '../../models/enums.dart';
+import 'candle_chart.dart';
+import 'live_candles.dart';
+import 'market_controller.dart';
+
+/// 마켓 셸 브랜치 **위로** push 된다. 마켓 탭은 계속 선택 상태이므로 `TickerStore` 가 살아
+/// 있고 차트는 별도로 토픽을 구독하지 않는다(계획서 §5.4).
+class CoinDetailPage extends ConsumerStatefulWidget {
+  const CoinDetailPage({super.key, required this.symbol});
+
+  final String symbol;
+
+  @override
+  ConsumerState<CoinDetailPage> createState() => _CoinDetailPageState();
+}
+
+class _CoinDetailPageState extends ConsumerState<CoinDetailPage> {
+  CandleInterval _interval = CandleInterval.day1;
+
+  @override
+  Widget build(BuildContext context) {
+    final exchange = ExchangeIds.byKey(
+      GoRouterState.of(context).uri.queryParameters['exchange'],
+    );
+    final coins = ref.watch(marketCoinsProvider(exchange.id));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.symbol),
+        actions: [
+          IconButton(
+            tooltip: '전체 화면',
+            icon: const Icon(LucideIcons.maximize),
+            onPressed: () => context.push(
+              Routes.coinChart(widget.symbol, exchange.key, _interval.wire),
+            ),
+          ),
+        ],
+      ),
+      body: AsyncView<List<CoinEntry>>(
+        value: coins,
+        onRetry: () => ref.invalidate(marketCoinsProvider(exchange.id)),
+        builder: (data) {
+          final entry = data
+              .where((coin) => coin.symbol == widget.symbol)
+              .firstOrNull;
+          if (entry == null) {
+            return const EmptyView(
+              icon: LucideIcons.circleAlert,
+              message: '이 거래소에 상장되지 않은 코인입니다.',
+            );
+          }
+
+          final request = CandleRequest(
+            exchangeCode: exchange.candleCode,
+            symbol: entry.symbol,
+            interval: _interval,
+          );
+
+          return Column(
+            children: [
+              // 헤더는 티커가 올 때마다 갱신되고 캔들 레이어는 실시간 봉이 보일 때만 다시
+              // 칠해진다. 경계가 없으면 헤더 한 줄이 200개 캔들을 다시 칠한다.
+              RepaintBoundary(
+                child: CoinDetailHeader(
+                  entry: entry,
+                  row: ref.watch(tickerStoreProvider).row(entry.symbol),
+                  baseCurrency: exchange.baseCurrency,
+                ),
+              ),
+              IntervalChips(
+                interval: _interval,
+                onChanged: (interval) => setState(() => _interval = interval),
+              ),
+              Expanded(
+                child: RepaintBoundary(
+                  child: CandleChart(
+                    key: ValueKey(request),
+                    request: request,
+                    baseCurrency: exchange.baseCurrency,
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// 현재가·등락률은 캔들이 아니라 **실시간 티커 값**이다(사양서 §4.3.1).
+class CoinDetailHeader extends StatelessWidget {
+  const CoinDetailHeader({
+    super.key,
+    required this.entry,
+    required this.row,
+    required this.baseCurrency,
+  });
+
+  final CoinEntry entry;
+  final RowNotifier? row;
+  final String baseCurrency;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final notifier = row;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(
+        TryptoSpacing.screen,
+        TryptoSpacing.sm,
+        TryptoSpacing.screen,
+        TryptoSpacing.md,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            entry.name,
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 2),
+          if (notifier == null)
+            _Quote(
+              price: entry.price,
+              changeRate: entry.changeRate,
+              baseCurrency: baseCurrency,
+            )
+          else
+            ValueListenableBuilder<CoinRowState>(
+              valueListenable: notifier,
+              builder: (context, state, child) => _Quote(
+                price: state.price,
+                changeRate: state.changeRate,
+                baseCurrency: baseCurrency,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Quote extends StatelessWidget {
+  const _Quote({
+    required this.price,
+    required this.changeRate,
+    required this.baseCurrency,
+  });
+
+  final double price;
+  final double changeRate;
+  final String baseCurrency;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Flexible(
+          child: NumericText(
+            price <= 0
+                ? '-'
+                : '${getCurrencySymbol(baseCurrency)}'
+                      '${formatPrice(price, baseCurrency)}',
+            size: 24,
+            weight: FontWeight.w700,
+            color: context.profitColor(changeRate),
+          ),
+        ),
+        const SizedBox(width: TryptoSpacing.sm),
+        ProfitBadge(
+          value: changeRate,
+          text: formatChangeRate(changeRate),
+          showTrendIcon: true,
+        ),
+      ],
+    );
+  }
+}
+
+class IntervalChips extends StatelessWidget {
+  const IntervalChips({
+    super.key,
+    required this.interval,
+    required this.onChanged,
+  });
+
+  final CandleInterval interval;
+  final ValueChanged<CandleInterval> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 40,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: TryptoSpacing.screen),
+        children: [
+          for (final entry in candleIntervalSpecs.entries) ...[
+            ChoiceChip(
+              label: Text(entry.value.label),
+              selected: entry.key == interval,
+              onSelected: (_) => onChanged(entry.key),
+            ),
+            const SizedBox(width: TryptoSpacing.xs),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/market/coin_row.dart
+++ b/mobile/lib/features/market/coin_row.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/format/formatters.dart';
+import '../../core/realtime/ticker_store.dart';
 import '../../core/theme/theme.dart';
 import '../../core/theme/trypto_colors.dart';
 import '../../core/widgets/numeric_text.dart';
@@ -14,75 +15,135 @@ const double kCoinRowHeight = 68;
 /// tight 제약을 받은 `RenderBox` 가 relayout boundary 가 된다(계획서 §4.2.5-4).
 const double _kNumericWidth = 160;
 
-/// 행 3분할(계획서 §4.2.5-3): ① 이름 ② 숫자 ③ 플래시 테두리.
+/// 행 3분할(계획서 §4.2.5-3).
 ///
-/// 이름 열은 앱 수명 동안 한 번만 빌드되고, 숫자만 티커를 구독한다. 9단위에서 [CoinNumbers]
-/// 를 `ValueListenableBuilder` 로 감싸면 되고, 이름 열은 그 바깥에 남는다.
+/// ① 이름·심볼은 [ValueListenableBuilder] **바깥**이다 — 목록 수명 동안 한 번만 빌드된다.
+/// ② 숫자 3개는 [RowNotifier] 를 구독한다.
+/// ③ 플래시 테두리는 [FlashNotifier] 를 구독한다. 테두리 깜빡임이 숫자의 레이아웃을 다시
+///    돌리지 않는다.
+///
+/// 행에 `key` 를 주지 않는다(호출부). sliver 자식은 index 슬롯으로 매칭되므로, 키가 있으면
+/// 재정렬 시 `canUpdate == false` 가 되어 Element·State·RenderObject 가 전부 재생성된다.
 class CoinRow extends StatelessWidget {
   const CoinRow({
     super.key,
     required this.symbol,
     required this.name,
-    required this.price,
-    required this.changeRate,
-    required this.volume,
+    required this.row,
+    required this.flash,
     required this.baseCurrency,
+    this.onTap,
   });
 
   final String symbol;
   final String name;
-  final double price;
-  final double changeRate;
-  final double volume;
+  final RowNotifier row;
+  final FlashNotifier flash;
   final String baseCurrency;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return Container(
-      height: kCoinRowHeight,
-      padding: const EdgeInsets.symmetric(horizontal: TryptoSpacing.screen),
-      decoration: const BoxDecoration(
-        border: Border(bottom: BorderSide(color: TryptoPalette.border)),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  symbol,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TryptoText.symbol,
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  name,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        height: kCoinRowHeight,
+        padding: const EdgeInsets.symmetric(horizontal: TryptoSpacing.screen),
+        decoration: const BoxDecoration(
+          border: Border(bottom: BorderSide(color: TryptoPalette.border)),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    symbol,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TryptoText.symbol,
                   ),
-                ),
-              ],
+                  const SizedBox(height: 2),
+                  Text(
+                    name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ),
-          const SizedBox(width: TryptoSpacing.sm),
-          SizedBox(
-            width: _kNumericWidth,
-            child: CoinNumbers(
-              price: price,
-              changeRate: changeRate,
-              volume: volume,
-              baseCurrency: baseCurrency,
+            const SizedBox(width: TryptoSpacing.sm),
+            SizedBox(
+              width: _kNumericWidth,
+              child: Stack(
+                // 테두리가 숫자 바깥(오른쪽 8 · 위아래 10)으로 확장된다. 자르면 안 된다.
+                clipBehavior: Clip.none,
+                children: [
+                  RepaintBoundary(
+                    child: ValueListenableBuilder<CoinRowState>(
+                      valueListenable: row,
+                      builder: (context, state, child) => CoinNumbers(
+                        price: state.price,
+                        changeRate: state.changeRate,
+                        volume: state.volume,
+                        baseCurrency: baseCurrency,
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    left: 0,
+                    right: -8,
+                    top: -10,
+                    bottom: -10,
+                    child: RepaintBoundary(child: _FlashBorder(flash: flash)),
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
+    );
+  }
+}
+
+/// 숫자의 글자색·배경을 바꾸지 않고 **테두리만 잠깐 두른다**. 읽어야 할 숫자가 흔들리지 않게
+/// 하려는 의도적 선택이다(사양서 §3.3.3). 페이드하지 않으므로 `AnimatedContainer` 를 쓰지
+/// 않는다.
+class _FlashBorder extends StatelessWidget {
+  const _FlashBorder({required this.flash});
+
+  final FlashNotifier flash;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.tryptoColors;
+
+    return ValueListenableBuilder<FlashDir?>(
+      valueListenable: flash,
+      builder: (context, dir, child) {
+        if (dir == null) return const SizedBox.shrink();
+        final color = switch (dir) {
+          FlashDir.up => colors.positive,
+          FlashDir.down => colors.negative,
+          FlashDir.same => colors.flashNeutral,
+        };
+        return IgnorePointer(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border.all(color: color),
+              borderRadius: BorderRadius.circular(TryptoRadius.md),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/mobile/lib/features/market/coin_row.dart
+++ b/mobile/lib/features/market/coin_row.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+
+import '../../core/format/formatters.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../core/widgets/profit_badge.dart';
+
+/// `ListView.builder(itemExtent:)` 의 고정 행 높이. 자식을 측정하지 않으므로 스크롤 중 위치
+/// 계산이 O(1) 이다(계획서 §4.2.5).
+const double kCoinRowHeight = 68;
+
+/// 우측 숫자 묶음의 고정 폭. 가격 문자열의 폭이 바뀌어도 이 경계에서 리레이아웃이 멈춘다 —
+/// tight 제약을 받은 `RenderBox` 가 relayout boundary 가 된다(계획서 §4.2.5-4).
+const double _kNumericWidth = 160;
+
+/// 행 3분할(계획서 §4.2.5-3): ① 이름 ② 숫자 ③ 플래시 테두리.
+///
+/// 이름 열은 앱 수명 동안 한 번만 빌드되고, 숫자만 티커를 구독한다. 9단위에서 [CoinNumbers]
+/// 를 `ValueListenableBuilder` 로 감싸면 되고, 이름 열은 그 바깥에 남는다.
+class CoinRow extends StatelessWidget {
+  const CoinRow({
+    super.key,
+    required this.symbol,
+    required this.name,
+    required this.price,
+    required this.changeRate,
+    required this.volume,
+    required this.baseCurrency,
+  });
+
+  final String symbol;
+  final String name;
+  final double price;
+  final double changeRate;
+  final double volume;
+  final String baseCurrency;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      height: kCoinRowHeight,
+      padding: const EdgeInsets.symmetric(horizontal: TryptoSpacing.screen),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: TryptoPalette.border)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  symbol,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TryptoText.symbol,
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: TryptoSpacing.sm),
+          SizedBox(
+            width: _kNumericWidth,
+            child: CoinNumbers(
+              price: price,
+              changeRate: changeRate,
+              volume: volume,
+              baseCurrency: baseCurrency,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 숫자 3개만 그린다. 티커가 바꾸는 것은 이 묶음뿐이다.
+class CoinNumbers extends StatelessWidget {
+  const CoinNumbers({
+    super.key,
+    required this.price,
+    required this.changeRate,
+    required this.volume,
+    required this.baseCurrency,
+  });
+
+  final double price;
+  final double changeRate;
+  final double volume;
+  final String baseCurrency;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // 시세를 아직 받지 못한 코인이 있다(사양서 §4.2.1).
+    final unpriced = price <= 0;
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        NumericText(
+          unpriced
+              ? '-'
+              : '${getCurrencySymbol(baseCurrency)}'
+                    '${formatPrice(price, baseCurrency)}',
+          color: unpriced
+              ? theme.colorScheme.onSurfaceVariant
+              : context.profitColor(changeRate),
+        ),
+        const SizedBox(height: 4),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            // 배지는 내용만큼 넓어진다. 세 자릿수 등락률(+300.00%)이 들어와도 열 밖으로
+            // 밀지 않도록 남은 폭 안에 가둔다.
+            Flexible(
+              child: unpriced
+                  ? NumericText(
+                      '-',
+                      size: 12,
+                      weight: FontWeight.w500,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    )
+                  : ProfitBadge(
+                      value: changeRate,
+                      text: formatChangeRate(changeRate),
+                    ),
+            ),
+            const SizedBox(width: TryptoSpacing.sm),
+            SizedBox(
+              width: 80,
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: NumericText(
+                  // 거래대금은 모바일 폭에 맞춰 억·만으로 축약한다(KRW). USDT 는 그대로다.
+                  volume <= 0
+                      ? '-'
+                      : formatCurrencyCompact(volume, baseCurrency),
+                  size: 12,
+                  weight: FontWeight.w500,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/market/coin_search_field.dart
+++ b/mobile/lib/features/market/coin_search_field.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../core/theme/theme.dart';
+
+/// 초성 질의(`ㅂㅌ`)와 자모 질의(`비트`)를 모두 받는다. 조합 중인 글자도 `onChanged` 로
+/// 그대로 흘러오며, 자모 분해가 자판 입력 순서를 따르므로 그 상태에서도 맞아떨어진다.
+class CoinSearchField extends StatelessWidget {
+  const CoinSearchField({
+    super.key,
+    required this.controller,
+    required this.onChanged,
+  });
+
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      onChanged: onChanged,
+      textInputAction: TextInputAction.search,
+      decoration: InputDecoration(
+        hintText: '코인명/심볼 검색 (초성 가능)',
+        prefixIcon: const Icon(LucideIcons.search, size: 16),
+        prefixIconConstraints: const BoxConstraints(minWidth: 40),
+        suffixIcon: ValueListenableBuilder(
+          valueListenable: controller,
+          builder: (context, value, _) => value.text.isEmpty
+              ? const SizedBox.shrink()
+              : IconButton(
+                  icon: const Icon(LucideIcons.x, size: 16),
+                  tooltip: '지우기',
+                  onPressed: () {
+                    controller.clear();
+                    onChanged('');
+                  },
+                ),
+        ),
+        suffixIconConstraints: const BoxConstraints(minWidth: 40),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: TryptoSpacing.md,
+          vertical: TryptoSpacing.md,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/market/live_candles.dart
+++ b/mobile/lib/features/market/live_candles.dart
@@ -1,0 +1,314 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+
+import '../../core/realtime/ticker_store.dart';
+import '../../models/candle.dart';
+import '../../models/enums.dart';
+import '../../models/ticker.dart';
+
+/// 클라이언트가 들고 있는 실시간 봉의 최대 개수. 봉이 닫혀도 서버 캔들은 InfluxDB 집계 주기
+/// (1분 + 오프셋 10초)만큼 늦게 확정된다. 그동안 실시간 봉이 자리를 지킨다(사양서 §4.3.2).
+const int kLiveCandleLimit = 4;
+
+/// 새 봉이 열린 뒤 서버 캔들을 다시 조회하기까지의 대기 시간.
+const Duration kReconcileDelay = Duration(milliseconds: 15000);
+
+/// 줌인 하한. 표시 개수는 `[12, 전체]` 로 가둔다.
+const int kMinVisibleCount = 12;
+
+class CandleIntervalSpec {
+  const CandleIntervalSpec({
+    required this.label,
+    required this.limit,
+    required this.visibleCount,
+  });
+
+  final String label;
+
+  /// 조회 개수(`limit`). 서버는 1~200 으로 제한한다.
+  final int limit;
+
+  /// 최초 표시 개수.
+  final int visibleCount;
+}
+
+const Map<CandleInterval, CandleIntervalSpec> candleIntervalSpecs = {
+  CandleInterval.minute1: CandleIntervalSpec(
+    label: '1분',
+    limit: 120,
+    visibleCount: 40,
+  ),
+  CandleInterval.hour1: CandleIntervalSpec(
+    label: '1시간',
+    limit: 96,
+    visibleCount: 32,
+  ),
+  CandleInterval.hour4: CandleIntervalSpec(
+    label: '4시간',
+    limit: 84,
+    visibleCount: 28,
+  ),
+  CandleInterval.day1: CandleIntervalSpec(
+    label: '일',
+    limit: 90,
+    visibleCount: 32,
+  ),
+  CandleInterval.week1: CandleIntervalSpec(
+    label: '주',
+    limit: 72,
+    visibleCount: 24,
+  ),
+  CandleInterval.month1: CandleIntervalSpec(
+    label: '월',
+    limit: 48,
+    visibleCount: 18,
+  ),
+};
+
+/// `(거래소, 코인, 간격)`. 웹의 `requestKey` 를 대신한다(사양서 §4.3.7).
+///
+/// 셋 중 하나가 바뀌면 서버 캔들 provider 의 키가 바뀌고 [LiveCandleFolder] 도 빈 배열에서
+/// 다시 시작한다 — 이전 코인의 봉에 새 코인의 체결이 접히지 않는다.
+@immutable
+class CandleRequest {
+  const CandleRequest({
+    required this.exchangeCode,
+    required this.symbol,
+    required this.interval,
+  });
+
+  /// 캔들 API 만 id 가 아니라 대문자 코드를 받는다(`UPBIT`).
+  final String exchangeCode;
+  final String symbol;
+  final CandleInterval interval;
+
+  CandleIntervalSpec get spec => candleIntervalSpecs[interval]!;
+
+  int get limit => spec.limit;
+
+  int get visibleCount => spec.visibleCount;
+
+  @override
+  bool operator ==(Object other) =>
+      other is CandleRequest &&
+      other.exchangeCode == exchangeCode &&
+      other.symbol == symbol &&
+      other.interval == interval;
+
+  @override
+  int get hashCode => Object.hash(exchangeCode, symbol, interval);
+}
+
+/// 체결 시각을 어느 봉에 떨어뜨릴지 정한다(사양서 §4.3.5.1).
+///
+/// **서버 캔들의 `time` 과 티커의 `timestamp` 양쪽에 같은 함수를 적용한다.** 두 출처의 봉
+/// 시각이 정확히 일치해야 합성이 성립하므로 이 함수가 유일한 공통 기준이다. 절삭은 **단말
+/// 로컬 시간** 기준이다.
+DateTime normalizeCandleTime(DateTime time, CandleInterval interval) {
+  final t = time.toLocal();
+  return switch (interval) {
+    CandleInterval.minute1 => DateTime(t.year, t.month, t.day, t.hour, t.minute),
+    CandleInterval.hour1 => DateTime(t.year, t.month, t.day, t.hour),
+    // 0, 4, 8, 12, 16, 20 시로 내림.
+    CandleInterval.hour4 => DateTime(t.year, t.month, t.day, (t.hour ~/ 4) * 4),
+    CandleInterval.day1 => DateTime(t.year, t.month, t.day),
+    // 그 주 월요일 자정. Dart 의 weekday 는 월=1 … 일=7 이다.
+    CandleInterval.week1 => DateTime(t.year, t.month, t.day - (t.weekday - 1)),
+    CandleInterval.month1 => DateTime(t.year, t.month),
+  };
+}
+
+DateTime normalizeTickTime(int epochMs, CandleInterval interval) =>
+    normalizeCandleTime(
+      DateTime.fromMillisecondsSinceEpoch(epochMs),
+      interval,
+    );
+
+/// 서버 캔들 후처리(사양서 §4.3.1 ①). 유한하지 않은 값이 하나라도 있으면 버리고, 봉 시각을
+/// 간격 단위로 절삭한 뒤 시간 오름차순으로 정렬한다.
+List<Candle> normalizeCandles(List<Candle> candles, CandleInterval interval) {
+  final result = [
+    for (final candle in candles)
+      if (candle.open.isFinite &&
+          candle.high.isFinite &&
+          candle.low.isFinite &&
+          candle.close.isFinite)
+        Candle(
+          time: normalizeCandleTime(candle.time, interval),
+          open: candle.open,
+          high: candle.high,
+          low: candle.low,
+          close: candle.close,
+        ),
+  ];
+  result.sort((a, b) => a.time.compareTo(b.time));
+  return result;
+}
+
+/// 가변 객체다. 같은 봉 안에서는 필드만 고쳐 쓴다 — 틱마다 배열을 새로 만들지 않는다.
+class LiveCandle {
+  LiveCandle(this.bucket, double price)
+    : open = price,
+      high = price,
+      low = price,
+      close = price;
+
+  final DateTime bucket;
+
+  /// 그 봉에서 클라이언트가 **처음 받은** 체결가다. 서버가 집계한 진짜 시가가 아니다(구독
+  /// 시작 전 체결을 못 봤을 수 있다). 서버 봉이 도착하면 [MergedCandles] 가 서버 값으로
+  /// 되돌린다.
+  final double open;
+
+  double high;
+  double low;
+  double close;
+}
+
+/// 진행 중인 봉을 만든다(사양서 §4.3.5.2).
+///
+/// [onTick] 은 `TickerStore.ingest` 안에서 **매 틱** 불린다. 프레임 버퍼로 솎아내면 한 프레임
+/// 안의 체결이 사라져 봉의 고가·저가가 실제보다 얕아진다. 그리기 알림은 [onFrame] 에서만
+/// 낸다 — 접기 빈도와 그리기 빈도를 분리한다.
+class LiveCandleFolder implements TickObserver {
+  LiveCandleFolder(this.request);
+
+  final CandleRequest request;
+
+  /// 최대 [kLiveCandleLimit] 개. 시간 오름차순.
+  final List<LiveCandle> live = [];
+
+  /// 봉이 **바뀔 때만** 발화한다. 재조정 타이머는 이것만 본다 — 틱마다 재무장하지 않는다.
+  final ValueNotifier<DateTime?> openedBucket = ValueNotifier(null);
+
+  /// 프레임당 최대 1회 증가한다. 차트는 이것만 구독한다.
+  final ValueNotifier<int> revision = ValueNotifier(0);
+
+  bool _dirty = false;
+
+  @override
+  void onTick(Ticker tick) {
+    // 배열에서 자기 심볼만 고른다.
+    if (tick.symbol != request.symbol) return;
+    if (!tick.price.isFinite || tick.price <= 0) return;
+
+    final bucket = normalizeTickTime(tick.timestamp, request.interval);
+    final opened = live.isEmpty ? null : live.last;
+
+    // ① 같은 봉 → 제자리 갱신. 할당 0. open 은 건드리지 않는다.
+    if (opened != null && opened.bucket == bucket) {
+      if (tick.price > opened.high) opened.high = tick.price;
+      if (tick.price < opened.low) opened.low = tick.price;
+      opened.close = tick.price;
+      _dirty = true;
+      return;
+    }
+
+    // ② 이미 닫힌 봉에 뒤늦게 도착한 체결 → 버린다. 다시 열면 서버 집계와 어긋난다.
+    if (opened != null && bucket.isBefore(opened.bucket)) return;
+
+    // ③ 새 봉 → 네 값이 모두 이 체결가다. 간격당 1회이며 매 틱이 아니다.
+    live.add(LiveCandle(bucket, tick.price));
+    if (live.length > kLiveCandleLimit) live.removeAt(0);
+    _dirty = true;
+    openedBucket.value = bucket;
+  }
+
+  @override
+  void onFrame() {
+    if (!_dirty) return;
+    _dirty = false;
+    revision.value++;
+  }
+
+  void dispose() {
+    openedBucket.dispose();
+    revision.dispose();
+  }
+}
+
+/// 서버 캔들 위에 실시간 봉을 얹는다(사양서 §4.3.5.3).
+///
+/// 배열을 materialize 하지 않는다 — 웹은 매번 새 배열을 만들지만(React 는 그래야 리렌더된다)
+/// 여기서는 **인덱스로 읽는 뷰**다. 틱당 배열 복사가 0이다.
+///
+/// 구조([_tailFrom]·[_overlapsLast])는 서버 캔들이 교체되거나 새 봉이 열릴 때만 달라진다.
+/// 같은 봉 안의 체결은 값만 바꾼다.
+class MergedCandles {
+  MergedCandles(this.server, this.live) {
+    var tail = 0;
+    var overlaps = false;
+    if (live.isNotEmpty && server.isNotEmpty) {
+      final lastTime = server.last.time;
+      for (var i = 0; i < live.length; i++) {
+        final bucket = live[i].bucket;
+        // ① 서버가 이미 확정한 과거 봉 → 무시한다.
+        if (bucket.isBefore(lastTime)) {
+          tail = i + 1;
+          continue;
+        }
+        // ② 서버의 마지막 봉과 같은 구간 → 서버가 기준이고 실시간을 덧댄다.
+        if (bucket == lastTime) {
+          overlaps = true;
+          tail = i + 1;
+          continue;
+        }
+        // ③ 이후는 전부 서버보다 미래다.
+        break;
+      }
+    }
+    _tailFrom = tail;
+    _overlapsLast = overlaps;
+  }
+
+  final List<Candle> server;
+  final List<LiveCandle> live;
+
+  late final int _tailFrom;
+  late final bool _overlapsLast;
+
+  int get length => server.length + (live.length - _tailFrom);
+
+  /// 실시간 값이 반영되는 첫 인덱스. 없으면 [length] 다. 페인터의 repaint 게이트가 이것을
+  /// 본다 — 실시간 봉이 표시 구간 밖이면 revision 이 올라도 그림이 같다.
+  int get liveFromIndex {
+    if (_overlapsLast) return server.length - 1;
+    if (_tailFrom < live.length) return server.length;
+    return length;
+  }
+
+  Candle operator [](int index) {
+    final lastIdx = server.length - 1;
+    if (index < lastIdx) return server[index];
+
+    if (index == lastIdx) {
+      if (!_overlapsLast) return server[index];
+      final s = server[index];
+      final l = live[_tailFrom - 1];
+      return Candle(
+        // 시가는 서버 값이고 종가는 최신 체결가다.
+        time: s.time,
+        open: s.open,
+        high: math.max(s.high, l.high),
+        low: math.min(s.low, l.low),
+        close: l.close,
+      );
+    }
+
+    final l = live[_tailFrom + (index - server.length)];
+    return Candle(
+      time: l.bucket,
+      open: l.open,
+      high: l.high,
+      low: l.low,
+      close: l.close,
+    );
+  }
+
+  /// 보이는 구간만 꺼낸다(≤120개). 과거 봉은 서버 객체를 그대로 돌려주므로 새로 만들어지는
+  /// 것은 실시간이 얹힌 최대 [kLiveCandleLimit]+1 개뿐이다.
+  List<Candle> slice(int start, int end) => [
+    for (var i = start; i < end; i++) this[i],
+  ];
+}

--- a/mobile/lib/features/market/market_controller.dart
+++ b/mobile/lib/features/market/market_controller.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/format/hangul.dart';
+import '../../models/exchange_coin.dart';
+import 'exchange_coin_repository.dart';
+
+/// 코인 하나의 정적 스냅샷 + 검색 색인.
+///
+/// 색인은 목록을 받은 시점에 **1회만** 만든다(사양서 §4.2.5) — 시세가 갱신돼도 이름은 바뀌지
+/// 않는다. 9단위의 실시간 시세는 이 객체가 아니라 `TickerStore` 가 심볼별로 들고 간다.
+class CoinEntry {
+  CoinEntry(this.coin) : index = HangulIndex(coin.coinName);
+
+  final ExchangeCoin coin;
+  final HangulIndex index;
+
+  String get symbol => coin.coinSymbol;
+
+  String get name => coin.coinName;
+
+  double get price => coin.price;
+
+  /// 비율이다(0.0123 = 1.23%).
+  double get changeRate => coin.changeRate;
+
+  double get volume => coin.volume;
+}
+
+/// 거래소별 코인 카탈로그. `family` 는 autoDispose 가 아니므로 거래소 탭을 오가도 다시 받지
+/// 않는다. 주문 대상 해석(`exchangeCoinId`)도 이 캐시를 읽는다.
+final marketCoinsProvider = FutureProvider.family<List<CoinEntry>, int>((
+  ref,
+  exchangeId,
+) async {
+  final coins = await ref.watch(exchangeCoinRepositoryProvider).getCoins(
+    exchangeId,
+  );
+  return [for (final coin in coins) CoinEntry(coin)];
+});
+
+enum MarketSortKey {
+  name('이름'),
+  price('현재가'),
+  change('변동률'),
+  volume('거래대금');
+
+  const MarketSortKey(this.label);
+
+  final String label;
+}
+
+/// `changeRate == 0` 인 코인은 상승·하락 어느 쪽에도 잡히지 않는다(사양서 §4.2.4).
+enum MarketFilter {
+  all('전체'),
+  rising('상승'),
+  falling('하락');
+
+  const MarketFilter(this.label);
+
+  final String label;
+
+  bool accepts(double changeRate) => switch (this) {
+    MarketFilter.all => true,
+    MarketFilter.rising => changeRate > 0,
+    MarketFilter.falling => changeRate < 0,
+  };
+}
+
+/// 목록의 표시 조건. 티커가 들어와도 이 값은 바뀌지 않는다 — 9단위의 재정렬 스로틀이 이
+/// 객체를 그대로 재사용한다.
+class MarketView {
+  const MarketView({
+    this.query = '',
+    this.filter = MarketFilter.all,
+    this.sortKey = MarketSortKey.volume,
+    this.descending = true,
+  });
+
+  final String query;
+  final MarketFilter filter;
+
+  /// 기본 정렬은 거래대금 내림차순이다(§4.2.2).
+  final MarketSortKey sortKey;
+  final bool descending;
+
+  MarketView withQuery(String query) => MarketView(
+    query: query,
+    filter: filter,
+    sortKey: sortKey,
+    descending: descending,
+  );
+
+  MarketView withFilter(MarketFilter filter) => MarketView(
+    query: query,
+    filter: filter,
+    sortKey: sortKey,
+    descending: descending,
+  );
+
+  /// 같은 키를 다시 누르면 방향을 뒤집고, 다른 키를 누르면 그 키로 바꾸며 방향을 `desc` 로
+  /// 되돌린다(§4.2.2).
+  MarketView sortBy(MarketSortKey key) => MarketView(
+    query: query,
+    filter: filter,
+    sortKey: key,
+    descending: key == sortKey ? !descending : true,
+  );
+
+  /// 거래소 전환 — 검색어와 필터는 초기화하고 **정렬은 유지한다**(§4.1.5).
+  MarketView forExchangeSwitch() =>
+      MarketView(sortKey: sortKey, descending: descending);
+}
+
+/// 검색 → 필터 → 정렬 순으로 적용한다(§4.2.4). 위젯 없이 테스트한다.
+List<CoinEntry> applyMarketView(List<CoinEntry> coins, MarketView view) {
+  final query = HangulQuery(view.query);
+
+  final result = [
+    for (final entry in coins)
+      if (query.matches(entry.symbol, entry.index) &&
+          view.filter.accepts(entry.changeRate))
+        entry,
+  ];
+
+  final sign = view.descending ? -1 : 1;
+  result.sort((a, b) => sign * _compare(a, b, view.sortKey));
+  return result;
+}
+
+int _compare(CoinEntry a, CoinEntry b, MarketSortKey key) => switch (key) {
+  // 코인명이 아니라 심볼 사전순이다(§4.2.2).
+  MarketSortKey.name => a.symbol.compareTo(b.symbol),
+  MarketSortKey.price => a.price.compareTo(b.price),
+  MarketSortKey.change => a.changeRate.compareTo(b.changeRate),
+  MarketSortKey.volume => a.volume.compareTo(b.volume),
+};

--- a/mobile/lib/features/market/market_controller.dart
+++ b/mobile/lib/features/market/market_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/format/hangul.dart';
+import '../../core/realtime/ticker_store.dart';
 import '../../models/exchange_coin.dart';
 import 'exchange_coin_repository.dart';
 
@@ -111,26 +112,49 @@ class MarketView {
       MarketView(sortKey: sortKey, descending: descending);
 }
 
+/// 실시간 시세 조회. `TickerStore.quote` 를 그대로 넘긴다. 목록 밖 심볼이면 null 이고 그때는
+/// REST 스냅샷 값을 쓴다.
+typedef QuoteLookup = CoinRowState? Function(String symbol);
+
 /// 검색 → 필터 → 정렬 순으로 적용한다(§4.2.4). 위젯 없이 테스트한다.
-List<CoinEntry> applyMarketView(List<CoinEntry> coins, MarketView view) {
+///
+/// 필터와 정렬은 **최신 시세**를 기준으로 판정해야 한다. 재정렬 캐던스(1초 스로틀 + 스크롤 중
+/// 동결)는 호출부가 정한다 — 이 함수는 프레임마다 불리지 않는다.
+List<CoinEntry> applyMarketView(
+  List<CoinEntry> coins,
+  MarketView view, {
+  QuoteLookup? quote,
+}) {
   final query = HangulQuery(view.query);
+  double changeOf(CoinEntry e) => quote?.call(e.symbol)?.changeRate ?? e.changeRate;
 
   final result = [
     for (final entry in coins)
       if (query.matches(entry.symbol, entry.index) &&
-          view.filter.accepts(entry.changeRate))
+          view.filter.accepts(changeOf(entry)))
         entry,
   ];
 
   final sign = view.descending ? -1 : 1;
-  result.sort((a, b) => sign * _compare(a, b, view.sortKey));
+  result.sort((a, b) => sign * _compare(a, b, view.sortKey, quote));
   return result;
 }
 
-int _compare(CoinEntry a, CoinEntry b, MarketSortKey key) => switch (key) {
-  // 코인명이 아니라 심볼 사전순이다(§4.2.2).
-  MarketSortKey.name => a.symbol.compareTo(b.symbol),
-  MarketSortKey.price => a.price.compareTo(b.price),
-  MarketSortKey.change => a.changeRate.compareTo(b.changeRate),
-  MarketSortKey.volume => a.volume.compareTo(b.volume),
-};
+int _compare(CoinEntry a, CoinEntry b, MarketSortKey key, QuoteLookup? quote) {
+  if (key == MarketSortKey.name) {
+    // 코인명이 아니라 심볼 사전순이다(§4.2.2).
+    return a.symbol.compareTo(b.symbol);
+  }
+  final qa = quote?.call(a.symbol);
+  final qb = quote?.call(b.symbol);
+  return switch (key) {
+    MarketSortKey.price => (qa?.price ?? a.price).compareTo(qb?.price ?? b.price),
+    MarketSortKey.change => (qa?.changeRate ?? a.changeRate).compareTo(
+      qb?.changeRate ?? b.changeRate,
+    ),
+    MarketSortKey.volume => (qa?.volume ?? a.volume).compareTo(
+      qb?.volume ?? b.volume,
+    ),
+    MarketSortKey.name => 0,
+  };
+}

--- a/mobile/lib/features/market/market_page.dart
+++ b/mobile/lib/features/market/market_page.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../../core/constants/exchanges.dart';
+import '../../core/realtime/stomp_service.dart';
+import '../../core/realtime/ticker_store.dart';
 import '../../core/router/guard.dart';
 import '../../core/theme/theme.dart';
 import '../../core/widgets/async_view.dart';
@@ -16,10 +20,15 @@ import 'coin_search_field.dart';
 import 'market_controller.dart';
 import 'overview_cards.dart';
 
+/// 시세 변동에 따른 재정렬 캐던스. 사용자 조작(정렬키·필터·검색어·거래소)은 즉시 반영한다.
+/// 이 스로틀이 없으면 인덱스→심볼 매핑이 매 프레임 뒤집혀 심볼별 notifier 의 이득이 통째로
+/// 사라지고, 초당 60번 자리를 바꾸는 목록은 읽을 수도 없다(계획서 §4.2.5-5).
+const Duration _kResortInterval = Duration(seconds: 1);
+
 /// 선택 거래소는 라우트 쿼리(`/market?exchange=upbit`)에 둔다 — 딥링크와 복원이 공짜로 된다.
 ///
-/// 이 단위의 시세는 REST 스냅샷 하나뿐이다. STOMP 구독과 `TickerStore` 는 9단위에서
-/// [CoinNumbers] 만 갈아 끼우는 방식으로 얹힌다.
+/// 티커 토픽 구독은 **거래소당 하나**다. `TickerStore` 가 목록과 캔들 차트에 나눠 준다 —
+/// 웹은 목록과 차트가 같은 토픽을 각각 구독해 페이로드를 두 번 받는다(사양서 §4.3.9).
 class MarketPage extends ConsumerStatefulWidget {
   const MarketPage({super.key});
 
@@ -31,10 +40,80 @@ class _MarketPageState extends ConsumerState<MarketPage> {
   final TextEditingController _search = TextEditingController();
   MarketView _view = const MarketView();
 
+  late final AppLifecycleListener _lifecycle;
+  VoidCallback? _cancelTickers;
+  int? _exchangeId;
+  bool _visible = false;
+  bool _primed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _lifecycle = AppLifecycleListener(onResume: _onResume);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final exchange = ExchangeIds.byKey(
+      GoRouterState.of(context).uri.queryParameters['exchange'],
+    );
+    // go_router 의 `indexedStack` 셸은 선택되지 않은 브랜치를 `TickerMode(enabled: false)` 로
+    // 감싼다. 숨은 탭에서 티커를 받으면 보이지도 않는 행을 계속 리빌드한다.
+    _sync(exchange.id, TickerMode.valuesOf(context).enabled);
+  }
+
   @override
   void dispose() {
+    _lifecycle.dispose();
+    _cancelTickers?.call();
     _search.dispose();
     super.dispose();
+  }
+
+  void _sync(int exchangeId, bool visible) {
+    if (_exchangeId == exchangeId && _visible == visible) return;
+    final store = ref.read(tickerStoreProvider);
+
+    _cancelTickers?.call();
+    _cancelTickers = null;
+
+    if (!visible) {
+      store.setActive(false);
+      _exchangeId = exchangeId;
+      _visible = false;
+      return;
+    }
+
+    store.setActive(true);
+    _cancelTickers = ref
+        .read(stompServiceProvider)
+        .subscribe(
+          '/topic/tickers.$exchangeId',
+          (body) => store.ingest(decodeTickers(body)),
+        );
+
+    // 탭 재활성·거래소 전환 시 REST 스냅샷을 한 번 다시 받는다. 구독이 끊긴 동안의 틱을
+    // 보정한다(계획서 §4.2.3). 첫 진입은 provider 가 알아서 조회하므로 건드리지 않는다.
+    if (_primed) _refetch(exchangeId);
+
+    _exchangeId = exchangeId;
+    _visible = visible;
+    _primed = true;
+  }
+
+  /// 포그라운드 복귀 — 누락 틱 보정(계획서 §4.2.2). 소켓 재연결은 `StompService` 가 한다.
+  void _onResume() {
+    final exchangeId = _exchangeId;
+    if (!_visible || exchangeId == null) return;
+    _refetch(exchangeId);
+  }
+
+  void _refetch(int exchangeId) {
+    // provider 무효화는 프레임 밖에서 한다.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) ref.invalidate(marketCoinsProvider(exchangeId));
+    });
   }
 
   void _switchExchange(Exchange exchange) {
@@ -118,7 +197,7 @@ class _MarketPageState extends ConsumerState<MarketPage> {
   }
 }
 
-class _CoinList extends StatelessWidget {
+class _CoinList extends ConsumerStatefulWidget {
   const _CoinList({
     required this.coins,
     required this.view,
@@ -136,17 +215,75 @@ class _CoinList extends StatelessWidget {
   final Future<void> Function() onRefresh;
 
   @override
-  Widget build(BuildContext context) {
-    final rows = applyMarketView(coins, view);
+  ConsumerState<_CoinList> createState() => _CoinListState();
+}
 
+class _CoinListState extends ConsumerState<_CoinList> {
+  final ScrollController _scroll = ScrollController();
+  late TickerStore _store;
+  late List<CoinEntry> _rows;
+  Timer? _resort;
+
+  @override
+  void initState() {
+    super.initState();
+    _store = ref.read(tickerStoreProvider);
+    _seed();
+    _resort = Timer.periodic(_kResortInterval, (_) => _reorder());
+  }
+
+  @override
+  void didUpdateWidget(_CoinList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(widget.coins, oldWidget.coins)) {
+      _seed();
+    } else if (!identical(widget.view, oldWidget.view)) {
+      _rows = _apply();
+    }
+  }
+
+  @override
+  void dispose() {
+    _resort?.cancel();
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  /// REST 스냅샷이 기준이다. 티커 맵을 비우고 이 목록으로 다시 채운다.
+  void _seed() {
+    _store.switchExchange([for (final entry in widget.coins) entry.coin]);
+    _rows = _apply();
+  }
+
+  List<CoinEntry> _apply() =>
+      applyMarketView(widget.coins, widget.view, quote: _store.quote);
+
+  void _reorder() {
+    if (!_store.orderDirty) return;
+    // 손가락 밑에서 행이 튀면 오탭이 난다. dirty 를 남겨 두고 스크롤이 멈춘 뒤에 반영한다.
+    if (_scroll.hasClients && _scroll.position.isScrollingNotifier.value) return;
+    _store.clearOrderDirty();
+    setState(() => _rows = _apply());
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Column(
       children: [
-        OverviewCards(coins: coins, baseCurrency: exchange.baseCurrency),
-        _ListControls(view: view, onFilter: onFilter, onSort: onSort),
+        OverviewCards(
+          coins: widget.coins,
+          store: _store,
+          baseCurrency: widget.exchange.baseCurrency,
+        ),
+        _ListControls(
+          view: widget.view,
+          onFilter: widget.onFilter,
+          onSort: widget.onSort,
+        ),
         Expanded(
           child: RefreshIndicator(
-            onRefresh: onRefresh,
-            child: rows.isEmpty
+            onRefresh: widget.onRefresh,
+            child: _rows.isEmpty
                 ? ListView(
                     children: const [
                       SizedBox(height: 120),
@@ -157,18 +294,21 @@ class _CoinList extends StatelessWidget {
                     ],
                   )
                 : ListView.builder(
+                    controller: _scroll,
                     // 자식을 측정하지 않는다. 600행에서 스크롤 위치 계산이 O(1) 이 된다.
                     itemExtent: kCoinRowHeight,
-                    itemCount: rows.length,
+                    itemCount: _rows.length,
                     itemBuilder: (context, index) {
-                      final entry = rows[index];
+                      final entry = _rows[index];
                       return CoinRow(
                         symbol: entry.symbol,
                         name: entry.name,
-                        price: entry.price,
-                        changeRate: entry.changeRate,
-                        volume: entry.volume,
-                        baseCurrency: exchange.baseCurrency,
+                        row: _store.row(entry.symbol)!,
+                        flash: _store.flash(entry.symbol)!,
+                        baseCurrency: widget.exchange.baseCurrency,
+                        onTap: () => context.push(
+                          Routes.coinDetail(entry.symbol, widget.exchange.key),
+                        ),
                       );
                     },
                   ),

--- a/mobile/lib/features/market/market_page.dart
+++ b/mobile/lib/features/market/market_page.dart
@@ -1,19 +1,290 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
+import '../../core/constants/exchanges.dart';
+import '../../core/router/guard.dart';
+import '../../core/theme/theme.dart';
+import '../../core/widgets/async_view.dart';
 import '../../core/widgets/empty_view.dart';
+import '../../core/widgets/exchange_segment.dart';
 import '../../core/widgets/mypage_button.dart';
+import '../round/round_controller.dart';
+import 'coin_row.dart';
+import 'coin_search_field.dart';
+import 'market_controller.dart';
+import 'overview_cards.dart';
 
-class MarketPage extends StatelessWidget {
+/// 선택 거래소는 라우트 쿼리(`/market?exchange=upbit`)에 둔다 — 딥링크와 복원이 공짜로 된다.
+///
+/// 이 단위의 시세는 REST 스냅샷 하나뿐이다. STOMP 구독과 `TickerStore` 는 9단위에서
+/// [CoinNumbers] 만 갈아 끼우는 방식으로 얹힌다.
+class MarketPage extends ConsumerStatefulWidget {
   const MarketPage({super.key});
 
   @override
+  ConsumerState<MarketPage> createState() => _MarketPageState();
+}
+
+class _MarketPageState extends ConsumerState<MarketPage> {
+  final TextEditingController _search = TextEditingController();
+  MarketView _view = const MarketView();
+
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
+  void _switchExchange(Exchange exchange) {
+    _search.clear();
+    setState(() => _view = _view.forExchangeSwitch());
+    context.go('${Routes.market}?exchange=${exchange.key}');
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final exchange = ExchangeIds.byKey(
+      GoRouterState.of(context).uri.queryParameters['exchange'],
+    );
+    final coins = ref.watch(marketCoinsProvider(exchange.id));
+    final hasRound = ref.watch(
+      roundControllerProvider.select((round) => round.hasActive),
+    );
+
     return Scaffold(
-      appBar: AppBar(title: const Text('마켓'), actions: const [MypageButton()]),
-      body: const EmptyView(
-        icon: LucideIcons.chartCandlestick,
-        message: '코인 목록은 8단위에서 붙는다.',
+      appBar: AppBar(title: const Text('코인 시세'), actions: const [MypageButton()]),
+      body: Column(
+        children: [
+          if (!hasRound) const _RoundStartBanner(),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              TryptoSpacing.screen,
+              TryptoSpacing.md,
+              TryptoSpacing.screen,
+              TryptoSpacing.sm,
+            ),
+            child: Column(
+              children: [
+                CoinSearchField(
+                  controller: _search,
+                  onChanged: (query) =>
+                      setState(() => _view = _view.withQuery(query)),
+                ),
+                const SizedBox(height: TryptoSpacing.sm),
+                ExchangeSegment<int>(
+                  items: [
+                    for (final item in ExchangeIds.all)
+                      SegmentItem(item.id, item.name),
+                  ],
+                  value: exchange.id,
+                  onChanged: (id) =>
+                      _switchExchange(ExchangeIds.byId(id) ?? exchange),
+                ),
+                const SizedBox(height: TryptoSpacing.sm),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '${exchange.name} 기준 · ${exchange.baseCurrency} 마켓',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: AsyncView<List<CoinEntry>>(
+              value: coins,
+              onRetry: () => ref.invalidate(marketCoinsProvider(exchange.id)),
+              builder: (data) => _CoinList(
+                coins: data,
+                view: _view,
+                exchange: exchange,
+                onFilter: (filter) =>
+                    setState(() => _view = _view.withFilter(filter)),
+                onSort: (key) => setState(() => _view = _view.sortBy(key)),
+                onRefresh: () =>
+                    ref.refresh(marketCoinsProvider(exchange.id).future),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CoinList extends StatelessWidget {
+  const _CoinList({
+    required this.coins,
+    required this.view,
+    required this.exchange,
+    required this.onFilter,
+    required this.onSort,
+    required this.onRefresh,
+  });
+
+  final List<CoinEntry> coins;
+  final MarketView view;
+  final Exchange exchange;
+  final ValueChanged<MarketFilter> onFilter;
+  final ValueChanged<MarketSortKey> onSort;
+  final Future<void> Function() onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = applyMarketView(coins, view);
+
+    return Column(
+      children: [
+        OverviewCards(coins: coins, baseCurrency: exchange.baseCurrency),
+        _ListControls(view: view, onFilter: onFilter, onSort: onSort),
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: onRefresh,
+            child: rows.isEmpty
+                ? ListView(
+                    children: const [
+                      SizedBox(height: 120),
+                      EmptyView(
+                        icon: LucideIcons.search,
+                        message: '검색 결과가 없습니다.',
+                      ),
+                    ],
+                  )
+                : ListView.builder(
+                    // 자식을 측정하지 않는다. 600행에서 스크롤 위치 계산이 O(1) 이 된다.
+                    itemExtent: kCoinRowHeight,
+                    itemCount: rows.length,
+                    itemBuilder: (context, index) {
+                      final entry = rows[index];
+                      return CoinRow(
+                        symbol: entry.symbol,
+                        name: entry.name,
+                        price: entry.price,
+                        changeRate: entry.changeRate,
+                        volume: entry.volume,
+                        baseCurrency: exchange.baseCurrency,
+                      );
+                    },
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ListControls extends StatelessWidget {
+  const _ListControls({
+    required this.view,
+    required this.onFilter,
+    required this.onSort,
+  });
+
+  final MarketView view;
+  final ValueChanged<MarketFilter> onFilter;
+  final ValueChanged<MarketSortKey> onSort;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        TryptoSpacing.screen,
+        TryptoSpacing.sm,
+        TryptoSpacing.sm,
+        TryptoSpacing.sm,
+      ),
+      child: Row(
+        children: [
+          for (final filter in MarketFilter.values) ...[
+            ChoiceChip(
+              label: Text(filter.label),
+              selected: view.filter == filter,
+              onSelected: (_) => onFilter(filter),
+            ),
+            const SizedBox(width: TryptoSpacing.xs),
+          ],
+          const Spacer(),
+          PopupMenuButton<MarketSortKey>(
+            tooltip: '정렬',
+            position: PopupMenuPosition.under,
+            onSelected: onSort,
+            itemBuilder: (context) => [
+              for (final key in MarketSortKey.values)
+                PopupMenuItem(
+                  value: key,
+                  child: Row(
+                    children: [
+                      Text(key.label),
+                      const Spacer(),
+                      if (view.sortKey == key)
+                        Icon(
+                          view.descending
+                              ? LucideIcons.arrowDown
+                              : LucideIcons.arrowUp,
+                          size: 14,
+                          color: theme.colorScheme.primary,
+                        ),
+                    ],
+                  ),
+                ),
+            ],
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(view.sortKey.label, style: theme.textTheme.labelMedium),
+                Icon(
+                  view.descending ? LucideIcons.arrowDown : LucideIcons.arrowUp,
+                  size: 14,
+                ),
+                const SizedBox(width: TryptoSpacing.xs),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 라운드가 없어도 시세 조회는 계속된다 — 주문만 막힌다(사양서 §7.4.2). 하단 탭 바에 자리가
+/// 없으므로 웹 헤더의 "라운드 시작" 버튼을 이 배너가 대신한다.
+class _RoundStartBanner extends StatelessWidget {
+  const _RoundStartBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(
+        horizontal: TryptoSpacing.screen,
+        vertical: TryptoSpacing.md,
+      ),
+      color: theme.colorScheme.primary.withValues(alpha: 0.08),
+      child: Row(
+        children: [
+          Icon(LucideIcons.flag, size: 16, color: theme.colorScheme.primary),
+          const SizedBox(width: TryptoSpacing.sm),
+          Expanded(
+            child: Text(
+              '진행 중인 라운드가 없습니다.',
+              style: theme.textTheme.labelLarge,
+            ),
+          ),
+          FilledButton(
+            onPressed: () => context.go(Routes.roundNew),
+            child: const Text('라운드 시작'),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/features/market/market_page.dart
+++ b/mobile/lib/features/market/market_page.dart
@@ -6,14 +6,20 @@ import 'package:go_router/go_router.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../../core/constants/exchanges.dart';
+import '../../core/format/formatters.dart';
 import '../../core/realtime/stomp_service.dart';
 import '../../core/realtime/ticker_store.dart';
 import '../../core/router/guard.dart';
 import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/app_snackbar.dart';
 import '../../core/widgets/async_view.dart';
 import '../../core/widgets/empty_view.dart';
 import '../../core/widgets/exchange_segment.dart';
 import '../../core/widgets/mypage_button.dart';
+import '../../models/enums.dart';
+import '../../models/round.dart';
+import '../round/emergency_funding_sheet.dart';
 import '../round/round_controller.dart';
 import 'coin_row.dart';
 import 'coin_search_field.dart';
@@ -129,15 +135,18 @@ class _MarketPageState extends ConsumerState<MarketPage> {
       GoRouterState.of(context).uri.queryParameters['exchange'],
     );
     final coins = ref.watch(marketCoinsProvider(exchange.id));
-    final hasRound = ref.watch(
-      roundControllerProvider.select((round) => round.hasActive),
+    final round = ref.watch(
+      roundControllerProvider.select((state) => state.activeRound),
     );
 
     return Scaffold(
       appBar: AppBar(title: const Text('코인 시세'), actions: const [MypageButton()]),
       body: Column(
         children: [
-          if (!hasRound) const _RoundStartBanner(),
+          if (round == null)
+            const _RoundStartBanner()
+          else if (round.emergencyFundingLimit > 0)
+            _EmergencyBanner(round: round, exchange: exchange),
           Padding(
             padding: const EdgeInsets.fromLTRB(
               TryptoSpacing.screen,
@@ -387,6 +396,59 @@ class _ListControls extends StatelessWidget {
                 const SizedBox(width: TryptoSpacing.xs),
               ],
             ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 사용 빈도(라운드당 최대 3회)에 비해 웹 카드는 자리를 너무 차지한다. 남은 횟수만 보여주는
+/// 접힌 배너로 줄이고 나머지는 바텀시트로 옮긴다(계획서 §4.6.1).
+class _EmergencyBanner extends StatelessWidget {
+  const _EmergencyBanner({required this.round, required this.exchange});
+
+  final ActiveRound round;
+  final Exchange exchange;
+
+  /// 웹 `canCharge` 와 같은 판별식이다(사양서 §4.5).
+  bool get _canCharge =>
+      round.status == RoundStatus.active && round.emergencyChargeCount > 0;
+
+  Future<void> _open(BuildContext context) async {
+    final charged = await showEmergencyFundingSheet(context, exchange: exchange);
+    if (charged == null || !context.mounted) return;
+    showAppSnackbar(context, '${formatKRW(charged.toDouble())}을 투입했습니다.');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final warning = context.tryptoColors.warning;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(
+        horizontal: TryptoSpacing.screen,
+        vertical: TryptoSpacing.sm,
+      ),
+      color: warning.withValues(alpha: 0.08),
+      child: Row(
+        children: [
+          Icon(LucideIcons.shieldPlus, size: 16, color: warning),
+          const SizedBox(width: TryptoSpacing.sm),
+          Expanded(
+            child: Text(
+              _canCharge
+                  ? '긴급 자금 · 남은 횟수 ${round.emergencyChargeCount}회'
+                  : '긴급 자금 · 3회를 모두 사용했습니다',
+              style: theme.textTheme.labelLarge,
+            ),
+          ),
+          FilledButton(
+            style: TryptoButtons.secondary,
+            onPressed: _canCharge ? () => _open(context) : null,
+            child: const Text('투입'),
           ),
         ],
       ),

--- a/mobile/lib/features/market/order_form.dart
+++ b/mobile/lib/features/market/order_form.dart
@@ -1,0 +1,272 @@
+import 'package:decimal/decimal.dart';
+
+import '../../core/constants/exchanges.dart';
+import '../../core/format/formatters.dart';
+import '../../core/json/decimal_x.dart';
+import '../../models/enums.dart';
+import '../../models/order.dart';
+import 'order_target.dart';
+
+/// 수량 표시·연동 자릿수(사양서 §4.4.3). 서버는 8자리까지 받지만 웹과 같은 6자리로 맞춘다.
+const int kQuantityScale = 6;
+
+/// 가격 스텝 버튼의 증감폭(§4.4.3).
+final Decimal kPriceStep = Decimal.fromInt(1000);
+
+/// 비율 버튼(§4.4.3).
+const List<int> kOrderRatios = [10, 25, 50, 100];
+
+enum OrderField { price, quantity, total }
+
+/// 폼이 계산에 쓰는 바깥 값. 거래소 상수(수수료율·최소 주문 금액) + 현재가 + 주문 가능 잔고.
+class OrderContext {
+  const OrderContext({
+    required this.exchange,
+    required this.currentPrice,
+    required this.availableBuy,
+    required this.availableSell,
+  });
+
+  final Exchange exchange;
+
+  final Decimal currentPrice;
+
+  /// `GET /api/orders/available?side=BUY` — 기준통화 가용 잔고.
+  final Decimal availableBuy;
+
+  /// `side=SELL` — 해당 코인의 가용 수량(잠금분 제외).
+  final Decimal availableSell;
+
+  String get baseCurrency => exchange.baseCurrency;
+
+  /// KRW 는 정수, USDT 는 소수 2자리다. 웹은 통화와 무관하게 0자리로 뭉갠다.
+  int get amountScale => baseCurrency == 'USDT' ? 2 : 0;
+
+  Decimal get feeRate => exchange.feeRate.dec;
+
+  Decimal get minOrderAmount => exchange.minOrderAmount.dec;
+
+  Decimal? get maxOrderAmount => exchange.maxOrderAmount?.dec;
+
+  /// 매수 차감액은 `총액 × (1 + feeRate)` 다(사양서 §4.4.5). 수수료까지 내고 살 수 있는
+  /// 최대 총액이며, 100% 비율 버튼의 상한이다.
+  Decimal get maxSpend => (availableBuy / (Decimal.one + feeRate)).toDecimal(
+    scaleOnInfinitePrecision: amountScale + 8,
+  );
+
+  String amountLabel(Decimal value) =>
+      '${formatPrice(value.toDouble(), baseCurrency)} $baseCurrency';
+}
+
+/// 주문 입력의 순수 상태. 위젯 없이 테스트한다.
+///
+/// **`volume`·`price` 의 의미가 주문 모드마다 다르다**(사양서 §4.4.7). 시장가 매수는 `volume` 을
+/// 보내면 거부되고 `price` 에 총액이 실리며, 시장가 매도는 `price` 를 보내면 거부된다. 조립
+/// 규칙을 [toRequest] 한 곳에 가둔다.
+class OrderForm {
+  const OrderForm({
+    required this.side,
+    required this.orderType,
+    required this.price,
+    required this.quantity,
+    required this.total,
+    required this.lastEdited,
+  });
+
+  factory OrderForm.empty({
+    required Side side,
+    OrderType orderType = OrderType.limit,
+  }) => OrderForm(
+    side: side,
+    orderType: orderType,
+    price: Decimal.zero,
+    quantity: Decimal.zero,
+    total: Decimal.zero,
+    lastEdited: OrderField.quantity,
+  );
+
+  final Side side;
+  final OrderType orderType;
+
+  /// 지정가. 시장가에서는 화면에 현재가가 고정 표시되고 이 값은 쓰이지 않는다.
+  final Decimal price;
+
+  final Decimal quantity;
+  final Decimal total;
+
+  /// 가격이 바뀌면 마지막으로 손댄 쪽을 기준으로 반대편을 다시 계산한다(§4.4.3).
+  final OrderField lastEdited;
+
+  bool get isLimit => orderType == OrderType.limit;
+
+  bool get isMarketBuy => orderType == OrderType.market && side == Side.buy;
+
+  bool get isMarketSell => orderType == OrderType.market && side == Side.sell;
+
+  /// 시장가는 가격 칸이 현재가로 고정되고 비활성이다(§4.4.2).
+  bool get priceEditable => isLimit;
+
+  /// 시장가 매수는 "얼마어치"(총액)로, 시장가 매도는 "몇 개"(수량)로 주문한다.
+  bool get showsQuantity => !isMarketBuy;
+
+  bool get showsTotal => !isMarketSell;
+
+  /// 수량↔총액 연동은 지정가에서만 한다(§4.4.3).
+  bool get linked => isLimit;
+
+  String get successMessage =>
+      isLimit ? '주문이 등록되었습니다.' : '주문이 체결되었습니다.';
+
+  Decimal displayPrice(Decimal currentPrice) =>
+      isLimit && price > Decimal.zero ? price : currentPrice;
+
+  OrderForm copyWith({
+    Side? side,
+    OrderType? orderType,
+    Decimal? price,
+    Decimal? quantity,
+    Decimal? total,
+    OrderField? lastEdited,
+  }) => OrderForm(
+    side: side ?? this.side,
+    orderType: orderType ?? this.orderType,
+    price: price ?? this.price,
+    quantity: quantity ?? this.quantity,
+    total: total ?? this.total,
+    lastEdited: lastEdited ?? this.lastEdited,
+  );
+
+  /// 탭을 바꾸면 세 입력을 비운다(§4.4.3).
+  OrderForm withSide(Side side) =>
+      OrderForm.empty(side: side, orderType: orderType);
+
+  OrderForm withOrderType(OrderType orderType, OrderContext ctx) =>
+      copyWith(orderType: orderType)._relink(ctx);
+
+  OrderForm withPrice(Decimal price, OrderContext ctx) =>
+      copyWith(price: price)._relink(ctx);
+
+  OrderForm withQuantity(Decimal quantity, OrderContext ctx) {
+    final next = copyWith(quantity: quantity, lastEdited: OrderField.quantity);
+    if (!next.linked) return next;
+    return next.copyWith(
+      total: _amountOf(quantity, next.displayPrice(ctx.currentPrice), ctx),
+    );
+  }
+
+  OrderForm withTotal(Decimal total, OrderContext ctx) {
+    final next = copyWith(total: total, lastEdited: OrderField.total);
+    if (!next.linked) return next;
+    return next.copyWith(
+      quantity: _quantityOf(total, next.displayPrice(ctx.currentPrice)),
+    );
+  }
+
+  /// 기준값은 현재 입력값이며, 비어 있으면 현재가다. 0 미만으로 내려가지 않는다(§4.4.3).
+  OrderForm stepPrice(int direction, OrderContext ctx) {
+    final base = price > Decimal.zero ? price : ctx.currentPrice;
+    final next = base + kPriceStep * Decimal.fromInt(direction);
+    return withPrice(next < Decimal.zero ? Decimal.zero : next, ctx);
+  }
+
+  /// 매수는 총액을, 매도는 수량을 채운다(§4.4.3).
+  ///
+  /// 매수 100% 에서 잔고를 그대로 채우면 수수료가 총액 **위에** 더 붙으므로 서버가 반드시
+  /// `INSUFFICIENT_BALANCE` 를 낸다(웹의 결함). 살 수 있는 최대치로 가둔다 — 10/25/50% 에서는
+  /// 이 상한에 닿지 않으므로 식은 웹과 같다.
+  OrderForm applyRatio(int percent, OrderContext ctx) {
+    final ratio = (Decimal.fromInt(percent) / Decimal.fromInt(100)).toDecimal();
+
+    if (side == Side.buy) {
+      final raw = ctx.availableBuy * ratio;
+      final capped = raw < ctx.maxSpend ? raw : ctx.maxSpend;
+      return withTotal(capped.floor(scale: ctx.amountScale), ctx);
+    }
+    final raw = ctx.availableSell * ratio;
+    return withQuantity(raw.floor(scale: kQuantityScale), ctx);
+  }
+
+  /// 서버가 정산 기준으로 삼는 주문 금액. 수수료·최소 주문 검증과 예상 수수료가 이 값을 쓴다.
+  Decimal amountOf(OrderContext ctx) {
+    if (isMarketBuy) return total;
+    return _amountOf(quantity, displayPrice(ctx.currentPrice), ctx);
+  }
+
+  /// 표시용 예상 수수료. 실제 수수료는 서버가 체결가로 계산한다(§4.4.5).
+  Decimal feeOf(OrderContext ctx) =>
+      (amountOf(ctx) * ctx.feeRate).round(scale: ctx.amountScale);
+
+  /// 첫 실패 사유. null 이면 제출할 수 있다.
+  ///
+  /// 1~3 은 웹의 클라이언트 검증(§4.4.6)이고, 4~5 는 서버 `OrderAmountPolicy`·잔고 검사를
+  /// 입력 단계로 당긴 것이다 — 웹은 여기서 400 을 받고 나서야 사용자에게 알린다.
+  String? validate(OrderContext ctx) {
+    if (isMarketBuy && total <= Decimal.zero) return '주문 총액을 입력해 주세요.';
+    if (!isMarketBuy && quantity <= Decimal.zero) return '주문 수량을 입력해 주세요.';
+    if (isLimit && price <= Decimal.zero) return '지정가를 입력해 주세요.';
+
+    final amount = amountOf(ctx);
+    if (amount < ctx.minOrderAmount) {
+      return '최소 주문 금액은 ${ctx.amountLabel(ctx.minOrderAmount)} 입니다.';
+    }
+    final max = ctx.maxOrderAmount;
+    if (max != null && amount > max) {
+      return '최대 주문 금액은 ${ctx.amountLabel(max)} 입니다.';
+    }
+
+    if (side == Side.buy) {
+      // 반올림하지 않고 정확히 비교한다. 100% 비율 버튼이 만든 총액이 이 검사에 걸리면 안 된다.
+      final required = amount * (Decimal.one + ctx.feeRate);
+      if (required > ctx.availableBuy) {
+        return '주문 가능 금액을 초과했습니다. '
+            '수수료를 포함해 ${ctx.amountLabel(required.round(scale: ctx.amountScale))} 가 필요합니다.';
+      }
+      return null;
+    }
+    if (quantity > ctx.availableSell) return '보유 수량을 초과했습니다.';
+    return null;
+  }
+
+  /// `POST /api/orders` 바디. 모드별 필드 규칙을 어기면 서버가 400 이다.
+  PlaceOrderRequest toRequest({
+    required OrderTarget target,
+    required String clientOrderId,
+  }) => PlaceOrderRequest(
+    clientOrderId: clientOrderId,
+    walletId: target.walletId,
+    exchangeCoinId: target.exchangeCoinId,
+    side: side,
+    orderType: orderType,
+    // 시장가 매수는 volume 을 보내면 거부된다(OrderMode.rejectVolume).
+    volume: isMarketBuy ? null : quantity.toDouble(),
+    // 시장가 매도는 price 를 보내면 거부된다. 시장가 매수의 price 는 가격이 아니라 **총액**이다.
+    price: isMarketSell ? null : (isMarketBuy ? total : price).toDouble(),
+  );
+
+  OrderForm _relink(OrderContext ctx) {
+    if (!linked) return this;
+    final priceOf = displayPrice(ctx.currentPrice);
+    return lastEdited == OrderField.total
+        ? copyWith(quantity: _quantityOf(total, priceOf))
+        : copyWith(total: _amountOf(quantity, priceOf, ctx));
+  }
+
+  static Decimal _amountOf(Decimal quantity, Decimal price, OrderContext ctx) =>
+      (quantity * price).round(scale: ctx.amountScale);
+
+  static Decimal _quantityOf(Decimal total, Decimal price) {
+    if (price <= Decimal.zero) return Decimal.zero;
+    return (total / price)
+        .toDecimal(scaleOnInfinitePrecision: kQuantityScale + 2)
+        .round(scale: kQuantityScale);
+  }
+}
+
+/// 콤마를 모두 제거한 뒤 숫자로 바꾸고, 숫자가 아니면 0 으로 본다(§4.4.3).
+Decimal parseAmountInput(String text) {
+  final cleaned = text.replaceAll(',', '').trim();
+  if (cleaned.isEmpty) return Decimal.zero;
+  final value = Decimal.tryParse(cleaned);
+  if (value == null || value < Decimal.zero) return Decimal.zero;
+  return value;
+}

--- a/mobile/lib/features/market/order_history_tab.dart
+++ b/mobile/lib/features/market/order_history_tab.dart
@@ -1,0 +1,395 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../core/api/api_exception.dart';
+import '../../core/format/formatters.dart';
+import '../../core/format/server_time.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/app_snackbar.dart';
+import '../../core/widgets/empty_view.dart';
+import '../../core/widgets/exchange_segment.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../core/widgets/profit_badge.dart';
+import '../../models/cursor_page.dart';
+import '../../models/enums.dart';
+import '../../models/order.dart';
+import 'order_repository.dart';
+import 'order_target.dart';
+
+const int _kPageSize = 20;
+
+/// 코인 상세의 두 번째 하단 탭(계획서 §4.6.1). 바텀시트 안에 커서 무한 스크롤 목록을 넣으면
+/// 시트 드래그와 목록 스크롤 제스처가 충돌하므로 주문 시트에서 분리했다.
+///
+/// **체결 반영은 REST 재조회다**(사양서 §4.4.8, R3). 화면 진입·주문 제출·포그라운드 복귀·
+/// 당김 새로고침에서 다시 읽는다. [revision] 이 바뀌면 주문이 나갔다는 뜻이다.
+class OrderHistoryTab extends ConsumerStatefulWidget {
+  const OrderHistoryTab({
+    super.key,
+    required this.target,
+    required this.symbol,
+    required this.revision,
+  });
+
+  final OrderTarget target;
+  final String symbol;
+  final int revision;
+
+  @override
+  ConsumerState<OrderHistoryTab> createState() => _OrderHistoryTabState();
+}
+
+class _OrderHistoryTabState extends ConsumerState<OrderHistoryTab> {
+  final ScrollController _scroll = ScrollController();
+
+  /// 응답에 `status` 가 없다(사양서 R4-9). 요청 필터값을 그대로 표시에 쓴다.
+  OrderStatus _status = OrderStatus.filled;
+
+  List<OrderHistoryItem> _items = [];
+  int? _cursor;
+  bool _hasNext = false;
+  bool _loading = true;
+  bool _loadingMore = false;
+  String? _error;
+  int _generation = 0;
+
+  late final AppLifecycleListener _lifecycle;
+
+  @override
+  void initState() {
+    super.initState();
+    _lifecycle = AppLifecycleListener(onResume: _reload);
+    _scroll.addListener(_onScroll);
+    _reload();
+  }
+
+  @override
+  void didUpdateWidget(OrderHistoryTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.revision != oldWidget.revision ||
+        widget.target != oldWidget.target) {
+      _reload();
+    }
+  }
+
+  @override
+  void dispose() {
+    _lifecycle.dispose();
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!_scroll.hasClients || !_hasNext || _loadingMore || _loading) return;
+    if (_scroll.position.pixels < _scroll.position.maxScrollExtent - 200) return;
+    _loadMore();
+  }
+
+  Future<void> _reload() async {
+    final generation = ++_generation;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final page = await _fetch(cursor: null);
+      if (!mounted || generation != _generation) return;
+      setState(() {
+        _items = page.content;
+        _cursor = page.nextCursor;
+        _hasNext = page.hasNext;
+        _loading = false;
+      });
+    } on ApiException catch (error) {
+      if (!mounted || generation != _generation) return;
+      setState(() {
+        _items = [];
+        _hasNext = false;
+        _error = error.userMessage;
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _loadMore() async {
+    final generation = _generation;
+    setState(() => _loadingMore = true);
+    try {
+      final page = await _fetch(cursor: _cursor);
+      if (!mounted || generation != _generation) return;
+      setState(() {
+        _items = [..._items, ...page.content];
+        _cursor = page.nextCursor;
+        _hasNext = page.hasNext;
+        _loadingMore = false;
+      });
+    } on ApiException catch (error) {
+      if (!mounted || generation != _generation) return;
+      setState(() => _loadingMore = false);
+      showAppSnackbar(context, error.userMessage, isError: true);
+    }
+  }
+
+  Future<CursorPage<OrderHistoryItem>> _fetch({required int? cursor}) => ref
+      .read(orderRepositoryProvider)
+      .getOrderHistory(
+        walletId: widget.target.walletId,
+        exchangeCoinId: widget.target.exchangeCoinId,
+        status: _status,
+        cursorOrderId: cursor,
+        size: _kPageSize,
+      );
+
+  void _setStatus(OrderStatus status) {
+    if (_status == status) return;
+    setState(() => _status = status);
+    _reload();
+  }
+
+  Future<void> _cancel(OrderHistoryItem item) async {
+    try {
+      await ref
+          .read(orderRepositoryProvider)
+          .cancelOrder(
+            orderId: item.orderId,
+            walletId: widget.target.walletId,
+          );
+      if (!mounted) return;
+      // 목록을 다시 읽지 않는다 — 취소된 주문은 미체결 필터에서 사라진다. 풀린 잠금 잔고는
+      // 주문 시트가 열릴 때마다 `available` 을 새로 읽으므로 저절로 맞는다.
+      setState(
+        () => _items = [
+          for (final order in _items)
+            if (order.orderId != item.orderId) order,
+        ],
+      );
+      showAppSnackbar(context, '주문을 취소했습니다.');
+    } on ApiException catch (error) {
+      if (mounted) showAppSnackbar(context, error.userMessage, isError: true);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            TryptoSpacing.screen,
+            TryptoSpacing.sm,
+            TryptoSpacing.screen,
+            TryptoSpacing.sm,
+          ),
+          child: ExchangeSegment<OrderStatus>(
+            items: const [
+              SegmentItem(OrderStatus.filled, '체결'),
+              SegmentItem(OrderStatus.pending, '미체결'),
+            ],
+            value: _status,
+            onChanged: _setStatus,
+          ),
+        ),
+        Expanded(child: _body()),
+      ],
+    );
+  }
+
+  Widget _body() {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+
+    final error = _error;
+    if (error != null) {
+      return EmptyView(
+        icon: LucideIcons.circleAlert,
+        message: error,
+        action: OutlinedButton(
+          onPressed: _reload,
+          child: const Text('다시 시도'),
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _reload,
+      child: _items.isEmpty
+          ? ListView(
+              children: [
+                const SizedBox(height: 80),
+                EmptyView(
+                  icon: LucideIcons.receipt,
+                  message: _status == OrderStatus.filled
+                      ? '체결 내역이 없습니다.'
+                      : '미체결 주문이 없습니다.',
+                ),
+              ],
+            )
+          : ListView.builder(
+              controller: _scroll,
+              itemCount: _items.length + (_hasNext ? 1 : 0),
+              itemBuilder: (context, index) {
+                if (index == _items.length) {
+                  return const Padding(
+                    padding: EdgeInsets.all(TryptoSpacing.lg),
+                    child: Center(
+                      child: SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    ),
+                  );
+                }
+                final item = _items[index];
+                return _OrderTile(
+                  item: item,
+                  status: _status,
+                  symbol: widget.symbol,
+                  baseCurrency: widget.target.exchange.baseCurrency,
+                  onCancel: _status == OrderStatus.pending
+                      ? () => _cancel(item)
+                      : null,
+                );
+              },
+            ),
+    );
+  }
+}
+
+class _OrderTile extends StatelessWidget {
+  const _OrderTile({
+    required this.item,
+    required this.status,
+    required this.symbol,
+    required this.baseCurrency,
+    this.onCancel,
+  });
+
+  final OrderHistoryItem item;
+  final OrderStatus status;
+  final String symbol;
+  final String baseCurrency;
+  final VoidCallback? onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+    final buy = item.side == Side.buy;
+    // 미체결 주문은 체결가·체결금액이 없다. 지정가를 대신 보여준다.
+    final price = item.filledPrice ?? item.price ?? 0;
+    final amount = item.orderAmount ?? price * item.quantity;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: TryptoSpacing.screen,
+        vertical: TryptoSpacing.md,
+      ),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: TryptoPalette.border)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              TryptoBadge(
+                label: buy ? '매수' : '매도',
+                foreground: buy ? colors.positive : colors.negative,
+                background: (buy ? colors.positive : colors.negative).withValues(
+                  alpha: 0.15,
+                ),
+              ),
+              const SizedBox(width: TryptoSpacing.xs),
+              Text(
+                item.orderType == OrderType.market ? '시장가' : '지정가',
+                style: theme.textTheme.labelMedium,
+              ),
+              const SizedBox(width: TryptoSpacing.xs),
+              if (status == OrderStatus.pending)
+                const WarningBadge(label: '대기')
+              else
+                Text(
+                  '체결',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              const Spacer(),
+              Text(
+                ServerTime.relative(item.createdAt),
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: TryptoSpacing.sm),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Expanded(
+                child: _Cell(
+                  label: '가격',
+                  value:
+                      '${getCurrencySymbol(baseCurrency)}'
+                      '${formatPrice(price, baseCurrency)}',
+                ),
+              ),
+              Expanded(
+                child: _Cell(
+                  label: '수량',
+                  value: '${formatQuantity(item.quantity)} $symbol',
+                ),
+              ),
+              Expanded(
+                child: _Cell(
+                  label: '금액',
+                  value: formatCurrencyCompact(amount, baseCurrency),
+                ),
+              ),
+              if (onCancel != null)
+                TextButton(
+                  style: TryptoButtons.link,
+                  onPressed: onCancel,
+                  child: Text(
+                    '취소',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.error,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Cell extends StatelessWidget {
+  const _Cell({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 2),
+        NumericText(value, size: 12, weight: FontWeight.w500),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/market/order_sheet.dart
+++ b/mobile/lib/features/market/order_sheet.dart
@@ -1,0 +1,673 @@
+import 'package:decimal/decimal.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../core/api/api_exception.dart';
+import '../../core/format/formatters.dart';
+import '../../core/json/decimal_x.dart';
+import '../../core/realtime/ticker_store.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/app_snackbar.dart';
+import '../../core/widgets/exchange_segment.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../models/enums.dart';
+import 'market_controller.dart';
+import 'order_form.dart';
+import 'order_repository.dart';
+import 'order_target.dart';
+
+/// 웹의 360px 고정 사이드바를 바텀시트로 옮긴 것(계획서 §4.6.1). 입력 3개 + 비율 버튼 + 안내가
+/// 세로로 길어 시트를 크게 연다.
+Future<void> showOrderSheet(
+  BuildContext context, {
+  required OrderTarget target,
+  required CoinEntry entry,
+  required Side side,
+  required VoidCallback onPlaced,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    builder: (context) => DraggableScrollableSheet(
+      initialChildSize: 0.75,
+      minChildSize: 0.5,
+      maxChildSize: 0.95,
+      expand: false,
+      builder: (context, controller) => OrderSheet(
+        target: target,
+        entry: entry,
+        initialSide: side,
+        scrollController: controller,
+        onPlaced: onPlaced,
+      ),
+    ),
+  );
+}
+
+class OrderSheet extends ConsumerStatefulWidget {
+  const OrderSheet({
+    super.key,
+    required this.target,
+    required this.entry,
+    required this.initialSide,
+    required this.scrollController,
+    required this.onPlaced,
+  });
+
+  final OrderTarget target;
+  final CoinEntry entry;
+  final Side initialSide;
+  final ScrollController scrollController;
+
+  /// 체결 반영은 REST 재조회다(사양서 §4.4.8) — 거래내역·주문 가능 금액을 다시 읽게 한다.
+  final VoidCallback onPlaced;
+
+  @override
+  ConsumerState<OrderSheet> createState() => _OrderSheetState();
+}
+
+class _OrderSheetState extends ConsumerState<OrderSheet> {
+  final TextEditingController _priceInput = TextEditingController();
+  final TextEditingController _quantityInput = TextEditingController();
+  final TextEditingController _totalInput = TextEditingController();
+
+  late OrderForm _form = OrderForm.empty(side: widget.initialSide);
+
+  /// 멱등키. **재시도 시 같은 값을 재사용**해야 중복 주문이 생기지 않는다(사양서 §4.4.7).
+  /// 성공한 뒤에만 새로 만든다.
+  String _clientOrderId = const Uuid().v4();
+
+  Decimal _availableBuy = Decimal.zero;
+  Decimal _availableSell = Decimal.zero;
+  late Decimal _restPrice = widget.entry.price.dec;
+
+  bool _loading = true;
+  bool _submitting = false;
+  String? _availabilityError;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAvailability();
+  }
+
+  @override
+  void dispose() {
+    _priceInput.dispose();
+    _quantityInput.dispose();
+    _totalInput.dispose();
+    super.dispose();
+  }
+
+  /// 시장가 계산의 기준가. 티커는 Riverpod 그래프를 타지 않으므로 **행동 시점에 읽는다** —
+  /// 구독하면 초당 수백 번 시트가 리빌드된다.
+  Decimal get _currentPrice {
+    final live = ref.read(tickerStoreProvider).quote(widget.entry.symbol)?.price;
+    if (live != null && live > 0) return live.dec;
+    return _restPrice;
+  }
+
+  OrderContext get _ctx => OrderContext(
+    exchange: widget.target.exchange,
+    currentPrice: _currentPrice,
+    availableBuy: _availableBuy,
+    availableSell: _availableSell,
+  );
+
+  /// BUY/SELL 을 **병렬 2회** 호출한다(사양서 §4.4.4). 실패하면 두 값을 0 으로 두고 알린다.
+  Future<void> _loadAvailability() async {
+    setState(() {
+      _loading = true;
+      _availabilityError = null;
+    });
+    final repository = ref.read(orderRepositoryProvider);
+    try {
+      final results = await Future.wait([
+        for (final side in [Side.buy, Side.sell])
+          repository.getAvailability(
+            walletId: widget.target.walletId,
+            exchangeCoinId: widget.target.exchangeCoinId,
+            side: side,
+          ),
+      ]);
+      if (!mounted) return;
+      setState(() {
+        _availableBuy = results[0].available.dec;
+        _availableSell = results[1].available.dec;
+        if (results[0].currentPrice > 0) _restPrice = results[0].currentPrice.dec;
+        _loading = false;
+      });
+    } on ApiException catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _availableBuy = Decimal.zero;
+        _availableSell = Decimal.zero;
+        _availabilityError = error.userMessage;
+        _loading = false;
+      });
+    }
+  }
+
+  void _apply(OrderForm next, {OrderField? edited}) {
+    setState(() => _form = next);
+    // 사용자가 손대고 있는 칸의 텍스트는 건드리지 않는다. 커서가 튄다.
+    if (edited != OrderField.price) _sync(_priceInput, _amountText(next.price));
+    if (edited != OrderField.quantity) {
+      _sync(_quantityInput, _quantityText(next.quantity));
+    }
+    if (edited != OrderField.total) _sync(_totalInput, _amountText(next.total));
+  }
+
+  void _sync(TextEditingController controller, String text) {
+    if (controller.text == text) return;
+    controller.value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+  }
+
+  String _amountText(Decimal value) => value <= Decimal.zero
+      ? ''
+      : formatPrice(value.toDouble(), _ctx.baseCurrency);
+
+  String _quantityText(Decimal value) =>
+      value <= Decimal.zero ? '' : value.toString();
+
+  bool get _touched =>
+      _form.price > Decimal.zero ||
+      _form.quantity > Decimal.zero ||
+      _form.total > Decimal.zero;
+
+  void _reset() =>
+      _apply(OrderForm.empty(side: _form.side, orderType: _form.orderType));
+
+  Future<void> _submit() async {
+    final form = _form;
+    if (_submitting || form.validate(_ctx) != null) return;
+
+    setState(() => _submitting = true);
+    try {
+      await ref
+          .read(orderRepositoryProvider)
+          .placeOrder(
+            form.toRequest(
+              target: widget.target,
+              clientOrderId: _clientOrderId,
+            ),
+          );
+      if (!mounted) return;
+      showAppSnackbar(context, form.successMessage);
+      _clientOrderId = const Uuid().v4();
+      _reset();
+      widget.onPlaced();
+      await _loadAvailability();
+    } on ApiException catch (error) {
+      // 키를 바꾸지 않는다. 같은 주문을 다시 눌렀을 때 서버가 중복을 걸러야 한다.
+      if (mounted) showAppSnackbar(context, error.userMessage, isError: true);
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ctx = _ctx;
+    final error = _form.validate(ctx);
+    final buy = _form.side == Side.buy;
+
+    // 시트가 자체 ScaffoldMessenger 를 갖는다. 바깥 Scaffold 의 스낵바는 시트 뒤로 가려진다.
+    return ScaffoldMessenger(
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: Padding(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.viewInsetsOf(context).bottom,
+          ),
+          child: Column(
+            children: [
+              Expanded(
+                child: ListView(
+                  controller: widget.scrollController,
+                  padding: const EdgeInsets.fromLTRB(
+                    TryptoSpacing.screen,
+                    0,
+                    TryptoSpacing.screen,
+                    TryptoSpacing.lg,
+                  ),
+                  children: [
+                    _header(ctx),
+                    const SizedBox(height: TryptoSpacing.md),
+                    ExchangeSegment<Side>(
+                      items: const [
+                        SegmentItem(Side.buy, '매수'),
+                        SegmentItem(Side.sell, '매도'),
+                      ],
+                      value: _form.side,
+                      onChanged: (side) => _apply(_form.withSide(side)),
+                    ),
+                    const SizedBox(height: TryptoSpacing.sm),
+                    ExchangeSegment<OrderType>(
+                      items: const [
+                        SegmentItem(OrderType.limit, '지정가'),
+                        SegmentItem(OrderType.market, '시장가'),
+                      ],
+                      value: _form.orderType,
+                      onChanged: (type) =>
+                          _apply(_form.withOrderType(type, ctx)),
+                    ),
+                    const SizedBox(height: TryptoSpacing.md),
+                    _available(ctx),
+                    const SizedBox(height: TryptoSpacing.md),
+                    _priceField(ctx),
+                    if (_form.showsQuantity) ...[
+                      const SizedBox(height: TryptoSpacing.md),
+                      _OrderField(
+                        label: '주문 수량',
+                        suffix: widget.entry.symbol,
+                        controller: _quantityInput,
+                        onChanged: (text) => _apply(
+                          _form.withQuantity(parseAmountInput(text), ctx),
+                          edited: OrderField.quantity,
+                        ),
+                      ),
+                    ],
+                    if (_form.showsTotal) ...[
+                      const SizedBox(height: TryptoSpacing.md),
+                      _OrderField(
+                        label: '주문 총액',
+                        suffix: ctx.baseCurrency,
+                        controller: _totalInput,
+                        onChanged: (text) => _apply(
+                          _form.withTotal(parseAmountInput(text), ctx),
+                          edited: OrderField.total,
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: TryptoSpacing.md),
+                    _ratios(ctx),
+                    const SizedBox(height: TryptoSpacing.md),
+                    _notice(ctx),
+                  ],
+                ),
+              ),
+              _footer(ctx, error: error, buy: buy),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _header(OrderContext ctx) {
+    final theme = Theme.of(context);
+    final row = ref.watch(tickerStoreProvider).row(widget.entry.symbol);
+
+    Widget price(double value) => NumericText(
+      value <= 0
+          ? '-'
+          : '${getCurrencySymbol(ctx.baseCurrency)}'
+                '${formatPrice(value, ctx.baseCurrency)}',
+      size: 18,
+      weight: FontWeight.w700,
+    );
+
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(widget.entry.symbol, style: TryptoText.symbol),
+              const SizedBox(height: 2),
+              Text(
+                '${widget.entry.name} · ${ctx.exchange.name}',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (row == null)
+          price(_restPrice.toDouble())
+        else
+          ValueListenableBuilder<CoinRowState>(
+            valueListenable: row,
+            builder: (context, state, child) => price(state.price),
+          ),
+      ],
+    );
+  }
+
+  Widget _available(OrderContext ctx) {
+    final theme = Theme.of(context);
+    final buy = _form.side == Side.buy;
+    final error = _availabilityError;
+
+    return Container(
+      padding: const EdgeInsets.all(TryptoSpacing.md),
+      decoration: BoxDecoration(
+        color: TryptoPalette.secondary,
+        borderRadius: BorderRadius.circular(TryptoRadius.md),
+      ),
+      child: Row(
+        children: [
+          Text(
+            buy ? '주문 가능 금액' : '주문 가능 수량',
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const Spacer(),
+          if (_loading)
+            const SizedBox(
+              width: 14,
+              height: 14,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          else if (error != null)
+            Flexible(
+              child: Text(
+                error,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
+            )
+          else
+            NumericText(
+              buy
+                  ? ctx.amountLabel(_availableBuy)
+                  : '${formatQuantity(_availableSell.toDouble())} '
+                        '${widget.entry.symbol}',
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _priceField(OrderContext ctx) {
+    // 시장가는 가격 칸이 현재가로 고정되고 비활성이다(사양서 §4.4.2).
+    if (!_form.priceEditable) {
+      return _FixedPriceField(
+        text: formatPrice(ctx.currentPrice.toDouble(), ctx.baseCurrency),
+        suffix: ctx.baseCurrency,
+      );
+    }
+
+    return _OrderField(
+      label: '지정가',
+      suffix: ctx.baseCurrency,
+      controller: _priceInput,
+      onChanged: (text) =>
+          _apply(_form.withPrice(parseAmountInput(text), ctx), edited: OrderField.price),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton.outlined(
+            icon: const Icon(LucideIcons.minus, size: 14),
+            onPressed: () => _apply(_form.stepPrice(-1, ctx)),
+          ),
+          const SizedBox(width: TryptoSpacing.xs),
+          IconButton.outlined(
+            icon: const Icon(LucideIcons.plus, size: 14),
+            onPressed: () => _apply(_form.stepPrice(1, ctx)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _ratios(OrderContext ctx) {
+    return Row(
+      children: [
+        for (final ratio in kOrderRatios) ...[
+          Expanded(
+            child: OutlinedButton(
+              onPressed: _loading
+                  ? null
+                  : () => _apply(_form.applyRatio(ratio, ctx)),
+              child: Text('$ratio%'),
+            ),
+          ),
+          if (ratio != kOrderRatios.last) const SizedBox(width: TryptoSpacing.xs),
+        ],
+      ],
+    );
+  }
+
+  /// 수수료율·최소 주문 금액은 **거래소별 실제 값**이다. 웹은 둘 다 하드코딩이라 바이낸스에서도
+  /// `0.05%` / `최소 주문 5,000 USDT` 로 나온다(사양서 §4.4.5).
+  Widget _notice(OrderContext ctx) {
+    final theme = Theme.of(context);
+    final style = theme.textTheme.labelMedium?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+    );
+    final fee = ctx.exchange.feeRate * 100;
+
+    return Column(
+      children: [
+        Row(
+          children: [
+            Text('예상 수수료', style: style),
+            const Spacer(),
+            NumericText(
+              '${ctx.amountLabel(_form.feeOf(ctx))} '
+              '(${fee.toStringAsFixed(2)}%)',
+              size: 12,
+              weight: FontWeight.w500,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
+        const SizedBox(height: TryptoSpacing.xs),
+        Row(
+          children: [
+            Text('최소 주문 금액', style: style),
+            const Spacer(),
+            NumericText(
+              ctx.amountLabel(ctx.minOrderAmount),
+              size: 12,
+              weight: FontWeight.w500,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _footer(OrderContext ctx, {required String? error, required bool buy}) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+    final ready = error == null && !_loading;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(
+        TryptoSpacing.screen,
+        TryptoSpacing.md,
+        TryptoSpacing.screen,
+        TryptoSpacing.md,
+      ),
+      decoration: const BoxDecoration(
+        color: TryptoPalette.card,
+        border: Border(top: BorderSide(color: TryptoPalette.border)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // 아무것도 입력하지 않은 첫 화면에서 "수량을 입력해 주세요" 를 붉게 띄우지 않는다.
+          if (error != null && _touched) ...[
+            Text(
+              error,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.sm),
+          ],
+          Row(
+            children: [
+              TextButton(
+                onPressed: _submitting ? null : _reset,
+                child: const Text('초기화'),
+              ),
+              const SizedBox(width: TryptoSpacing.sm),
+              Expanded(
+                child: SizedBox(
+                  height: 48,
+                  child: FilledButton(
+                    style: FilledButton.styleFrom(
+                      backgroundColor: buy ? colors.positive : colors.negative,
+                      foregroundColor: Colors.white,
+                      disabledBackgroundColor:
+                          (buy ? colors.positive : colors.negative).withValues(
+                            alpha: 0.4,
+                          ),
+                      disabledForegroundColor: Colors.white,
+                    ),
+                    onPressed: ready && !_submitting ? _submit : null,
+                    child: _submitting
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Colors.white,
+                            ),
+                          )
+                        : Text(buy ? '매수' : '매도'),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 시장가의 가격 칸. `TextField` 를 비활성으로 두면 build 마다 컨트롤러를 새로 만들어야 한다.
+class _FixedPriceField extends StatelessWidget {
+  const _FixedPriceField({required this.text, required this.suffix});
+
+  final String text;
+  final String suffix;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '주문 가격 (현재가)',
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: TryptoSpacing.xs),
+        Container(
+          height: 36,
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(TryptoRadius.md),
+            border: Border.all(
+              color: TryptoPalette.secondary.withValues(alpha: 0.5),
+            ),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              NumericText(
+                text,
+                size: 16,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: TryptoSpacing.xs),
+              Text(
+                suffix,
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _OrderField extends StatelessWidget {
+  const _OrderField({
+    required this.label,
+    required this.suffix,
+    required this.controller,
+    required this.onChanged,
+    this.trailing,
+  });
+
+  final String label;
+  final String suffix;
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: TryptoSpacing.xs),
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: controller,
+                onChanged: onChanged,
+                textAlign: TextAlign.right,
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: true,
+                ),
+                inputFormatters: [
+                  FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
+                ],
+                style: TryptoText.numeric(size: 16),
+                decoration: InputDecoration(
+                  hintText: '0',
+                  suffixText: suffix,
+                  suffixStyle: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ),
+            if (trailing != null) ...[
+              const SizedBox(width: TryptoSpacing.sm),
+              trailing!,
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/market/order_target.dart
+++ b/mobile/lib/features/market/order_target.dart
@@ -1,0 +1,89 @@
+import '../../core/constants/exchanges.dart';
+import 'market_controller.dart';
+
+/// 주문 대상 해석 실패 3종(사양서 §1.10.2, §4.4.1). 문구는 웹과 같다.
+enum OrderTargetFailure {
+  noRound('진행 중인 라운드가 없어 주문할 수 없습니다.'),
+  coinUnlisted('이 코인은 아직 주문을 지원하지 않습니다.'),
+  lookupFailed('주문 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.');
+
+  const OrderTargetFailure(this.message);
+
+  final String message;
+}
+
+/// 주문·잔고 조회에 필요한 세 ID 의 묶음.
+///
+/// [key] 로 어느 (거래소, 코인) 의 것인지 함께 들고 다닌다 — 다른 코인으로 옮긴 직후 이전
+/// 코인의 주문 대상이 잘못 쓰이는 일을 막는다(사양서 §4.4.1).
+class OrderTarget {
+  const OrderTarget({
+    required this.exchange,
+    required this.symbol,
+    required this.walletId,
+    required this.exchangeCoinId,
+  });
+
+  final Exchange exchange;
+  final String symbol;
+  final int walletId;
+
+  /// 주문 API 는 `coinId` 가 아니라 `exchangeCoinId` 를 받는다. 송금 API 는 `coinId` 를 받는다.
+  final int exchangeCoinId;
+
+  int get exchangeId => exchange.id;
+
+  String get key => '${exchange.key}:$symbol';
+
+  @override
+  bool operator ==(Object other) =>
+      other is OrderTarget &&
+      other.key == key &&
+      other.walletId == walletId &&
+      other.exchangeCoinId == exchangeCoinId;
+
+  @override
+  int get hashCode => Object.hash(key, walletId, exchangeCoinId);
+}
+
+class OrderTargetResult {
+  const OrderTargetResult.resolved(OrderTarget this.target) : failure = null;
+
+  const OrderTargetResult.failed(OrderTargetFailure this.failure)
+    : target = null;
+
+  final OrderTarget? target;
+  final OrderTargetFailure? failure;
+}
+
+/// `exchangeId`(상수) → `walletId`(활성 라운드) → `exchangeCoinId`(코인 목록 캐시) 순서로
+/// 유도한다(사양서 §1.10.2). [coins] 가 null 이면 목록 조회 자체가 실패한 것이다.
+///
+/// 심볼 비교는 **대소문자를 무시한다**.
+OrderTargetResult resolveOrderTarget({
+  required Exchange exchange,
+  required String symbol,
+  required int? walletId,
+  required List<CoinEntry>? coins,
+}) {
+  if (walletId == null) {
+    return const OrderTargetResult.failed(OrderTargetFailure.noRound);
+  }
+  if (coins == null) {
+    return const OrderTargetResult.failed(OrderTargetFailure.lookupFailed);
+  }
+
+  final target = symbol.toUpperCase();
+  for (final entry in coins) {
+    if (entry.symbol.toUpperCase() != target) continue;
+    return OrderTargetResult.resolved(
+      OrderTarget(
+        exchange: exchange,
+        symbol: entry.symbol,
+        walletId: walletId,
+        exchangeCoinId: entry.coin.exchangeCoinId,
+      ),
+    );
+  }
+  return const OrderTargetResult.failed(OrderTargetFailure.coinUnlisted);
+}

--- a/mobile/lib/features/market/overview_cards.dart
+++ b/mobile/lib/features/market/overview_cards.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+
+import '../../core/format/formatters.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../core/widgets/profit_badge.dart';
+import 'market_controller.dart';
+
+/// 주요 코인 카드. 표시 대상은 `BTC/ETH/SOL` 고정이며 목록에 없는 심볼은 건너뛴다
+/// (사양서 §4.2.8). 하나도 없으면 영역 자체를 그리지 않는다.
+class OverviewCards extends StatelessWidget {
+  const OverviewCards({
+    super.key,
+    required this.coins,
+    required this.baseCurrency,
+  });
+
+  final List<CoinEntry> coins;
+  final String baseCurrency;
+
+  static const List<String> _symbols = ['BTC', 'ETH', 'SOL'];
+
+  @override
+  Widget build(BuildContext context) {
+    final bySymbol = {for (final entry in coins) entry.symbol: entry};
+    final featured = [
+      for (final symbol in _symbols)
+        if (bySymbol[symbol] case final entry?) entry,
+    ];
+    if (featured.isEmpty) return const SizedBox.shrink();
+
+    return SizedBox(
+      height: 84,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: TryptoSpacing.screen),
+        itemCount: featured.length,
+        separatorBuilder: (context, index) =>
+            const SizedBox(width: TryptoSpacing.sm),
+        itemBuilder: (context, index) =>
+            _OverviewCard(entry: featured[index], baseCurrency: baseCurrency),
+      ),
+    );
+  }
+}
+
+class _OverviewCard extends StatelessWidget {
+  const _OverviewCard({required this.entry, required this.baseCurrency});
+
+  final CoinEntry entry;
+  final String baseCurrency;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      width: 156,
+      padding: const EdgeInsets.all(TryptoSpacing.md),
+      decoration: BoxDecoration(
+        color: TryptoPalette.card,
+        borderRadius: BorderRadius.circular(TryptoRadius.xl),
+        border: Border.all(color: TryptoPalette.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  entry.symbol,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TryptoText.symbol,
+                ),
+              ),
+              ProfitBadge(
+                value: entry.changeRate,
+                text: formatChangeRate(entry.changeRate),
+              ),
+            ],
+          ),
+          Text(
+            entry.name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          NumericText(
+            entry.price <= 0
+                ? '-'
+                : '${getCurrencySymbol(baseCurrency)}'
+                      '${formatPrice(entry.price, baseCurrency)}',
+            size: 15,
+            weight: FontWeight.w700,
+            color: context.profitColor(entry.changeRate),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/market/overview_cards.dart
+++ b/mobile/lib/features/market/overview_cards.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/format/formatters.dart';
+import '../../core/realtime/ticker_store.dart';
 import '../../core/theme/theme.dart';
 import '../../core/theme/trypto_colors.dart';
 import '../../core/widgets/numeric_text.dart';
@@ -13,10 +14,12 @@ class OverviewCards extends StatelessWidget {
   const OverviewCards({
     super.key,
     required this.coins,
+    required this.store,
     required this.baseCurrency,
   });
 
   final List<CoinEntry> coins;
+  final TickerStore store;
   final String baseCurrency;
 
   static const List<String> _symbols = ['BTC', 'ETH', 'SOL'];
@@ -38,22 +41,33 @@ class OverviewCards extends StatelessWidget {
         itemCount: featured.length,
         separatorBuilder: (context, index) =>
             const SizedBox(width: TryptoSpacing.sm),
-        itemBuilder: (context, index) =>
-            _OverviewCard(entry: featured[index], baseCurrency: baseCurrency),
+        itemBuilder: (context, index) {
+          final entry = featured[index];
+          return _OverviewCard(
+            entry: entry,
+            row: store.row(entry.symbol),
+            baseCurrency: baseCurrency,
+          );
+        },
       ),
     );
   }
 }
 
 class _OverviewCard extends StatelessWidget {
-  const _OverviewCard({required this.entry, required this.baseCurrency});
+  const _OverviewCard({
+    required this.entry,
+    required this.row,
+    required this.baseCurrency,
+  });
 
   final CoinEntry entry;
+  final RowNotifier? row;
   final String baseCurrency;
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final notifier = row;
 
     return Container(
       width: 156,
@@ -63,45 +77,82 @@ class _OverviewCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(TryptoRadius.xl),
         border: Border.all(color: TryptoPalette.border),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  entry.symbol,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TryptoText.symbol,
-                ),
+      child: notifier == null
+          ? _CardBody(
+              symbol: entry.symbol,
+              name: entry.name,
+              price: entry.price,
+              changeRate: entry.changeRate,
+              baseCurrency: baseCurrency,
+            )
+          : ValueListenableBuilder<CoinRowState>(
+              valueListenable: notifier,
+              builder: (context, state, child) => _CardBody(
+                symbol: entry.symbol,
+                name: entry.name,
+                price: state.price,
+                changeRate: state.changeRate,
+                baseCurrency: baseCurrency,
               ),
-              ProfitBadge(
-                value: entry.changeRate,
-                text: formatChangeRate(entry.changeRate),
-              ),
-            ],
-          ),
-          Text(
-            entry.name,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
             ),
+    );
+  }
+}
+
+class _CardBody extends StatelessWidget {
+  const _CardBody({
+    required this.symbol,
+    required this.name,
+    required this.price,
+    required this.changeRate,
+    required this.baseCurrency,
+  });
+
+  final String symbol;
+  final String name;
+  final double price;
+  final double changeRate;
+  final String baseCurrency;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                symbol,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TryptoText.symbol,
+              ),
+            ),
+            ProfitBadge(value: changeRate, text: formatChangeRate(changeRate)),
+          ],
+        ),
+        Text(
+          name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
           ),
-          NumericText(
-            entry.price <= 0
-                ? '-'
-                : '${getCurrencySymbol(baseCurrency)}'
-                      '${formatPrice(entry.price, baseCurrency)}',
-            size: 15,
-            weight: FontWeight.w700,
-            color: context.profitColor(entry.changeRate),
-          ),
-        ],
-      ),
+        ),
+        NumericText(
+          price <= 0
+              ? '-'
+              : '${getCurrencySymbol(baseCurrency)}'
+                    '${formatPrice(price, baseCurrency)}',
+          size: 15,
+          weight: FontWeight.w700,
+          color: context.profitColor(changeRate),
+        ),
+      ],
     );
   }
 }

--- a/mobile/lib/features/mypage/feedback_card.dart
+++ b/mobile/lib/features/mypage/feedback_card.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/api/api_exception.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/app_snackbar.dart';
+import 'feedback_repository.dart';
+
+const int kFeedbackMin = 20;
+const int kFeedbackMax = 1000;
+
+/// 길이 기준은 `trim()` 후의 길이다 — 서버도 strip 후 20~1000자를 강제한다(사양서 §7.5.3).
+String? validateFeedback(String raw) {
+  final value = raw.trim();
+  if (value.length < kFeedbackMin) return '최소 $kFeedbackMin자 이상 입력해주세요.';
+  if (value.length > kFeedbackMax) return '$kFeedbackMax자 이하로 입력해주세요.';
+  return null;
+}
+
+class FeedbackCard extends ConsumerStatefulWidget {
+  const FeedbackCard({super.key});
+
+  @override
+  ConsumerState<FeedbackCard> createState() => _FeedbackCardState();
+}
+
+class _FeedbackCardState extends ConsumerState<FeedbackCard> {
+  final TextEditingController _controller = TextEditingController();
+
+  bool _sending = false;
+  int _length = 0;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _send() async {
+    final content = _controller.text.trim();
+    if (validateFeedback(content) != null) return;
+
+    setState(() => _sending = true);
+    try {
+      await ref.read(feedbackRepositoryProvider).sendFeedback(content);
+      if (!mounted) return;
+      _controller.clear();
+      setState(() {
+        _sending = false;
+        _length = 0;
+      });
+      showAppSnackbar(context, '피드백이 접수되었습니다. 소중한 의견 감사합니다.');
+    } on ApiException catch (error) {
+      if (!mounted) return;
+      setState(() => _sending = false);
+      showAppSnackbar(context, error.userMessage, isError: true);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+    final short = _length < kFeedbackMin;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(TryptoSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('피드백 보내기', style: theme.textTheme.titleMedium),
+            const SizedBox(height: TryptoSpacing.xs),
+            Text(
+              '사용하면서 느낀 점이나 개선했으면 하는 부분을 알려주세요.',
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.md),
+            TextField(
+              controller: _controller,
+              maxLines: 5,
+              maxLength: kFeedbackMax,
+              enabled: !_sending,
+              decoration: const InputDecoration(
+                hintText: '어떤 점이 좋았고, 무엇이 아쉬웠나요?',
+                counterText: '',
+              ),
+              onChanged: (value) =>
+                  setState(() => _length = value.trim().length),
+            ),
+            const SizedBox(height: TryptoSpacing.xs),
+            Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                short && _length > 0
+                    ? '최소 $kFeedbackMin자 이상 입력해주세요.'
+                    : '$_length / $kFeedbackMax자',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: short && _length > 0
+                      ? colors.negative
+                      : theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.md),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _sending || short ? null : _send,
+                child: Text(_sending ? '보내는 중...' : '보내기'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/mypage/mypage_page.dart
+++ b/mobile/lib/features/mypage/mypage_page.dart
@@ -1,42 +1,507 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
+import '../../core/format/formatters.dart';
+import '../../core/format/server_time.dart';
+import '../../core/router/guard.dart';
 import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/app_snackbar.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../core/widgets/profit_badge.dart';
+import '../../models/enums.dart';
 import '../auth/auth_controller.dart';
+import '../round/round_controller.dart';
+import '../round/round_end_sheet.dart';
+import '../round/round_rules.dart';
+import 'feedback_card.dart';
+import 'nickname_sheet.dart';
+import 'user_repository.dart';
 
-/// 프로필·닉네임·피드백·회원 탈퇴는 17단위에서 붙는다. 로그아웃은 라우터 가드를 검증하는
-/// 유일한 경로이므로 먼저 만든다 — 인증 상태가 비면 redirect 가 /login 으로 보낸다.
-class MypagePage extends ConsumerWidget {
+/// 웹의 2열 그리드를 세로 1열 카드 스택으로 편다 — 프로필 → 현재 라운드 → 피드백 → 로그아웃 →
+/// 회원 탈퇴(사양서 §7.6).
+class MypagePage extends StatelessWidget {
   const MypagePage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final user = ref.watch(authControllerProvider).user;
-    final theme = Theme.of(context);
-
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('마이페이지')),
       body: ListView(
         padding: const EdgeInsets.all(TryptoSpacing.screen),
+        children: const [
+          _ProfileCard(),
+          SizedBox(height: TryptoSpacing.md),
+          _RoundCard(),
+          SizedBox(height: TryptoSpacing.md),
+          FeedbackCard(),
+          SizedBox(height: TryptoSpacing.xl),
+          _AccountActions(),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfileCard extends ConsumerWidget {
+  const _ProfileCard();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final user = ref.watch(authControllerProvider).user;
+    final profile = ref.watch(userProfileProvider);
+
+    return Card(
+      child: Column(
         children: [
           ListTile(
-            leading: const Icon(LucideIcons.circleUser),
-            title: Text(user?.nickname ?? '-'),
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: TryptoSpacing.lg,
+              vertical: TryptoSpacing.sm,
+            ),
+            leading: Container(
+              width: 40,
+              height: 40,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primary.withValues(alpha: 0.12),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                LucideIcons.user,
+                size: 20,
+                color: theme.colorScheme.primary,
+              ),
+            ),
+            title: Text(
+              user?.nickname ?? '-',
+              style: theme.textTheme.titleMedium,
+            ),
             subtitle: Text(
               '회원번호 ${user?.userId ?? '-'}',
-              style: theme.textTheme.labelMedium?.copyWith(
+              style: theme.textTheme.labelSmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
             ),
+            trailing: const Icon(LucideIcons.pencil, size: 16),
+            onTap: user == null
+                ? null
+                : () async {
+                    final changed = await showNicknameSheet(
+                      context,
+                      current: user.nickname,
+                    );
+                    if (!changed || !context.mounted) return;
+                    showAppSnackbar(context, '닉네임을 변경했습니다.');
+                  },
           ),
-          const SizedBox(height: TryptoSpacing.xl),
-          OutlinedButton.icon(
+          const Divider(),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              TryptoSpacing.lg,
+              TryptoSpacing.md,
+              TryptoSpacing.lg,
+              TryptoSpacing.lg,
+            ),
+            child: Row(
+              children: [
+                Text(
+                  '가입일',
+                  style: theme.textTheme.labelLarge?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const Spacer(),
+                // 조회가 실패해도 화면을 무너뜨리지 않는다. 웹과 같이 `-` 로 떨어진다.
+                NumericText(
+                  profile.maybeWhen(
+                    data: (data) => ServerTime.formatKoreanDate(data.createdAt),
+                    orElse: () => '-',
+                  ),
+                  size: 13,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RoundCard extends ConsumerWidget {
+  const _RoundCard();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final round = ref.watch(
+      roundControllerProvider.select((state) => state.activeRound),
+    );
+
+    if (round == null) {
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(TryptoSpacing.lg),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('현재 라운드', style: theme.textTheme.titleMedium),
+              const SizedBox(height: TryptoSpacing.sm),
+              Text(
+                '진행 중인 라운드가 없습니다.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: TryptoSpacing.md),
+              OutlinedButton(
+                onPressed: () => context.go(Routes.roundNew),
+                child: const Text('새 라운드 시작'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(TryptoSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(
+                  '라운드 ${round.roundNumber}',
+                  style: theme.textTheme.titleMedium,
+                ),
+                const SizedBox(width: TryptoSpacing.sm),
+                _RoundStatusBadge(status: round.status),
+              ],
+            ),
+            const SizedBox(height: TryptoSpacing.xs),
+            Text(
+              '시작일 ${ServerTime.formatKoreanDate(round.startedAt)}',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.lg),
+            // 3칸 그리드는 폭이 좁다. 시드머니를 전체 폭으로 빼고 나머지를 2열로 둔다(§7.5.2).
+            // 금액은 축약하지 않는다.
+            _RoundStat(
+              label: '시드머니',
+              value: '${formatGrouped(round.initialSeed)}원',
+              size: 20,
+            ),
+            const SizedBox(height: TryptoSpacing.md),
+            Row(
+              children: [
+                Expanded(
+                  child: _RoundStat(
+                    label: '긴급자금 상한',
+                    value: '${formatGrouped(round.emergencyFundingLimit)}원',
+                  ),
+                ),
+                Expanded(
+                  child: _RoundStat(
+                    label: '남은 충전',
+                    value: '${round.emergencyChargeCount}회',
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: TryptoSpacing.lg),
+            Text('투자 원칙', style: theme.textTheme.titleMedium),
+            const SizedBox(height: TryptoSpacing.sm),
+            if (round.rules.isEmpty)
+              Text(
+                '설정된 원칙이 없습니다.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              )
+            else
+              // 5종 전부 처리한다 — 과거 라운드가 손절·익절을 가질 수 있다.
+              for (final rule in round.rules)
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    vertical: TryptoSpacing.xs,
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          ruleLabels[rule.ruleType] ?? '알 수 없는 원칙',
+                          style: theme.textTheme.labelLarge,
+                        ),
+                      ),
+                      NumericText(
+                        '${_threshold(rule.thresholdValue)}'
+                        '${ruleUnits[rule.ruleType] ?? ''}',
+                        size: 13,
+                      ),
+                    ],
+                  ),
+                ),
+            const SizedBox(height: TryptoSpacing.lg),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: () => confirmEndRound(context, ref),
+                icon: Icon(
+                  LucideIcons.flagOff,
+                  size: 16,
+                  color: context.tryptoColors.negative,
+                ),
+                label: Text(
+                  '라운드 종료',
+                  style: TextStyle(color: context.tryptoColors.negative),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _threshold(double value) =>
+    value == value.roundToDouble() ? '${value.toInt()}' : '$value';
+
+class _RoundStatusBadge extends StatelessWidget {
+  const _RoundStatusBadge({required this.status});
+
+  final RoundStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+
+    final (String label, Color foreground, Color? background) = switch (status) {
+      RoundStatus.active => (
+        '진행중',
+        theme.colorScheme.primary,
+        theme.colorScheme.primary.withValues(alpha: 0.12),
+      ),
+      RoundStatus.bankrupt => (
+        '파산',
+        colors.negative,
+        colors.negative.withValues(alpha: 0.15),
+      ),
+      RoundStatus.ended => (
+        '종료',
+        theme.colorScheme.onSurfaceVariant,
+        theme.colorScheme.surfaceContainer,
+      ),
+      RoundStatus.unknown => (
+        '알 수 없음',
+        theme.colorScheme.onSurfaceVariant,
+        null,
+      ),
+    };
+
+    return TryptoBadge(
+      label: label,
+      foreground: foreground,
+      background: background,
+    );
+  }
+}
+
+class _RoundStat extends StatelessWidget {
+  const _RoundStat({required this.label, required this.value, this.size = 14});
+
+  final String label;
+  final String value;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 2),
+        NumericText(value, size: size, weight: FontWeight.w700),
+      ],
+    );
+  }
+}
+
+class _AccountActions extends ConsumerWidget {
+  const _AccountActions();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+
+    return Column(
+      children: [
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton.icon(
+            // 서버 호출이 실패해도 로컬 상태를 비운다. 인증이 비면 redirect 가 /login 으로 보낸다.
             onPressed: () => ref.read(authControllerProvider.notifier).logout(),
             icon: const Icon(LucideIcons.logOut, size: 16),
             label: const Text('로그아웃'),
           ),
-        ],
+        ),
+        const SizedBox(height: TryptoSpacing.xl),
+        TextButton(
+          onPressed: () => _confirmDeleteAccount(context, ref),
+          child: Text(
+            '회원 탈퇴',
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: colors.negative,
+              decoration: TextDecoration.underline,
+              decorationColor: colors.negative,
+            ),
+          ),
+        ),
+        const SizedBox(height: TryptoSpacing.sm),
+      ],
+    );
+  }
+}
+
+/// 회원 탈퇴(사양서 R11). 웹에는 호출부가 없지만 **iOS 심사 지침상 필수**다.
+///
+/// 되돌릴 수 없으므로 확인을 2단계로 둔다: 안내 시트 → 최종 확인 다이얼로그. 성공하면 인증
+/// 상태가 비고 redirect 가 `/login` 으로 보낸다.
+Future<void> _confirmDeleteAccount(BuildContext context, WidgetRef ref) async {
+  final proceed = await showModalBottomSheet<bool>(
+    context: context,
+    useSafeArea: true,
+    builder: (context) => const _DeleteAccountSheet(),
+  );
+  if (proceed != true || !context.mounted) return;
+
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('정말 탈퇴하시겠습니까?'),
+      content: const Text('탈퇴 후에는 데이터를 복구할 수 없습니다.'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('취소'),
+        ),
+        FilledButton(
+          style: TryptoButtons.destructive,
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('탈퇴'),
+        ),
+      ],
+    ),
+  );
+  if (confirmed != true || !context.mounted) return;
+
+  // 성공하면 이 화면은 redirect 로 사라진다. 메신저를 미리 잡아 두어야 완료 안내를 띄울 수 있다.
+  final messenger = ScaffoldMessenger.of(context);
+  final error = await ref.read(authControllerProvider.notifier).deleteAccount();
+  if (error != null) {
+    if (!context.mounted) return;
+    showAppSnackbar(context, error, isError: true);
+    return;
+  }
+  messenger
+    ..hideCurrentSnackBar()
+    ..showSnackBar(const SnackBar(content: Text('회원 탈퇴가 완료되었습니다.')));
+}
+
+class _DeleteAccountSheet extends StatelessWidget {
+  const _DeleteAccountSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          TryptoSpacing.screen,
+          0,
+          TryptoSpacing.screen,
+          TryptoSpacing.screen,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  LucideIcons.triangleAlert,
+                  size: 18,
+                  color: colors.negative,
+                ),
+                const SizedBox(width: TryptoSpacing.sm),
+                Text('회원 탈퇴', style: theme.textTheme.titleLarge),
+              ],
+            ),
+            const SizedBox(height: TryptoSpacing.md),
+            for (final line in const [
+              '진행 중인 라운드가 종료되고 모든 거래·자산·랭킹 기록이 삭제됩니다.',
+              '탈퇴 후 30일 동안은 같은 소셜 계정으로 다시 가입할 수 없습니다.',
+              '삭제된 데이터는 복구할 수 없습니다.',
+            ])
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: TryptoSpacing.xs),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      LucideIcons.dot,
+                      size: 16,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    Expanded(
+                      child: Text(
+                        line,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            const SizedBox(height: TryptoSpacing.xl),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                style: TryptoButtons.destructive,
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('탈퇴하기'),
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.sm),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('취소'),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/features/mypage/nickname_sheet.dart
+++ b/mobile/lib/features/mypage/nickname_sheet.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/api/api_exception.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../auth/auth_controller.dart';
+import 'user_repository.dart';
+
+const int kNicknameMin = 2;
+const int kNicknameMax = 20;
+
+/// 서버 제약은 2~20자다(위반 시 400 `INVALID_NICKNAME_LENGTH`). 웹은 길이 검증을 하지 않고
+/// 실패해도 화면에 아무 표시가 없다(사양서 §7.5.1 · R9). **입력 단계에서** 막는다.
+String? validateNickname(String raw) {
+  final value = raw.trim();
+  if (value.length < kNicknameMin || value.length > kNicknameMax) {
+    return '닉네임은 $kNicknameMin~$kNicknameMax자여야 합니다.';
+  }
+  return null;
+}
+
+/// 닉네임을 실제로 바꿨으면 `true`. 호출부가 성공 스낵바를 띄운다 — 시트가 닫힌 뒤에는 시트의
+/// `context` 로 스낵바를 띄울 수 없다.
+Future<bool> showNicknameSheet(
+  BuildContext context, {
+  required String current,
+}) async {
+  final changed = await showModalBottomSheet<bool>(
+    context: context,
+    useSafeArea: true,
+    isScrollControlled: true,
+    builder: (context) => Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.viewInsetsOf(context).bottom,
+      ),
+      child: _NicknameSheet(current: current),
+    ),
+  );
+  return changed ?? false;
+}
+
+class _NicknameSheet extends ConsumerStatefulWidget {
+  const _NicknameSheet({required this.current});
+
+  final String current;
+
+  @override
+  ConsumerState<_NicknameSheet> createState() => _NicknameSheetState();
+}
+
+class _NicknameSheetState extends ConsumerState<_NicknameSheet> {
+  late final TextEditingController _controller = TextEditingController(
+    text: widget.current,
+  );
+
+  bool _saving = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final value = _controller.text.trim();
+    final invalid = validateNickname(value);
+    if (invalid != null) {
+      setState(() => _error = invalid);
+      return;
+    }
+    // 값이 그대로면 요청을 보내지 않는다.
+    if (value == widget.current) {
+      Navigator.of(context).pop(false);
+      return;
+    }
+
+    setState(() {
+      _saving = true;
+      _error = null;
+    });
+    try {
+      final response = await ref
+          .read(userRepositoryProvider)
+          .changeNickname(value);
+      ref.read(authControllerProvider.notifier).updateNickname(
+        response.nickname,
+      );
+      ref.invalidate(userProfileProvider);
+      if (!mounted) return;
+      Navigator.of(context).pop(true);
+    } on ApiException catch (error) {
+      if (!mounted) return;
+      // 시트 안에서 알린다. 시트 뒤로 스낵바를 던지면 가려서 보이지 않는다.
+      setState(() {
+        _saving = false;
+        _error = error.userMessage;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final error = _error;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          TryptoSpacing.screen,
+          0,
+          TryptoSpacing.screen,
+          TryptoSpacing.screen,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('닉네임 변경', style: theme.textTheme.titleLarge),
+            const SizedBox(height: TryptoSpacing.lg),
+            TextField(
+              controller: _controller,
+              autofocus: true,
+              maxLength: kNicknameMax,
+              enabled: !_saving,
+              textInputAction: TextInputAction.done,
+              decoration: InputDecoration(
+                hintText: '$kNicknameMin~$kNicknameMax자',
+                errorText: error,
+                counterText: '',
+              ),
+              onChanged: (value) {
+                final invalid = validateNickname(value);
+                if (invalid == _error) return;
+                setState(() => _error = invalid);
+              },
+              onSubmitted: (_) => _save(),
+            ),
+            const SizedBox(height: TryptoSpacing.xs),
+            Text(
+              '${_controller.text.trim().length} / $kNicknameMax자',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: error == null
+                    ? theme.colorScheme.onSurfaceVariant
+                    : context.tryptoColors.negative,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.lg),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _saving || error != null ? null : _save,
+                child: Text(_saving ? '저장 중...' : '저장'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/mypage/user_repository.dart
+++ b/mobile/lib/features/mypage/user_repository.dart
@@ -38,3 +38,9 @@ class UserRepository {
 final userRepositoryProvider = Provider<UserRepository>(
   (ref) => UserRepository(ref.watch(dioProvider)),
 );
+
+/// 마이페이지의 가입일. 부팅 시 세션 복구가 읽는 것과 같은 엔드포인트지만, 그쪽은 인증 여부만
+/// 확인하고 프로필을 보관하지 않는다.
+final userProfileProvider = FutureProvider<UserProfile>(
+  (ref) => ref.watch(userRepositoryProvider).getMe(),
+);

--- a/mobile/lib/features/portfolio/donut_painter.dart
+++ b/mobile/lib/features/portfolio/donut_painter.dart
@@ -1,0 +1,360 @@
+import 'dart:math' as math;
+
+import 'package:decimal/decimal.dart';
+import 'package:flutter/material.dart';
+
+import '../../core/format/formatters.dart';
+import '../../core/theme/theme.dart';
+import '../../core/widgets/numeric_text.dart';
+import 'portfolio_summary.dart';
+
+/// §8.1.5 — 미등록 심볼과 "기타" 조각이 같은 회색을 쓴다.
+const Color _kFallback = Color(0xFF8B949E);
+
+/// 기준통화 조각 색(`DonutChart.tsx`).
+const Color _kCash = Color(0xFFC2B8AB);
+
+const Map<String, Color> _kCoinColors = {
+  'BTC': Color(0xFFF7931A),
+  'ETH': Color(0xFF627EEA),
+  'XRP': Color(0xFF00AAE4),
+  'SOL': Color(0xFF9945FF),
+  'DOGE': Color(0xFFC2A633),
+  'ADA': Color(0xFF0033AD),
+  'AVAX': Color(0xFFE84142),
+  'DOT': Color(0xFFE6007A),
+  'LINK': Color(0xFF2A5ADA),
+  'MATIC': Color(0xFF8247E5),
+  'ATOM': Color(0xFF2E3148),
+  'UNI': Color(0xFFFF007A),
+  'AAVE': Color(0xFFB6509E),
+  'SAND': Color(0xFF04ADEF),
+  'MANA': Color(0xFFFF2D55),
+  'BNB': Color(0xFFF3BA2F),
+  'ARB': Color(0xFF28A0F0),
+  'OP': Color(0xFFFF0420),
+  'EOS': Color(0xFF000000),
+  'TRX': Color(0xFFEF0027),
+  'QTUM': Color(0xFF2E9AD0),
+  'JUP': Color(0xFF00D18C),
+  'BONK': Color(0xFFF8A100),
+  'RAY': Color(0xFF6C5CE7),
+  'ORCA': Color(0xFFFFDA44),
+  'MNGO': Color(0xFFE4572E),
+  'PYTH': Color(0xFF7B61FF),
+  'WIF': Color(0xFFC08B5C),
+  'RENDER': Color(0xFF1A1A2E),
+  'HNT': Color(0xFF474DFF),
+  'MSOL': Color(0xFF9945FF),
+};
+
+Color coinColor(String symbol) => _kCoinColors[symbol] ?? _kFallback;
+
+const double _kDonutSize = 180;
+const double _kRadius = 73;
+const double _kStroke = 28;
+const double _kStrokeSelected = 34;
+
+/// 코인 조각의 최대 개수. 이보다 많으면 상위 5개 + "기타" 로 접는다(사양서 §5.1.4-3).
+const int _kMaxCoinSegments = 6;
+
+class DonutSegment {
+  const DonutSegment({
+    required this.label,
+    required this.value,
+    required this.ratio,
+    required this.color,
+  });
+
+  final String label;
+  final double value;
+
+  /// 0~1. 총자산 대비 비중이다.
+  final double ratio;
+
+  final Color color;
+}
+
+/// 현금 조각이 맨 앞, 이어서 코인 조각을 value 내림차순으로 놓는다(사양서 §5.1.4).
+/// 총자산이 0이면 조각이 없다 — 도넛은 배경 원만 그린다.
+List<DonutSegment> buildDonutSegments(PortfolioSummary summary) {
+  final total = summary.totalAsset.toDouble();
+  if (total <= 0) return const [];
+
+  final coins = [
+    for (final holding in summary.holdings)
+      if (holding.evalAmount > Decimal.zero)
+        (
+          label: holding.symbol,
+          value: holding.evalAmount.toDouble(),
+          color: coinColor(holding.symbol),
+        ),
+  ]..sort((a, b) => b.value.compareTo(a.value));
+
+  final folded = coins.length > _kMaxCoinSegments
+      ? [
+          ...coins.take(_kMaxCoinSegments - 1),
+          (
+            label: '기타',
+            value: coins
+                .skip(_kMaxCoinSegments - 1)
+                .fold<double>(0, (sum, coin) => sum + coin.value),
+            color: _kFallback,
+          ),
+        ]
+      : coins;
+
+  final cash = summary.cash.toDouble();
+  return [
+    if (cash > 0)
+      DonutSegment(
+        label: summary.baseCurrency,
+        value: cash,
+        ratio: cash / total,
+        color: _kCash,
+      ),
+    for (final coin in folded)
+      DonutSegment(
+        label: coin.label,
+        value: coin.value,
+        ratio: coin.value / total,
+        color: coin.color,
+      ),
+  ];
+}
+
+/// 자산 구성. 웹의 hover 강조를 **조각/범례 탭** 토글로 옮긴다.
+class DonutChart extends StatefulWidget {
+  const DonutChart({
+    super.key,
+    required this.segments,
+    required this.totalAsset,
+    required this.baseCurrency,
+  });
+
+  final List<DonutSegment> segments;
+  final double totalAsset;
+  final String baseCurrency;
+
+  @override
+  State<DonutChart> createState() => _DonutChartState();
+}
+
+class _DonutChartState extends State<DonutChart> {
+  int? _selected;
+
+  @override
+  void didUpdateWidget(DonutChart oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_selected != null && _selected! >= widget.segments.length) {
+      _selected = null;
+    }
+  }
+
+  void _toggle(int index) =>
+      setState(() => _selected = _selected == index ? null : index);
+
+  /// 조각 히트 테스트. 중심에서의 거리가 링 위이고, 12시부터 시계 방향으로 잰 각도가
+  /// 조각의 스윕 안에 들어오는 조각을 고른다.
+  void _tapDonut(Offset local) {
+    const center = Offset(_kDonutSize / 2, _kDonutSize / 2);
+    final offset = local - center;
+    final distance = offset.distance;
+    if (distance < _kRadius - _kStrokeSelected / 2 ||
+        distance > _kRadius + _kStrokeSelected / 2) {
+      return;
+    }
+
+    final angle =
+        (math.atan2(offset.dy, offset.dx) + math.pi / 2 + 2 * math.pi) %
+        (2 * math.pi);
+    var start = 0.0;
+    for (var i = 0; i < widget.segments.length; i++) {
+      final end = start + widget.segments[i].ratio * 2 * math.pi;
+      if (angle >= start && angle < end) {
+        _toggle(i);
+        return;
+      }
+      start = end;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final selected = _selected == null ? null : widget.segments[_selected!];
+
+    return Column(
+      children: [
+        GestureDetector(
+          onTapUp: (details) => _tapDonut(details.localPosition),
+          child: SizedBox(
+            width: _kDonutSize,
+            height: _kDonutSize,
+            child: CustomPaint(
+              painter: DonutPainter(
+                segments: widget.segments,
+                selected: _selected,
+                track: TryptoPalette.secondary,
+              ),
+              child: Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      selected?.label ?? '총 자산',
+                      style: TryptoText.micro.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    NumericText(
+                      formatCurrency(
+                        selected?.value ?? widget.totalAsset,
+                        widget.baseCurrency,
+                      ),
+                      size: 15,
+                      weight: FontWeight.w700,
+                    ),
+                    if (selected != null) ...[
+                      const SizedBox(height: 2),
+                      NumericText(
+                        '${(selected.ratio * 100).toStringAsFixed(1)}%',
+                        size: 11,
+                        weight: FontWeight.w500,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: TryptoSpacing.lg),
+        for (var i = 0; i < widget.segments.length; i++)
+          _LegendRow(
+            segment: widget.segments[i],
+            selected: _selected == i,
+            dimmed: _selected != null && _selected != i,
+            onTap: () => _toggle(i),
+          ),
+      ],
+    );
+  }
+}
+
+class _LegendRow extends StatelessWidget {
+  const _LegendRow({
+    required this.segment,
+    required this.selected,
+    required this.dimmed,
+    required this.onTap,
+  });
+
+  final DonutSegment segment;
+  final bool selected;
+  final bool dimmed;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    // 알파는 색으로만 준다. Opacity 위젯은 saveLayer 를 만든다(계획서 §4.2.5-8).
+    final alpha = dimmed ? 0.4 : 1.0;
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(TryptoRadius.md),
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: TryptoSpacing.sm,
+          vertical: TryptoSpacing.xs,
+        ),
+        decoration: BoxDecoration(
+          color: selected
+              ? theme.colorScheme.primary.withValues(alpha: 0.06)
+              : null,
+          borderRadius: BorderRadius.circular(TryptoRadius.md),
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 8,
+              height: 8,
+              decoration: BoxDecoration(
+                color: segment.color.withValues(alpha: alpha),
+                shape: BoxShape.circle,
+              ),
+            ),
+            const SizedBox(width: TryptoSpacing.sm),
+            Expanded(
+              child: Text(
+                segment.label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: alpha),
+                ),
+              ),
+            ),
+            NumericText(
+              '${(segment.ratio * 100).toStringAsFixed(1)}%',
+              size: 12,
+              weight: FontWeight.w500,
+              color: theme.colorScheme.onSurfaceVariant.withValues(
+                alpha: alpha,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 12시에서 시작해 시계 방향, 끝 모양은 `butt`(사양서 §5.1.4). 선택된 조각만 두께가 굵어진다.
+class DonutPainter extends CustomPainter {
+  const DonutPainter({
+    required this.segments,
+    required this.selected,
+    required this.track,
+  });
+
+  final List<DonutSegment> segments;
+  final int? selected;
+  final Color track;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rect = Rect.fromCircle(
+      center: size.center(Offset.zero),
+      radius: _kRadius,
+    );
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.butt
+      ..strokeWidth = _kStroke
+      ..color = track;
+    canvas.drawArc(rect, 0, 2 * math.pi, false, paint);
+
+    var start = -math.pi / 2;
+    for (var i = 0; i < segments.length; i++) {
+      final segment = segments[i];
+      final sweep = segment.ratio * 2 * math.pi;
+      paint
+        ..strokeWidth = selected == i ? _kStrokeSelected : _kStroke
+        ..color = selected == null || selected == i
+            ? segment.color
+            : segment.color.withValues(alpha: 0.4);
+      canvas.drawArc(rect, start, sweep, false, paint);
+      start += sweep;
+    }
+  }
+
+  @override
+  bool shouldRepaint(DonutPainter old) =>
+      old.selected != selected ||
+      old.track != track ||
+      !identical(old.segments, segments);
+}

--- a/mobile/lib/features/portfolio/holding_card.dart
+++ b/mobile/lib/features/portfolio/holding_card.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+
+import '../../core/format/formatters.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../core/widgets/profit_badge.dart';
+import 'portfolio_summary.dart';
+
+/// 웹의 7열 표(§5.1.5)를 카드 한 장으로 접는다. 상단 심볼·수익률, 중단 평가금액·평가손익,
+/// 하단 보유수량·평균매수가·현재가.
+class HoldingCard extends StatelessWidget {
+  const HoldingCard({
+    super.key,
+    required this.holding,
+    required this.baseCurrency,
+    required this.onTap,
+  });
+
+  final HoldingView holding;
+  final String baseCurrency;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final profitLoss = holding.profitLoss.toDouble();
+    final sign = profitLoss > 0 ? '+' : '';
+
+    return Card(
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(TryptoSpacing.lg),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Text(holding.symbol, style: TryptoText.symbol),
+                  const SizedBox(width: TryptoSpacing.xs),
+                  Expanded(
+                    child: Text(
+                      holding.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                  ProfitBadge(
+                    value: holding.profitRate,
+                    text: '${holding.profitRate > 0 ? '+' : ''}'
+                        '${holding.profitRate.toStringAsFixed(2)}%',
+                  ),
+                ],
+              ),
+              const SizedBox(height: TryptoSpacing.md),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '평가금액',
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        NumericText(
+                          formatCurrencyCompact(
+                            holding.evalAmount.toDouble(),
+                            baseCurrency,
+                          ),
+                          size: 18,
+                          weight: FontWeight.w700,
+                        ),
+                      ],
+                    ),
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        '평가손익',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      NumericText(
+                        '$sign${formatCurrencyCompact(profitLoss, baseCurrency)}',
+                        size: 14,
+                        weight: FontWeight.w600,
+                        color: context.profitColor(profitLoss),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              const SizedBox(height: TryptoSpacing.md),
+              const Divider(),
+              const SizedBox(height: TryptoSpacing.sm),
+              Row(
+                children: [
+                  Expanded(
+                    child: _MiniCell(
+                      label: '보유수량',
+                      value: formatQuantity(holding.quantity),
+                    ),
+                  ),
+                  Expanded(
+                    child: _MiniCell(
+                      label: '평균매수가',
+                      value: formatPrice(holding.avgBuyPrice, baseCurrency),
+                    ),
+                  ),
+                  Expanded(
+                    child: _MiniCell(
+                      label: '현재가',
+                      value: formatPrice(holding.currentPrice, baseCurrency),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MiniCell extends StatelessWidget {
+  const _MiniCell({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 2),
+        NumericText(value, size: 12, weight: FontWeight.w500),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/portfolio/portfolio_page.dart
+++ b/mobile/lib/features/portfolio/portfolio_page.dart
@@ -1,22 +1,439 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
+import '../../core/constants/exchanges.dart';
+import '../../core/format/formatters.dart';
+import '../../core/router/guard.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/async_view.dart';
 import '../../core/widgets/empty_view.dart';
+import '../../core/widgets/exchange_segment.dart';
 import '../../core/widgets/mypage_button.dart';
+import '../../core/widgets/no_round_notice.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../round/round_controller.dart';
+import 'donut_painter.dart';
+import 'holding_card.dart';
+import 'portfolio_repository.dart';
+import 'portfolio_summary.dart';
 
-class PortfolioPage extends StatelessWidget {
+/// 선택 거래소는 라우트 쿼리(`/portfolio?exchange=upbit`)에 둔다 — 마켓과 같은 규칙이다.
+///
+/// 이 화면은 스스로 갱신되지 않는다(사양서 §5.1.2 — 폴링·WS 없음). 당김 새로고침이 유일한
+/// 수동 갱신 경로이므로 반드시 있어야 한다.
+class PortfolioPage extends ConsumerStatefulWidget {
   const PortfolioPage({super.key});
 
   @override
+  ConsumerState<PortfolioPage> createState() => _PortfolioPageState();
+}
+
+class _PortfolioPageState extends ConsumerState<PortfolioPage> {
+  HoldingSortKey _sortKey = HoldingSortKey.evalAmount;
+  bool _descending = true;
+
+  Future<void> _openSortSheet() async {
+    final selected = await showModalBottomSheet<HoldingSortKey>(
+      context: context,
+      useSafeArea: true,
+      builder: (context) => _SortSheet(sortKey: _sortKey, descending: _descending),
+    );
+    if (selected == null) return;
+    setState(() {
+      // 같은 키를 다시 고르면 방향을 뒤집고, 다른 키면 내림차순으로 되돌린다(§5.1.5).
+      _descending = selected == _sortKey ? !_descending : true;
+      _sortKey = selected;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final exchange = ExchangeIds.byKey(
+      GoRouterState.of(context).uri.queryParameters['exchange'],
+    );
+    final round = ref.watch(
+      roundControllerProvider.select((state) => state.activeRound),
+    );
+    final walletId = round?.walletIdOf(exchange.id);
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('포트폴리오'),
+        title: const Text('투자내역'),
         actions: const [MypageButton()],
       ),
-      body: const EmptyView(
-        icon: LucideIcons.chartPie,
-        message: '보유 자산은 13단위에서 붙는다.',
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              TryptoSpacing.screen,
+              TryptoSpacing.md,
+              TryptoSpacing.screen,
+              TryptoSpacing.sm,
+            ),
+            child: Column(
+              children: [
+                ExchangeSegment<int>(
+                  items: [
+                    for (final item in ExchangeIds.all)
+                      SegmentItem(item.id, item.name),
+                  ],
+                  value: exchange.id,
+                  onChanged: (id) => context.go(
+                    '${Routes.portfolio}?exchange='
+                    '${(ExchangeIds.byId(id) ?? exchange).key}',
+                  ),
+                ),
+                const SizedBox(height: TryptoSpacing.sm),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '${exchange.name} 기준 · ${exchange.baseCurrency} 마켓',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(child: _body(exchange, round == null, walletId)),
+        ],
+      ),
+    );
+  }
+
+  Widget _body(Exchange exchange, bool noRound, int? walletId) {
+    if (noRound) {
+      return const NoRoundNotice(
+        message: '진행 중인 라운드가 없어 포트폴리오가 비어 있습니다.',
+      );
+    }
+    if (walletId == null) {
+      return EmptyView(
+        icon: LucideIcons.wallet,
+        message: '${exchange.name} 지갑이 없습니다.',
+        description: '이 라운드에서 자금을 배정하지 않은 거래소입니다.',
+      );
+    }
+
+    return AsyncView<PortfolioSummary>(
+      value: ref.watch(portfolioProvider(walletId)),
+      onRetry: () => ref.invalidate(portfolioProvider(walletId)),
+      builder: (summary) => RefreshIndicator(
+        onRefresh: () => ref.refresh(portfolioProvider(walletId).future),
+        child: _Content(
+          summary: summary,
+          exchange: exchange,
+          sortKey: _sortKey,
+          descending: _descending,
+          onSort: _openSortSheet,
+        ),
+      ),
+    );
+  }
+}
+
+class _Content extends StatelessWidget {
+  const _Content({
+    required this.summary,
+    required this.exchange,
+    required this.sortKey,
+    required this.descending,
+    required this.onSort,
+  });
+
+  final PortfolioSummary summary;
+  final Exchange exchange;
+  final HoldingSortKey sortKey;
+  final bool descending;
+  final VoidCallback onSort;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final holdings = sortHoldings(
+      summary.holdings,
+      sortKey,
+      descending: descending,
+    );
+
+    return CustomScrollView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      slivers: [
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(
+            TryptoSpacing.screen,
+            TryptoSpacing.sm,
+            TryptoSpacing.screen,
+            TryptoSpacing.md,
+          ),
+          sliver: SliverToBoxAdapter(child: _SummaryCard(summary: summary)),
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: TryptoSpacing.screen),
+          sliver: SliverToBoxAdapter(
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.all(TryptoSpacing.lg),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('자산 구성', style: theme.textTheme.titleMedium),
+                    const SizedBox(height: TryptoSpacing.lg),
+                    // 보유 코인이 0개여도 현금 한 조각으로 정상 렌더된다.
+                    DonutChart(
+                      segments: buildDonutSegments(summary),
+                      totalAsset: summary.totalAsset.toDouble(),
+                      baseCurrency: summary.baseCurrency,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        if (holdings.isEmpty)
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: TryptoSpacing.xxl),
+              child: EmptyView(
+                icon: LucideIcons.coins,
+                message: '보유 중인 코인이 없습니다.',
+                action: FilledButton(
+                  onPressed: () =>
+                      context.go('${Routes.market}?exchange=${exchange.key}'),
+                  child: const Text('코인 사러 가기'),
+                ),
+              ),
+            ),
+          )
+        else ...[
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(
+              TryptoSpacing.screen,
+              TryptoSpacing.lg,
+              TryptoSpacing.screen,
+              TryptoSpacing.sm,
+            ),
+            sliver: SliverToBoxAdapter(
+              child: Row(
+                children: [
+                  Text(
+                    '보유 종목 ${holdings.length}',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  const Spacer(),
+                  ActionChip(
+                    avatar: Icon(
+                      descending ? LucideIcons.arrowDown : LucideIcons.arrowUp,
+                      size: 12,
+                    ),
+                    label: Text('정렬: ${sortKey.label}'),
+                    onPressed: onSort,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: TryptoSpacing.screen,
+            ),
+            sliver: SliverList.separated(
+              itemCount: holdings.length,
+              separatorBuilder: (context, index) =>
+                  const SizedBox(height: TryptoSpacing.sm),
+              itemBuilder: (context, index) => HoldingCard(
+                holding: holdings[index],
+                baseCurrency: summary.baseCurrency,
+                onTap: () => context.push(
+                  Routes.coinDetail(holdings[index].symbol, exchange.key),
+                ),
+              ),
+            ),
+          ),
+        ],
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.all(TryptoSpacing.screen),
+            child: Text(
+              '* 모의투자 데이터입니다.',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  const _SummaryCard({required this.summary});
+
+  final PortfolioSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final base = summary.baseCurrency;
+    final profitLoss = summary.profitLoss.toDouble();
+    final rate = summary.profitRate;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(TryptoSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '보유 $base ${formatCurrency(summary.cash.toDouble(), base)}',
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.sm),
+            Text(
+              '총 보유자산',
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.xs),
+            NumericText(
+              formatCurrency(summary.totalAsset.toDouble(), base),
+              size: 24,
+              weight: FontWeight.w700,
+            ),
+            const SizedBox(height: TryptoSpacing.xs),
+            Text(
+              '보유 $base + 코인 평가 합계',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.lg),
+            Row(
+              children: [
+                Expanded(
+                  child: _SummaryCell(
+                    label: '총매수',
+                    value: formatCurrencyCompact(
+                      summary.totalBuy.toDouble(),
+                      base,
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: _SummaryCell(
+                    label: '총평가',
+                    value: formatCurrencyCompact(
+                      summary.totalEval.toDouble(),
+                      base,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: TryptoSpacing.md),
+            Row(
+              children: [
+                Expanded(
+                  child: _SummaryCell(
+                    label: '평가손익',
+                    value:
+                        '${profitLoss > 0 ? '+' : ''}'
+                        '${formatCurrencyCompact(profitLoss, base)}',
+                    color: context.profitColor(profitLoss),
+                  ),
+                ),
+                Expanded(
+                  child: _SummaryCell(
+                    label: '수익률',
+                    value:
+                        '${rate > 0 ? '+' : ''}${rate.toStringAsFixed(2)}%',
+                    color: context.profitColor(rate),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryCell extends StatelessWidget {
+  const _SummaryCell({required this.label, required this.value, this.color});
+
+  final String label;
+  final String value;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 2),
+        NumericText(value, size: 14, weight: FontWeight.w600, color: color),
+      ],
+    );
+  }
+}
+
+class _SortSheet extends StatelessWidget {
+  const _SortSheet({required this.sortKey, required this.descending});
+
+  final HoldingSortKey sortKey;
+  final bool descending;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              TryptoSpacing.screen,
+              0,
+              TryptoSpacing.screen,
+              TryptoSpacing.sm,
+            ),
+            child: Text('정렬 기준', style: theme.textTheme.titleLarge),
+          ),
+          for (final key in HoldingSortKey.values)
+            ListTile(
+              title: Text(key.label),
+              trailing: key == sortKey
+                  ? Icon(
+                      descending ? LucideIcons.arrowDown : LucideIcons.arrowUp,
+                      size: 16,
+                      color: theme.colorScheme.primary,
+                    )
+                  : null,
+              onTap: () => Navigator.of(context).pop(key),
+            ),
+          const SizedBox(height: TryptoSpacing.sm),
+        ],
       ),
     );
   }

--- a/mobile/lib/features/portfolio/portfolio_repository.dart
+++ b/mobile/lib/features/portfolio/portfolio_repository.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/api/api_client.dart';
 import '../../core/api/api_exception.dart';
 import '../../models/portfolio.dart';
+import 'portfolio_summary.dart';
 
 class PortfolioRepository {
   const PortfolioRepository(this._dio);
@@ -20,3 +21,14 @@ class PortfolioRepository {
 final portfolioRepositoryProvider = Provider<PortfolioRepository>(
   (ref) => PortfolioRepository(ref.watch(dioProvider)),
 );
+
+/// 폴링도 WS 구독도 없다(사양서 §5.1.2). 갱신 경로는 당김 새로고침 하나뿐이다.
+final portfolioProvider = FutureProvider.family<PortfolioSummary, int>((
+  ref,
+  walletId,
+) async {
+  final holdings = await ref
+      .watch(portfolioRepositoryProvider)
+      .getPortfolio(walletId);
+  return PortfolioSummary.of(holdings);
+});

--- a/mobile/lib/features/portfolio/portfolio_summary.dart
+++ b/mobile/lib/features/portfolio/portfolio_summary.dart
@@ -1,0 +1,113 @@
+import 'package:decimal/decimal.dart';
+
+import '../../core/json/decimal_x.dart';
+import '../../models/portfolio.dart';
+
+/// 보유 종목 하나의 파생값(사양서 §5.1.5). 서버는 평가금액도 손익도 주지 않는다.
+class HoldingView {
+  HoldingView(this.holding)
+    : evalAmount = holding.currentPrice.dec * holding.quantity.dec,
+      buyAmount = holding.avgBuyPrice.dec * holding.quantity.dec;
+
+  final HoldingSnapshot holding;
+  final Decimal evalAmount;
+  final Decimal buyAmount;
+
+  String get symbol => holding.coinSymbol;
+
+  String get name => holding.coinName;
+
+  double get quantity => holding.quantity;
+
+  double get avgBuyPrice => holding.avgBuyPrice;
+
+  double get currentPrice => holding.currentPrice;
+
+  Decimal get profitLoss => evalAmount - buyAmount;
+
+  /// 퍼센트 값 그 자체다(12.34 = +12.34%). 티커의 `changeRate`(비율)와 단위가 다르다.
+  double get profitRate => _percent(profitLoss, buyAmount);
+}
+
+/// 자산 요약(사양서 §5.1.3). 계산은 전부 `Decimal` 로 한다 — 8자리 수량 × 원 단위 가격을
+/// double 로 누산하면 합계에서 오차가 눈에 보인다(계획서 §4.5.1).
+class PortfolioSummary {
+  PortfolioSummary._({
+    required this.baseCurrency,
+    required this.cash,
+    required this.totalBuy,
+    required this.totalEval,
+    required this.holdings,
+  });
+
+  factory PortfolioSummary.of(MyHoldings source) {
+    final views = [for (final holding in source.holdings) HoldingView(holding)];
+    var totalBuy = Decimal.zero;
+    var totalEval = Decimal.zero;
+    for (final view in views) {
+      totalBuy += view.buyAmount;
+      totalEval += view.evalAmount;
+    }
+    return PortfolioSummary._(
+      baseCurrency: source.baseCurrencySymbol,
+      cash: source.baseCurrencyBalance.dec,
+      totalBuy: totalBuy,
+      totalEval: totalEval,
+      holdings: views,
+    );
+  }
+
+  final String baseCurrency;
+
+  /// 사용 가능 기준통화 잔고. 보유 코인이 0개여도 이 값은 있다.
+  final Decimal cash;
+
+  final Decimal totalBuy;
+  final Decimal totalEval;
+  final List<HoldingView> holdings;
+
+  Decimal get totalAsset => cash + totalEval;
+
+  Decimal get profitLoss => totalEval - totalBuy;
+
+  double get profitRate => _percent(profitLoss, totalBuy);
+}
+
+double _percent(Decimal profitLoss, Decimal base) {
+  if (base <= Decimal.zero) return 0;
+  return (profitLoss / base).toDouble() * 100;
+}
+
+/// 웹은 응답 순서 그대로라 사용자가 볼 기준이 없다. 기본값을 평가금액 내림차순으로 둔다.
+enum HoldingSortKey {
+  evalAmount('평가금액'),
+  profitLoss('평가손익'),
+  profitRate('수익률'),
+  quantity('보유수량'),
+  avgBuyPrice('평균매수가'),
+  currentPrice('현재가'),
+  name('코인명');
+
+  const HoldingSortKey(this.label);
+
+  final String label;
+}
+
+List<HoldingView> sortHoldings(
+  List<HoldingView> holdings,
+  HoldingSortKey key, {
+  bool descending = true,
+}) {
+  final sign = descending ? -1 : 1;
+  return [...holdings]..sort((a, b) => sign * _compare(a, b, key));
+}
+
+int _compare(HoldingView a, HoldingView b, HoldingSortKey key) => switch (key) {
+  HoldingSortKey.name => a.symbol.compareTo(b.symbol),
+  HoldingSortKey.evalAmount => a.evalAmount.compareTo(b.evalAmount),
+  HoldingSortKey.profitLoss => a.profitLoss.compareTo(b.profitLoss),
+  HoldingSortKey.profitRate => a.profitRate.compareTo(b.profitRate),
+  HoldingSortKey.quantity => a.quantity.compareTo(b.quantity),
+  HoldingSortKey.avgBuyPrice => a.avgBuyPrice.compareTo(b.avgBuyPrice),
+  HoldingSortKey.currentPrice => a.currentPrice.compareTo(b.currentPrice),
+};

--- a/mobile/lib/features/ranking/ranker_portfolio_sheet.dart
+++ b/mobile/lib/features/ranking/ranker_portfolio_sheet.dart
@@ -1,0 +1,243 @@
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../core/api/api_exception.dart';
+import '../../core/format/formatters.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/empty_view.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../models/ranking.dart';
+
+/// 서버가 101위 이하에 403 `PORTFOLIO_VIEW_NOT_ALLOWED` 를 낸다. 요청을 보내기 전에 순위로
+/// 선제 차단한다(계획서 §4.1.4).
+const int rankingPortfolioMaxRank = 100;
+
+bool canViewRankerPortfolio(int rank) => rank <= rankingPortfolioMaxRank;
+
+/// 서버가 비중을 `0.35` 로 주든 `35` 로 주든 35.0% 로 렌더한다(사양서 §6.2.7).
+double asRatio(double value) => value > 1 ? value / 100 : value;
+
+/// 행 확장(ExpansionTile)이 아니라 바텀시트다 — 좁은 화면에서 확장은 스크롤 위치를 흔든다.
+/// [load] 는 호출부가 유저별 캐시를 물려 준다(사양서 §6.2.7 — 유저당 1회 조회).
+Future<void> showRankerPortfolioSheet(
+  BuildContext context, {
+  required RankingItem item,
+  required Future<RankerPortfolio> Function() load,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    useSafeArea: true,
+    isScrollControlled: true,
+    builder: (context) => _RankerPortfolioSheet(item: item, load: load),
+  );
+}
+
+class _RankerPortfolioSheet extends StatefulWidget {
+  const _RankerPortfolioSheet({required this.item, required this.load});
+
+  final RankingItem item;
+  final Future<RankerPortfolio> Function() load;
+
+  @override
+  State<_RankerPortfolioSheet> createState() => _RankerPortfolioSheetState();
+}
+
+class _RankerPortfolioSheetState extends State<_RankerPortfolioSheet> {
+  late Future<RankerPortfolio> _future = widget.load();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final item = widget.item;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          TryptoSpacing.screen,
+          0,
+          TryptoSpacing.screen,
+          TryptoSpacing.screen,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                RankBadge(rank: item.rank),
+                const SizedBox(width: TryptoSpacing.md),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        item.nickname,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleMedium,
+                      ),
+                      Text(
+                        '${item.tradeCount}회 거래',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                NumericText(
+                  formatProfitPercent(item.profitRate),
+                  size: 18,
+                  weight: FontWeight.w700,
+                  color: context.profitColor(item.profitRate),
+                ),
+              ],
+            ),
+            const SizedBox(height: TryptoSpacing.lg),
+            Text('보유 자산 비중', style: theme.textTheme.titleMedium),
+            const SizedBox(height: TryptoSpacing.sm),
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.sizeOf(context).height * 0.5,
+              ),
+              child: FutureBuilder<RankerPortfolio>(
+                future: _future,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const Padding(
+                      padding: EdgeInsets.all(TryptoSpacing.xxl),
+                      child: Center(
+                        child: Text('포트폴리오를 불러오는 중입니다...'),
+                      ),
+                    );
+                  }
+                  final error = snapshot.error;
+                  if (error != null) {
+                    return EmptyView(
+                      icon: LucideIcons.circleAlert,
+                      message: error.asApiException.isCode(
+                        ErrorCodes.rankingNotFound,
+                      )
+                          ? '집계된 포트폴리오가 없습니다.'
+                          : '포트폴리오를 불러오지 못했습니다.',
+                      action: OutlinedButton(
+                        onPressed: () =>
+                            setState(() => _future = widget.load()),
+                        child: const Text('다시 시도'),
+                      ),
+                    );
+                  }
+                  final holdings = snapshot.requireData.holdings;
+                  if (holdings.isEmpty) {
+                    return const EmptyView(
+                      icon: LucideIcons.coins,
+                      message: '보유 자산 정보가 없습니다.',
+                    );
+                  }
+                  return ListView.separated(
+                    shrinkWrap: true,
+                    itemCount: holdings.length,
+                    separatorBuilder: (context, index) =>
+                        const SizedBox(height: TryptoSpacing.md),
+                    itemBuilder: (context, index) =>
+                        _HoldingRow(holding: holdings[index]),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.md),
+            Text(
+              '보유 수량은 공개되지 않습니다.',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HoldingRow extends StatelessWidget {
+  const _HoldingRow({required this.holding});
+
+  final RankerHolding holding;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ratio = asRatio(holding.assetRatio);
+    final percent = (ratio * 100).clamp(0.0, 100.0);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                holding.coinSymbol,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TryptoText.symbol,
+              ),
+            ),
+            NumericText(
+              formatProfitPercent(holding.profitRate),
+              size: 12,
+              weight: FontWeight.w500,
+              color: context.profitColor(holding.profitRate),
+            ),
+            const SizedBox(width: TryptoSpacing.sm),
+            NumericText('${(ratio * 100).toStringAsFixed(1)}%', size: 13),
+          ],
+        ),
+        const SizedBox(height: TryptoSpacing.xs),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(TryptoRadius.base),
+          child: LinearProgressIndicator(
+            value: percent / 100,
+            minHeight: 6,
+            backgroundColor: theme.colorScheme.surfaceContainer,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// 순위 배지 32×32. 1~3위는 금·은·동으로 갈린다(사양서 §6.6.1-8).
+class RankBadge extends StatelessWidget {
+  const RankBadge({super.key, required this.rank, this.size = 32});
+
+  final int rank;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+
+    final (Color background, Color foreground) = switch (rank) {
+      1 => (colors.warning, Colors.white),
+      2 => (const Color(0xFFB8B8C4), Colors.white),
+      3 => (const Color(0xFFB08D57), Colors.white),
+      _ => (theme.colorScheme.surfaceContainer, theme.colorScheme.onSurface),
+    };
+
+    return Container(
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(color: background, shape: BoxShape.circle),
+      child: NumericText(
+        '$rank',
+        size: size <= 32 ? 13 : 16,
+        weight: FontWeight.w700,
+        color: foreground,
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/ranking/ranking_page.dart
+++ b/mobile/lib/features/ranking/ranking_page.dart
@@ -1,20 +1,1016 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
+import '../../core/api/api_exception.dart';
+import '../../core/format/formatters.dart';
+import '../../core/router/guard.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/app_snackbar.dart';
 import '../../core/widgets/empty_view.dart';
+import '../../core/widgets/exchange_segment.dart';
 import '../../core/widgets/mypage_button.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../models/enums.dart';
+import '../../models/ranking.dart';
+import '../auth/auth_controller.dart';
+import 'ranker_portfolio_sheet.dart';
+import 'ranking_repository.dart';
 
-class RankingPage extends StatelessWidget {
+const int _kPageSize = 20;
+
+const Map<RankingPeriod, String> _periodLabels = {
+  RankingPeriod.daily: '일간',
+  RankingPeriod.weekly: '주간',
+  RankingPeriod.monthly: '월간',
+};
+
+/// 라우트 쿼리 값이라 무엇이든 들어올 수 있다. 웹과 같이 알 수 없는 값은 `daily` 로 강제한다
+/// (사양서 §6.2.1).
+RankingPeriod _periodOf(String? key) => switch (key) {
+  'weekly' => RankingPeriod.weekly,
+  'monthly' => RankingPeriod.monthly,
+  _ => RankingPeriod.daily,
+};
+
+/// 기간은 라우트 쿼리(`/ranking?period=weekly`)에 유지한다 — 딥링크·뒤로가기가 공짜로 된다.
+///
+/// 목록·통계·내 랭킹은 **개별 실패를 허용**한다(사양서 §6.2.3). 목록만 전체 에러 화면으로
+/// 전환하고, 통계와 내 랭킹은 각각 null 로 떨어뜨린다.
+class RankingPage extends ConsumerStatefulWidget {
   const RankingPage({super.key});
 
   @override
+  ConsumerState<RankingPage> createState() => _RankingPageState();
+}
+
+class _RankingPageState extends ConsumerState<RankingPage> {
+  final ScrollController _scroll = ScrollController();
+  final GlobalKey _myCardKey = GlobalKey();
+  final ValueNotifier<bool> _stickyVisible = ValueNotifier(false);
+
+  /// 유저별 1회 조회. 시트를 닫았다 다시 열어도 재요청하지 않는다(사양서 §6.2.7).
+  final Map<int, RankerPortfolio> _portfolioCache = {};
+
+  RankingPeriod? _period;
+  List<RankingItem> _entries = [];
+  MyRanking? _myRanking;
+  RankingStats? _stats;
+  int? _cursor;
+  bool _hasNext = false;
+  bool _loading = true;
+  bool _loadingMore = false;
+  String? _error;
+  String? _moreError;
+  int _generation = 0;
+  double _myCardExtent = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _scroll.addListener(_onScroll);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final period = _periodOf(
+      GoRouterState.of(context).uri.queryParameters['period'],
+    );
+    if (period == _period) return;
+    _period = period;
+    _reload();
+  }
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    _stickyVisible.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!_scroll.hasClients) return;
+    _stickyVisible.value = _myRanking != null && _scroll.offset > _myCardExtent;
+
+    if (!_hasNext || _loadingMore || _loading) return;
+    if (_scroll.position.pixels < _scroll.position.maxScrollExtent - 200) return;
+    _loadMore();
+  }
+
+  /// 실패를 삼킨다. 통계·내 랭킹의 개별 실패가 화면 전체를 무너뜨리면 안 된다. 여기서 잡지
+  /// 않으면 목록이 먼저 실패했을 때 남은 future 가 처리되지 않은 예외로 터진다.
+  Future<T?> _optional<T>(Future<T> request) async {
+    try {
+      return await request;
+    } on ApiException {
+      return null;
+    }
+  }
+
+  Future<void> _reload() async {
+    final period = _period!;
+    final generation = ++_generation;
+    final repository = ref.read(rankingRepositoryProvider);
+    final authed = ref.read(authControllerProvider).isAuthenticated;
+
+    setState(() {
+      _loading = true;
+      _error = null;
+      _moreError = null;
+      _portfolioCache.clear();
+    });
+
+    final entries = repository.getRankings(period: period, size: _kPageSize);
+    final stats = _optional(repository.getStats(period));
+    final myRanking = authed
+        ? _optional(repository.getMyRanking(period))
+        : Future<MyRanking?>.value();
+
+    try {
+      final page = await entries;
+      if (!mounted || generation != _generation) return;
+      setState(() {
+        _entries = page.content;
+        _cursor = page.nextCursor;
+        _hasNext = page.hasNext;
+        _stats = null;
+        _myRanking = null;
+        _loading = false;
+      });
+    } on ApiException {
+      if (!mounted || generation != _generation) return;
+      setState(() {
+        _entries = [];
+        _hasNext = false;
+        _stats = null;
+        _myRanking = null;
+        _error = '랭킹을 불러오지 못했습니다.';
+        _loading = false;
+      });
+      return;
+    }
+
+    final loaded = await (stats, myRanking).wait;
+    if (!mounted || generation != _generation) return;
+    setState(() {
+      _stats = loaded.$1;
+      _myRanking = loaded.$2;
+    });
+    _measureMyCard();
+  }
+
+  /// 스티키 바는 내 랭킹 카드가 화면 밖으로 나갔을 때만 뜬다. 카드 높이는 폰트 배율에 따라
+  /// 달라지므로 실제 레이아웃에서 잰다.
+  void _measureMyCard() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _myCardExtent = _myCardKey.currentContext?.size?.height ?? 0;
+    });
+  }
+
+  Future<void> _loadMore() async {
+    final period = _period!;
+    final generation = _generation;
+    setState(() {
+      _loadingMore = true;
+      _moreError = null;
+    });
+    try {
+      final page = await ref
+          .read(rankingRepositoryProvider)
+          .getRankings(period: period, cursorRank: _cursor, size: _kPageSize);
+      if (!mounted || generation != _generation) return;
+      setState(() {
+        _entries = [..._entries, ...page.content];
+        _cursor = page.nextCursor;
+        _hasNext = page.hasNext;
+        _loadingMore = false;
+      });
+    } on ApiException {
+      if (!mounted || generation != _generation) return;
+      // 더보기 실패는 화면 전체를 에러로 바꾸지 않는다(사양서 §6.2.6).
+      setState(() {
+        _loadingMore = false;
+        _moreError = '추가 랭킹을 불러오지 못했습니다.';
+      });
+    }
+  }
+
+  void _setPeriod(RankingPeriod period) {
+    if (period == _period) return;
+    context.go('${Routes.ranking}?period=${period.wire.toLowerCase()}');
+  }
+
+  Future<void> _openPortfolio(RankingItem item) async {
+    if (!canViewRankerPortfolio(item.rank)) {
+      // 403 이 뻔한 요청은 보내지 않는다(계획서 §4.1.4).
+      showAppSnackbar(context, '포트폴리오는 $rankingPortfolioMaxRank위까지 공개됩니다.');
+      return;
+    }
+    await showRankerPortfolioSheet(
+      context,
+      item: item,
+      load: () => _loadPortfolio(item.userId),
+    );
+  }
+
+  Future<RankerPortfolio> _loadPortfolio(int userId) async {
+    final cached = _portfolioCache[userId];
+    if (cached != null) return cached;
+    final portfolio = await ref
+        .read(rankingRepositoryProvider)
+        .getRankerPortfolio(userId: userId, period: _period!);
+    _portfolioCache[userId] = portfolio;
+    return portfolio;
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final period = _period ?? RankingPeriod.daily;
+
     return Scaffold(
       appBar: AppBar(title: const Text('랭킹'), actions: const [MypageButton()]),
-      body: const EmptyView(
-        icon: LucideIcons.trophy,
-        message: '랭킹은 15단위에서 붙는다.',
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              TryptoSpacing.screen,
+              TryptoSpacing.md,
+              TryptoSpacing.screen,
+              TryptoSpacing.sm,
+            ),
+            child: Column(
+              children: [
+                ExchangeSegment<RankingPeriod>(
+                  items: [
+                    for (final entry in _periodLabels.entries)
+                      SegmentItem(entry.key, entry.value),
+                  ],
+                  value: period,
+                  onChanged: _setPeriod,
+                ),
+                const SizedBox(height: TryptoSpacing.sm),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '${_periodLabels[period]} 수익률 기준 순위',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Stack(
+              children: [
+                _body(period),
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: ValueListenableBuilder<bool>(
+                    valueListenable: _stickyVisible,
+                    builder: (context, visible, child) {
+                      final myRanking = _myRanking;
+                      if (!visible || myRanking == null) {
+                        return const SizedBox.shrink();
+                      }
+                      return _StickyMyRankBar(
+                        myRanking: myRanking,
+                        onTap: () => _scroll.animateTo(
+                          0,
+                          duration: TryptoMotion.sheet,
+                          curve: TryptoMotion.enterCurve,
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }
+
+  Widget _body(RankingPeriod period) {
+    if (_loading) {
+      return const Center(child: Text('랭킹 데이터를 불러오는 중입니다...'));
+    }
+
+    final error = _error;
+    if (error != null) {
+      return EmptyView(
+        icon: LucideIcons.circleAlert,
+        message: error,
+        description: '일시적인 문제일 수 있습니다. 잠시 후 다시 시도해 주세요.',
+        action: OutlinedButton(onPressed: _reload, child: const Text('다시 시도')),
+      );
+    }
+
+    // 집계 전에는 서버가 오류가 아니라 빈 결과를 준다(사양서 §6.2.8). 통계 응답이 성공이어도
+    // 자리표시가 우선한다.
+    final aggregated = _entries.isNotEmpty;
+    final top3 = _entries.take(3).toList();
+    final rest = _entries.skip(3).toList();
+
+    return RefreshIndicator(
+      onRefresh: _reload,
+      child: CustomScrollView(
+        controller: _scroll,
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(
+              TryptoSpacing.screen,
+              TryptoSpacing.sm,
+              TryptoSpacing.screen,
+              TryptoSpacing.md,
+            ),
+            sliver: SliverToBoxAdapter(
+              child: Column(
+                children: [
+                  _MyRankingCard(key: _myCardKey, myRanking: _myRanking),
+                  const SizedBox(height: TryptoSpacing.md),
+                  _StatsCard(
+                    stats: aggregated ? _stats : null,
+                    period: period,
+                    // 목록이 비면 통계도 자리표시다. 목록이 있는데 통계만 없으면 조회 실패다.
+                    failed: aggregated && _stats == null,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (!aggregated) ...[
+            const SliverPadding(
+              padding: EdgeInsets.symmetric(horizontal: TryptoSpacing.screen),
+              sliver: SliverToBoxAdapter(child: _PodiumPlaceholder()),
+            ),
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: TryptoSpacing.xxl),
+                child: EmptyView(
+                  icon: LucideIcons.trophy,
+                  message: '아직 집계된 랭킹이 없습니다',
+                  description:
+                      '랭킹은 매일 밤 자정에 집계됩니다.\n지금 거래를 시작하면 내일 첫 순위에 오릅니다.',
+                  action: FilledButton(
+                    onPressed: () => context.go(Routes.market),
+                    child: const Text('거래하러 가기'),
+                  ),
+                ),
+              ),
+            ),
+          ] else ...[
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: TryptoSpacing.screen,
+              ),
+              sliver: SliverToBoxAdapter(
+                child: _Podium(
+                  entries: top3,
+                  myRank: _myRanking?.rank,
+                  onTap: _openPortfolio,
+                ),
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(
+                TryptoSpacing.screen,
+                TryptoSpacing.lg,
+                TryptoSpacing.screen,
+                0,
+              ),
+              sliver: SliverList.separated(
+                itemCount: rest.length,
+                separatorBuilder: (context, index) =>
+                    const SizedBox(height: TryptoSpacing.sm),
+                itemBuilder: (context, index) => _RankerTile(
+                  item: rest[index],
+                  isMe: rest[index].rank == _myRanking?.rank,
+                  onTap: _openPortfolio,
+                ),
+              ),
+            ),
+            SliverToBoxAdapter(
+              child: _ListFooter(
+                loading: _loadingMore,
+                error: _moreError,
+                onRetry: _loadMore,
+                // 스티키 바가 마지막 행을 가리지 않게 여백을 남긴다.
+                bottomInset: _myRanking != null ? 72 : TryptoSpacing.xxl,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _MyRankingCard extends StatelessWidget {
+  const _MyRankingCard({super.key, required this.myRanking});
+
+  final MyRanking? myRanking;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final myRanking = this.myRanking;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(TryptoSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('내 랭킹', style: theme.textTheme.titleMedium),
+            const SizedBox(height: TryptoSpacing.md),
+            if (myRanking == null)
+              // `data: null` 은 오류가 아니다 — 아직 집계에 포함되지 않은 사용자다(§6.2.5).
+              Text(
+                '아직 순위가 없습니다.\n거래를 시작하면 다음 집계에 반영됩니다.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              )
+            else
+              Row(
+                children: [
+                  RankBadge(rank: myRanking.rank),
+                  const SizedBox(width: TryptoSpacing.md),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          myRanking.nickname,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.titleMedium,
+                        ),
+                        Text(
+                          '${myRanking.tradeCount}회 거래',
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: TryptoSpacing.md,
+                      vertical: TryptoSpacing.sm,
+                    ),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.surfaceContainer,
+                      borderRadius: BorderRadius.circular(TryptoRadius.md),
+                    ),
+                    child: NumericText(
+                      formatProfitPercent(myRanking.profitRate),
+                      size: 20,
+                      weight: FontWeight.w700,
+                      color: context.profitColor(myRanking.profitRate),
+                    ),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatsCard extends StatelessWidget {
+  const _StatsCard({
+    required this.stats,
+    required this.period,
+    required this.failed,
+  });
+
+  final RankingStats? stats;
+  final RankingPeriod period;
+  final bool failed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+    final stats = this.stats;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(TryptoSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${_periodLabels[period]} 통계',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: TryptoSpacing.md),
+            if (failed)
+              Text(
+                '통계를 불러오지 못했습니다.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colors.negative,
+                ),
+              )
+            else
+              Row(
+                children: [
+                  Expanded(
+                    child: _StatTile(
+                      label: '참여자',
+                      value: stats == null
+                          ? '0명'
+                          : '${formatGrouped(stats.totalParticipants)}명',
+                      muted: stats == null,
+                    ),
+                  ),
+                  Expanded(
+                    child: _StatTile(
+                      label: '최고 수익률',
+                      value: stats == null
+                          ? '--'
+                          : formatProfitPercent(stats.maxProfitRate),
+                      color: stats == null ? null : colors.positive,
+                      muted: stats == null,
+                    ),
+                  ),
+                  Expanded(
+                    child: _StatTile(
+                      label: '평균 수익률',
+                      value: stats == null
+                          ? '--'
+                          : formatProfitPercent(stats.avgProfitRate),
+                      color: stats == null
+                          ? null
+                          : context.profitColor(stats.avgProfitRate),
+                      muted: stats == null,
+                    ),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatTile extends StatelessWidget {
+  const _StatTile({
+    required this.label,
+    required this.value,
+    this.color,
+    this.muted = false,
+  });
+
+  final String label;
+  final String value;
+  final Color? color;
+
+  /// 집계 전 자리표시. 실데이터와 구분되게 흐리다.
+  final bool muted;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final onSurface = theme.colorScheme.onSurface;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 2),
+        NumericText(
+          value,
+          size: 14,
+          weight: FontWeight.w700,
+          // 알파는 색으로만 준다 — Opacity 위젯은 saveLayer 를 만든다(계획서 §4.2.5-8).
+          color: muted
+              ? onSurface.withValues(alpha: 0.4)
+              : (color ?? onSurface),
+        ),
+      ],
+    );
+  }
+}
+
+/// 1위를 크게, 2·3위를 아래 2열로 둔다. 3열 그리드는 좁은 화면에서 글자가 뭉개진다(§6.6.1-8).
+class _Podium extends StatelessWidget {
+  const _Podium({
+    required this.entries,
+    required this.myRank,
+    required this.onTap,
+  });
+
+  final List<RankingItem> entries;
+  final int? myRank;
+  final void Function(RankingItem item) onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _PodiumCard(
+          item: entries.first,
+          isMe: entries.first.rank == myRank,
+          large: true,
+          onTap: onTap,
+        ),
+        if (entries.length > 1) ...[
+          const SizedBox(height: TryptoSpacing.sm),
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  child: _PodiumCard(
+                    item: entries[1],
+                    isMe: entries[1].rank == myRank,
+                    large: false,
+                    onTap: onTap,
+                  ),
+                ),
+                const SizedBox(width: TryptoSpacing.sm),
+                Expanded(
+                  child: entries.length > 2
+                      ? _PodiumCard(
+                          item: entries[2],
+                          isMe: entries[2].rank == myRank,
+                          large: false,
+                          onTap: onTap,
+                        )
+                      : const SizedBox.shrink(),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _PodiumCard extends StatelessWidget {
+  const _PodiumCard({
+    required this.item,
+    required this.isMe,
+    required this.large,
+    required this.onTap,
+  });
+
+  final RankingItem item;
+  final bool isMe;
+  final bool large;
+  final void Function(RankingItem item) onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      shape: _cardShape(context, isMe),
+      child: InkWell(
+        onTap: () => onTap(item),
+        child: Padding(
+          padding: const EdgeInsets.all(TryptoSpacing.lg),
+          child: Column(
+            children: [
+              RankBadge(rank: item.rank, size: large ? 44 : 32),
+              const SizedBox(height: TryptoSpacing.sm),
+              Text(
+                item.nickname,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.titleMedium,
+              ),
+              const SizedBox(height: 2),
+              NumericText(
+                formatProfitPercent(item.profitRate),
+                size: large ? 20 : 16,
+                weight: FontWeight.w700,
+                color: context.profitColor(item.profitRate),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                '${item.tradeCount}회 거래',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RankerTile extends StatelessWidget {
+  const _RankerTile({
+    required this.item,
+    required this.isMe,
+    required this.onTap,
+  });
+
+  final RankingItem item;
+  final bool isMe;
+  final void Function(RankingItem item) onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      shape: _cardShape(context, isMe),
+      child: InkWell(
+        onTap: () => onTap(item),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: TryptoSpacing.lg,
+            vertical: TryptoSpacing.md,
+          ),
+          child: Row(
+            children: [
+              RankBadge(rank: item.rank),
+              const SizedBox(width: TryptoSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      item.nickname,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.labelLarge,
+                    ),
+                    Text(
+                      '${item.tradeCount}회 거래',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              // 색만으로 방향을 알리지 않는다 — 부호와 아이콘을 함께 쓴다(§6.6.1-9).
+              Icon(
+                item.profitRate > 0
+                    ? LucideIcons.trendingUp
+                    : item.profitRate < 0
+                    ? LucideIcons.trendingDown
+                    : LucideIcons.minus,
+                size: 14,
+                color: context.profitColor(item.profitRate),
+              ),
+              const SizedBox(width: TryptoSpacing.xs),
+              NumericText(
+                formatProfitPercent(item.profitRate),
+                color: context.profitColor(item.profitRate),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StickyMyRankBar extends StatelessWidget {
+  const _StickyMyRankBar({required this.myRanking, required this.onTap});
+
+  final MyRanking myRanking;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Material(
+      color: theme.colorScheme.surface,
+      child: InkWell(
+        onTap: onTap,
+        child: Container(
+          decoration: const BoxDecoration(
+            border: Border(top: BorderSide(color: TryptoPalette.border)),
+          ),
+          padding: const EdgeInsets.symmetric(
+            horizontal: TryptoSpacing.screen,
+            vertical: TryptoSpacing.md,
+          ),
+          child: Row(
+            children: [
+              RankBadge(rank: myRanking.rank, size: 28),
+              const SizedBox(width: TryptoSpacing.md),
+              Expanded(
+                child: Text(
+                  '내 순위 · ${myRanking.nickname}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.labelLarge,
+                ),
+              ),
+              NumericText(
+                formatProfitPercent(myRanking.profitRate),
+                color: context.profitColor(myRanking.profitRate),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 집계 전 1·2·3위 자리표시(파선 테두리 · `--%` · "집계 대기").
+class _PodiumPlaceholder extends StatelessWidget {
+  const _PodiumPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Row(
+      children: [
+        for (final rank in [1, 2, 3]) ...[
+          if (rank > 1) const SizedBox(width: TryptoSpacing.sm),
+          Expanded(
+            child: _DashedBox(
+              child: Column(
+                children: [
+                  Container(
+                    width: 28,
+                    height: 28,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.surfaceContainer,
+                      shape: BoxShape.circle,
+                    ),
+                    child: NumericText(
+                      '$rank',
+                      size: 12,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: TryptoSpacing.sm),
+                  NumericText(
+                    '--%',
+                    size: 14,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    '집계 대기',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// 파선 테두리 상자. 자리표시가 실데이터 카드와 혼동되지 않게 한다.
+class _DashedBox extends StatelessWidget {
+  const _DashedBox({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: const _DashedBorderPainter(color: TryptoPalette.border),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: TryptoSpacing.sm,
+          vertical: TryptoSpacing.lg,
+        ),
+        child: child,
+      ),
+    );
+  }
+}
+
+class _DashedBorderPainter extends CustomPainter {
+  const _DashedBorderPainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1;
+    final border = Path()
+      ..addRRect(
+        RRect.fromRectAndRadius(
+          Offset.zero & size,
+          const Radius.circular(TryptoRadius.xl),
+        ),
+      );
+
+    for (final metric in border.computeMetrics()) {
+      var distance = 0.0;
+      while (distance < metric.length) {
+        final next = (distance + 4).clamp(0.0, metric.length);
+        canvas.drawPath(metric.extractPath(distance, next), paint);
+        distance = next + 4;
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_DashedBorderPainter oldDelegate) =>
+      oldDelegate.color != color;
+}
+
+class _ListFooter extends StatelessWidget {
+  const _ListFooter({
+    required this.loading,
+    required this.error,
+    required this.onRetry,
+    required this.bottomInset,
+  });
+
+  final bool loading;
+  final String? error;
+  final VoidCallback onRetry;
+  final double bottomInset;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final error = this.error;
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        TryptoSpacing.screen,
+        TryptoSpacing.lg,
+        TryptoSpacing.screen,
+        bottomInset,
+      ),
+      child: Center(
+        child: loading
+            ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : error == null
+            ? const SizedBox.shrink()
+            : Column(
+                children: [
+                  Text(
+                    error,
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: context.tryptoColors.negative,
+                    ),
+                  ),
+                  const SizedBox(height: TryptoSpacing.sm),
+                  OutlinedButton(
+                    onPressed: onRetry,
+                    child: const Text('다시 시도'),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}
+
+/// 내 행은 목록 안에서도 테두리로 강조한다(§6.6.1-3).
+ShapeBorder _cardShape(BuildContext context, bool isMe) {
+  return RoundedRectangleBorder(
+    borderRadius: BorderRadius.circular(TryptoRadius.xl),
+    side: BorderSide(
+      color: isMe ? Theme.of(context).colorScheme.primary : TryptoPalette.border,
+      width: isMe ? 1.5 : 1,
+    ),
+  );
 }

--- a/mobile/lib/features/regret/regret_chart.dart
+++ b/mobile/lib/features/regret/regret_chart.dart
@@ -1,0 +1,542 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../core/format/formatters.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../models/enums.dart';
+import '../../models/regret.dart';
+import 'regret_simulation.dart';
+
+/// BTC 홀드 벤치마크 색(사양서 §6.4.3). 팔레트에 없는 브랜드 색이라 여기서만 쓴다.
+const Color btcHoldColor = Color(0xFFF7931A);
+
+const int _kMinSnapshots = 2;
+
+final DateFormat _monthDay = DateFormat('M/d', 'en_US');
+final DateFormat _yearMonth = DateFormat('yyyy.MM', 'en_US');
+final DateFormat _fullDate = DateFormat('yyyy-MM-dd', 'en_US');
+
+/// 자산 곡선 3선 + 위반 마커. 모델 `RegretChart` 와 이름이 겹치지 않게 `RegretAssetChart` 다.
+///
+/// 마우스 호버가 없으므로 드래그 크로스헤어로 대체하고, 값은 차트 위 툴팁이 아니라 **차트 아래
+/// 고정 패널**에 내린다(사양서 §6.6.2-2).
+class RegretAssetChart extends StatefulWidget {
+  const RegretAssetChart({
+    super.key,
+    required this.chart,
+    required this.enabledRules,
+    required this.btcEnabled,
+  });
+
+  final RegretChart chart;
+  final Set<RuleType> enabledRules;
+  final bool btcEnabled;
+
+  @override
+  State<RegretAssetChart> createState() => _RegretAssetChartState();
+}
+
+class _RegretAssetChartState extends State<RegretAssetChart> {
+  int? _touchedIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    final history = widget.chart.assetHistory;
+    if (history.length < _kMinSnapshots) {
+      return const _EmptyChart();
+    }
+
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+    final currency = widget.chart.currency;
+
+    final actual = [for (final point in history) point.actualAsset];
+    final simulation = simulationLine(history, widget.enabledRules);
+    final btcHold = [for (final point in history) point.btcHoldAsset];
+    final showSimulation = widget.enabledRules.isNotEmpty;
+
+    final range = chartYRange([
+      actual,
+      if (showSimulation) simulation,
+      if (widget.btcEnabled) btcHold,
+    ]);
+
+    // 마커는 문자열이 아니라 날짜로 매칭한다(사양서 §6.4.3).
+    final markerIndexes = _markerIndexes(history, widget.chart.violationMarkers);
+    final interval = labelTickInterval(widget.chart.totalDays);
+    final index = _touchedIndex;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          height: 220,
+          child: LineChart(
+            LineChartData(
+              minX: 0,
+              maxX: (history.length - 1).toDouble(),
+              minY: range.min,
+              maxY: range.max,
+              clipData: const FlClipData.all(),
+              gridData: FlGridData(
+                drawVerticalLine: false,
+                horizontalInterval: (range.max - range.min) / 4,
+                getDrawingHorizontalLine: (value) =>
+                    const FlLine(color: TryptoPalette.border, strokeWidth: 1),
+              ),
+              borderData: FlBorderData(show: false),
+              titlesData: FlTitlesData(
+                topTitles: const AxisTitles(),
+                rightTitles: const AxisTitles(),
+                leftTitles: AxisTitles(
+                  sideTitles: SideTitles(
+                    showTitles: true,
+                    reservedSize: 52,
+                    interval: (range.max - range.min) / 4,
+                    getTitlesWidget: (value, meta) => Padding(
+                      padding: const EdgeInsets.only(right: TryptoSpacing.xs),
+                      child: NumericText(
+                        formatCurrencyCompact(value, currency),
+                        size: 10,
+                        weight: FontWeight.w500,
+                        color: theme.colorScheme.onSurfaceVariant,
+                        textAlign: TextAlign.right,
+                      ),
+                    ),
+                  ),
+                ),
+                bottomTitles: AxisTitles(
+                  sideTitles: SideTitles(
+                    showTitles: true,
+                    reservedSize: 24,
+                    interval: 1,
+                    getTitlesWidget: (value, meta) {
+                      final i = value.round();
+                      if (i < 0 || i >= history.length) {
+                        return const SizedBox.shrink();
+                      }
+                      // 마지막 날짜는 직전 라벨과 충분히 떨어졌을 때만 덧붙인다(§6.4.2).
+                      final last = history.length - 1;
+                      final isTick = i % interval == 0;
+                      final isTail =
+                          i == last && last % interval > interval / 2;
+                      if (!isTick && !isTail) return const SizedBox.shrink();
+                      return Text(
+                        _axisLabel(
+                          history[i].snapshotDate,
+                          widget.chart.totalDays,
+                        ),
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
+              lineTouchData: LineTouchData(
+                touchSpotThreshold: 24,
+                touchCallback: (event, response) {
+                  final spot = response?.lineBarSpots?.firstOrNull;
+                  if (spot == null) return;
+                  if (spot.spotIndex == _touchedIndex) return;
+                  setState(() => _touchedIndex = spot.spotIndex);
+                },
+                // 툴팁 상자를 그리지 않는다. 값은 아래 패널이 보여주고, 여기서는 세로 지시선과
+                // 강조 점만 남긴다.
+                touchTooltipData: LineTouchTooltipData(
+                  getTooltipItems: (spots) => [for (final _ in spots) null],
+                ),
+                getTouchedSpotIndicator: (barData, indexes) => [
+                  for (final _ in indexes)
+                    TouchedSpotIndicatorData(
+                      const FlLine(
+                        color: TryptoPalette.mutedForeground,
+                        strokeWidth: 1,
+                        dashArray: [4, 3],
+                      ),
+                      FlDotData(
+                        getDotPainter: (spot, percent, bar, index) =>
+                            FlDotCirclePainter(
+                              radius: 4,
+                              color: bar.color ?? theme.colorScheme.primary,
+                              strokeColor: TryptoPalette.card,
+                              strokeWidth: 1.5,
+                            ),
+                      ),
+                    ),
+                ],
+              ),
+              lineBarsData: [
+                _line(actual, theme.colorScheme.primary, 2.2),
+                if (showSimulation)
+                  _line(
+                    simulation,
+                    colors.negative,
+                    1.8,
+                    dashArray: const [6, 4],
+                  ),
+                if (widget.btcEnabled)
+                  _line(
+                    btcHold,
+                    btcHoldColor.withValues(alpha: 0.5),
+                    1.5,
+                  ),
+                _markers(actual, markerIndexes, colors.negative),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: TryptoSpacing.md),
+        _ValuePanel(
+          date: history[index ?? history.length - 1].snapshotDate,
+          actual: actual[index ?? actual.length - 1],
+          simulation: showSimulation
+              ? simulation[index ?? simulation.length - 1]
+              : null,
+          btcHold: widget.btcEnabled
+              ? btcHold[index ?? btcHold.length - 1]
+              : null,
+          violated: markerIndexes.contains(index ?? history.length - 1),
+          currency: currency,
+          touched: index != null,
+        ),
+        const SizedBox(height: TryptoSpacing.sm),
+        _Legend(
+          showSimulation: showSimulation,
+          showBtcHold: widget.btcEnabled,
+        ),
+      ],
+    );
+  }
+
+  LineChartBarData _line(
+    List<double> values,
+    Color color,
+    double width, {
+    List<int>? dashArray,
+  }) {
+    return LineChartBarData(
+      spots: [
+        for (var i = 0; i < values.length; i++)
+          FlSpot(i.toDouble(), values[i]),
+      ],
+      color: color,
+      barWidth: width,
+      dashArray: dashArray,
+      isCurved: false,
+      dotData: const FlDotData(show: false),
+    );
+  }
+
+  /// 위반 마커는 선을 그리지 않는 별도 시리즈다 — 점만 남긴다(사양서 §6.4.3).
+  LineChartBarData _markers(
+    List<double> actual,
+    Set<int> indexes,
+    Color color,
+  ) {
+    return LineChartBarData(
+      spots: [
+        for (var i = 0; i < actual.length; i++)
+          FlSpot(i.toDouble(), actual[i]),
+      ],
+      color: Colors.transparent,
+      barWidth: 0,
+      dotData: FlDotData(
+        checkToShowDot: (spot, bar) => indexes.contains(spot.x.round()),
+        getDotPainter: (spot, percent, bar, index) => FlDotCirclePainter(
+          radius: 3,
+          color: color,
+          strokeColor: TryptoPalette.card,
+          strokeWidth: 1.5,
+        ),
+      ),
+    );
+  }
+}
+
+Set<int> _markerIndexes(
+  List<AssetHistoryPoint> history,
+  List<ViolationMarker> markers,
+) {
+  final byDate = <DateTime, int>{
+    for (var i = 0; i < history.length; i++) history[i].snapshotDate: i,
+  };
+  return {
+    for (final marker in markers)
+      if (byDate[marker.snapshotDate] != null) byDate[marker.snapshotDate]!,
+  };
+}
+
+String _axisLabel(DateTime date, int totalDays) =>
+    totalDays <= 180 ? _monthDay.format(date) : _yearMonth.format(date);
+
+/// 차트 아래 고정 값 패널. 손가락이 차트를 가려도 값이 보인다.
+class _ValuePanel extends StatelessWidget {
+  const _ValuePanel({
+    required this.date,
+    required this.actual,
+    required this.simulation,
+    required this.btcHold,
+    required this.violated,
+    required this.currency,
+    required this.touched,
+  });
+
+  final DateTime date;
+  final double actual;
+  final double? simulation;
+  final double? btcHold;
+  final bool violated;
+  final String currency;
+  final bool touched;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+    final simulation = this.simulation;
+    final btcHold = this.btcHold;
+
+    return Container(
+      padding: const EdgeInsets.all(TryptoSpacing.md),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainer,
+        borderRadius: BorderRadius.circular(TryptoRadius.md),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                _fullDate.format(date),
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const Spacer(),
+              if (violated)
+                Text(
+                  '규칙 위반 (손실)',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: colors.negative,
+                  ),
+                )
+              else if (!touched)
+                Text(
+                  '차트를 드래그해 날짜별 값을 봅니다',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: TryptoSpacing.sm),
+          Row(
+            children: [
+              Expanded(
+                child: _ValueCell(
+                  label: '실제',
+                  value: formatCurrencyCompact(actual, currency),
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+              if (simulation != null)
+                Expanded(
+                  child: _ValueCell(
+                    label: '규칙 준수',
+                    value: formatCurrencyCompact(simulation, currency),
+                    color: colors.negative,
+                  ),
+                ),
+              if (btcHold != null)
+                Expanded(
+                  child: _ValueCell(
+                    label: 'BTC 홀드',
+                    value: formatCurrencyCompact(btcHold, currency),
+                    color: btcHoldColor,
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ValueCell extends StatelessWidget {
+  const _ValueCell({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Container(
+              width: 8,
+              height: 2,
+              decoration: BoxDecoration(
+                color: color,
+                borderRadius: BorderRadius.circular(TryptoRadius.xs),
+              ),
+            ),
+            const SizedBox(width: TryptoSpacing.xs),
+            Text(
+              label,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 2),
+        NumericText(value, size: 13),
+      ],
+    );
+  }
+}
+
+class _Legend extends StatelessWidget {
+  const _Legend({required this.showSimulation, required this.showBtcHold});
+
+  final bool showSimulation;
+  final bool showBtcHold;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+
+    return Wrap(
+      spacing: TryptoSpacing.md,
+      runSpacing: TryptoSpacing.xs,
+      children: [
+        _LegendItem(color: theme.colorScheme.primary, label: '실제'),
+        if (showSimulation)
+          _LegendItem(color: colors.negative, label: '규칙 준수 시뮬레이션', dashed: true),
+        if (showBtcHold) const _LegendItem(color: btcHoldColor, label: 'BTC 홀드'),
+        _LegendItem(color: colors.negative, label: '위반 지점', dot: true),
+      ],
+    );
+  }
+}
+
+class _LegendItem extends StatelessWidget {
+  const _LegendItem({
+    required this.color,
+    required this.label,
+    this.dashed = false,
+    this.dot = false,
+  });
+
+  final Color color;
+  final String label;
+  final bool dashed;
+  final bool dot;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (dot)
+          Container(
+            width: 6,
+            height: 6,
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          )
+        else
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (var i = 0; i < (dashed ? 2 : 1); i++) ...[
+                if (i > 0) const SizedBox(width: 2),
+                Container(width: dashed ? 5 : 12, height: 2, color: color),
+              ],
+            ],
+          ),
+        const SizedBox(width: TryptoSpacing.xs),
+        Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// 스냅샷이 2개 미만이면 선을 그릴 수 없다. **스켈레톤을 쓰지 않는다** — 빈 상태를 로딩으로
+/// 오인시킨다(사양서 §6.6.2-8).
+class _EmptyChart extends StatelessWidget {
+  const _EmptyChart();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return SizedBox(
+      height: 220,
+      child: CustomPaint(
+        painter: const _DashedGridPainter(),
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(TryptoSpacing.lg),
+            child: Text(
+              '복기 리포트는 매일 밤 집계됩니다.\n내일 다시 확인해 주세요.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DashedGridPainter extends CustomPainter {
+  const _DashedGridPainter();
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = TryptoPalette.border
+      ..strokeWidth = 1;
+
+    for (var line = 0; line < 5; line++) {
+      final y = size.height * line / 4;
+      for (var x = 0.0; x < size.width; x += 8) {
+        canvas.drawLine(
+          Offset(x, y),
+          Offset((x + 4).clamp(0, size.width), y),
+          paint,
+        );
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_DashedGridPainter oldDelegate) => false;
+}

--- a/mobile/lib/features/regret/regret_page.dart
+++ b/mobile/lib/features/regret/regret_page.dart
@@ -1,19 +1,464 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
+import '../../core/constants/exchanges.dart';
+import '../../core/format/formatters.dart';
+import '../../core/router/guard.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/async_view.dart';
 import '../../core/widgets/empty_view.dart';
+import '../../core/widgets/exchange_segment.dart';
 import '../../core/widgets/mypage_button.dart';
+import '../../core/widgets/no_round_notice.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../models/enums.dart';
+import '../../models/regret.dart';
+import '../../models/round.dart';
+import '../round/round_controller.dart';
+import 'regret_chart.dart';
+import 'regret_repository.dart';
+import 'regret_simulation.dart';
+import 'rule_chips.dart';
+import 'violation_list.dart';
 
-class RegretPage extends StatelessWidget {
+const String _kDisclaimer = '* 모의투자 데이터입니다. 규칙 준수 시 수익률은 시뮬레이션 결과입니다.';
+
+final DateFormat _analysisDate = DateFormat('M/d', 'en_US');
+
+/// 웹은 `wallets[0]` 에 고정되어 다른 거래소의 복기를 볼 수 없다(사양서 §6.3.2). 거래소 선택기를
+/// 추가하고 응답의 `exchangeName`·`currency` 를 표기해 통화(KRW/USDT) 혼동을 막는다.
+///
+/// 선택 거래소는 라우트 쿼리(`/regret?exchange=upbit`)에 둔다 — 다른 탭과 같은 규칙이다.
+class RegretPage extends ConsumerStatefulWidget {
   const RegretPage({super.key});
 
   @override
+  ConsumerState<RegretPage> createState() => _RegretPageState();
+}
+
+class _RegretPageState extends ConsumerState<RegretPage> {
+  RegretRequest? _request;
+
+  /// null 이면 아직 리포트가 도착하지 않았다는 뜻이다. 사용자가 규칙을 전부 끈 **빈 집합**과
+  /// 구분해야 한다 — 빈 집합은 시뮬레이션 라인을 숨기라는 의사 표시다.
+  Set<RuleType>? _enabledRules;
+  bool _btcEnabled = true;
+  ViolationFilter _filter = ViolationFilter.all;
+
+  @override
   Widget build(BuildContext context) {
+    final round = ref.watch(
+      roundControllerProvider.select((state) => state.activeRound),
+    );
+
+    if (round == null) {
+      return const Scaffold(
+        appBar: _RegretAppBar(),
+        body: Column(
+          children: [
+            Expanded(
+              child: NoRoundNotice(message: '진행 중인 라운드가 없어 복기할 내역이 없습니다.'),
+            ),
+            _Disclaimer(),
+          ],
+        ),
+      );
+    }
+
+    final exchange = _selectedExchange(round);
+    final request = (roundId: round.roundId, exchangeId: exchange.id);
+    if (request != _request) {
+      // 거래소·라운드가 바뀌면 이전 리포트의 토글 상태를 버린다.
+      _request = request;
+      _enabledRules = null;
+      _btcEnabled = true;
+      _filter = ViolationFilter.all;
+    }
+
     return Scaffold(
-      appBar: AppBar(title: const Text('투자 복기'), actions: const [MypageButton()]),
-      body: const EmptyView(
-        icon: LucideIcons.notebookPen,
-        message: '투자 복기는 16단위에서 붙는다.',
+      appBar: const _RegretAppBar(),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              TryptoSpacing.screen,
+              TryptoSpacing.md,
+              TryptoSpacing.screen,
+              TryptoSpacing.sm,
+            ),
+            child: ExchangeSegment<int>(
+              items: [
+                for (final wallet in round.wallets)
+                  SegmentItem(
+                    wallet.exchangeId,
+                    ExchangeIds.byId(wallet.exchangeId)?.name ??
+                        '거래소 ${wallet.exchangeId}',
+                  ),
+              ],
+              value: exchange.id,
+              onChanged: (id) => context.go(
+                '${Routes.regret}?exchange='
+                '${(ExchangeIds.byId(id) ?? exchange).key}',
+              ),
+            ),
+          ),
+          Expanded(
+            child: AsyncView<RegretBundle>(
+              value: ref.watch(regretProvider(request)),
+              onRetry: () => ref.invalidate(regretProvider(request)),
+              builder: (bundle) => RefreshIndicator(
+                onRefresh: () => ref.refresh(regretProvider(request).future),
+                child: _Content(
+                  bundle: bundle,
+                  // 초기값은 리포트에 담긴 규칙 전체 활성이다(사양서 §6.3.4).
+                  enabledRules: _enabledRules ??= _initialRules(bundle.report),
+                  btcEnabled: _btcEnabled,
+                  filter: _filter,
+                  onToggleRule: _toggleRule,
+                  onToggleBtc: () => setState(() => _btcEnabled = !_btcEnabled),
+                  onFilter: (filter) => setState(() => _filter = filter),
+                ),
+              ),
+            ),
+          ),
+          const _Disclaimer(),
+        ],
+      ),
+    );
+  }
+
+  Set<RuleType> _initialRules(RegretReport report) => {
+    for (final impact in report.ruleImpacts)
+      if (impact.ruleType != null) impact.ruleType!,
+  };
+
+  void _toggleRule(RuleType rule) {
+    setState(() {
+      final rules = {..._enabledRules ?? <RuleType>{}};
+      if (!rules.remove(rule)) rules.add(rule);
+      _enabledRules = rules;
+    });
+  }
+
+  /// 쿼리가 가리키는 거래소에 이 라운드의 지갑이 없으면 첫 지갑으로 떨어진다.
+  Exchange _selectedExchange(ActiveRound round) {
+    final requested = ExchangeIds.byKey(
+      GoRouterState.of(context).uri.queryParameters['exchange'],
+    );
+    if (round.walletIdOf(requested.id) != null) return requested;
+    for (final wallet in round.wallets) {
+      final exchange = ExchangeIds.byId(wallet.exchangeId);
+      if (exchange != null) return exchange;
+    }
+    return requested;
+  }
+}
+
+class _RegretAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const _RegretAppBar();
+
+  @override
+  Size get preferredSize => const Size.fromHeight(56);
+
+  @override
+  Widget build(BuildContext context) => AppBar(
+    title: const Text('투자 복기'),
+    actions: const [MypageButton()],
+  );
+}
+
+class _Content extends StatelessWidget {
+  const _Content({
+    required this.bundle,
+    required this.enabledRules,
+    required this.btcEnabled,
+    required this.filter,
+    required this.onToggleRule,
+    required this.onToggleBtc,
+    required this.onFilter,
+  });
+
+  final RegretBundle bundle;
+  final Set<RuleType> enabledRules;
+  final bool btcEnabled;
+  final ViolationFilter filter;
+  final void Function(RuleType rule) onToggleRule;
+  final VoidCallback onToggleBtc;
+  final ValueChanged<ViolationFilter> onFilter;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final report = bundle.report;
+    final chart = bundle.chart;
+    final violations = filterViolations(report.violationDetails, filter);
+    final start = report.analysisStart;
+    final end = report.analysisEnd;
+
+    return CustomScrollView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      slivers: [
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(
+            TryptoSpacing.screen,
+            TryptoSpacing.sm,
+            TryptoSpacing.screen,
+            TryptoSpacing.md,
+          ),
+          sliver: SliverToBoxAdapter(child: _Hero(report: report)),
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: TryptoSpacing.screen),
+          sliver: SliverToBoxAdapter(
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.all(TryptoSpacing.lg),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text('자산 추이', style: theme.textTheme.titleMedium),
+                        const Spacer(),
+                        if (start != null && end != null)
+                          Text(
+                            '분석 구간 ${_analysisDate.format(start)}'
+                            ' ~ ${_analysisDate.format(end)}',
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: TryptoSpacing.md),
+                    RegretAssetChart(
+                      chart: chart,
+                      enabledRules: enabledRules,
+                      btcEnabled: btcEnabled,
+                    ),
+                    // 배치 전에는 규칙 임팩트도 비어 있다. 토글 행을 그리지 않는다.
+                    if (!report.isEmpty) ...[
+                      const SizedBox(height: TryptoSpacing.lg),
+                      Text('만약 규칙을 지켰다면', style: theme.textTheme.titleMedium),
+                      const SizedBox(height: TryptoSpacing.sm),
+                      RuleChips(
+                        impacts: report.ruleImpacts,
+                        enabled: enabledRules,
+                        btcEnabled: btcEnabled,
+                        btcProfitRate: btcHoldProfitRate(chart.assetHistory),
+                        onToggleRule: onToggleRule,
+                        onToggleBtc: onToggleBtc,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        if (!report.isEmpty) ...[
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(
+              TryptoSpacing.screen,
+              TryptoSpacing.lg,
+              TryptoSpacing.screen,
+              TryptoSpacing.sm,
+            ),
+            sliver: SliverToBoxAdapter(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Icon(
+                        LucideIcons.triangleAlert,
+                        size: 16,
+                        color: context.tryptoColors.warning,
+                      ),
+                      const SizedBox(width: TryptoSpacing.sm),
+                      Text('규칙 위반 거래', style: theme.textTheme.titleMedium),
+                    ],
+                  ),
+                  const SizedBox(height: TryptoSpacing.sm),
+                  ViolationFilterBar(
+                    violations: report.violationDetails,
+                    filter: filter,
+                    onChanged: onFilter,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (violations.isEmpty)
+            const SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: TryptoSpacing.xl),
+                child: EmptyView(
+                  icon: LucideIcons.circleCheck,
+                  message: '해당 조건의 위반 거래가 없습니다.',
+                ),
+              ),
+            )
+          else
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: TryptoSpacing.screen,
+              ),
+              sliver: SliverList.separated(
+                itemCount: violations.length,
+                separatorBuilder: (context, index) =>
+                    const SizedBox(height: TryptoSpacing.sm),
+                itemBuilder: (context, index) => ViolationTile(
+                  violation: violations[index],
+                  currency: report.currency,
+                ),
+              ),
+            ),
+        ],
+        const SliverToBoxAdapter(child: SizedBox(height: TryptoSpacing.lg)),
+      ],
+    );
+  }
+}
+
+/// "놓친 수익" 히어로 + 3-stat 타일. 비율은 `toStringAsFixed(2)` 로 다듬는다 — 서버 `BigDecimal`
+/// 의 scale 이 그대로 노출되면 `12.340000%` 가 된다(사양서 §6.4.4).
+class _Hero extends StatelessWidget {
+  const _Hero({required this.report});
+
+  final RegretReport report;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(TryptoSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${report.exchangeName} · ${report.currency}',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.sm),
+            Text(
+              '놓친 수익',
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.xs),
+            NumericText(
+              formatCurrency(report.missedProfit, report.currency),
+              size: 30,
+              weight: FontWeight.w700,
+              color: report.missedProfit > 0
+                  ? colors.negative
+                  : theme.colorScheme.onSurface,
+            ),
+            const SizedBox(height: TryptoSpacing.xs),
+            Text(
+              report.isEmpty
+                  ? '복기 리포트는 매일 밤 집계됩니다. 내일 다시 확인해 주세요.'
+                  : report.missedProfit > 0
+                  ? '규칙을 지켰다면 이만큼 더 벌었습니다.'
+                  : '규칙을 잘 지켰습니다. 놓친 수익이 없습니다.',
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.lg),
+            Row(
+              children: [
+                Expanded(
+                  child: _StatTile(
+                    label: '실제',
+                    value: formatProfitPercent(report.actualProfitRate),
+                    color: context.profitColor(report.actualProfitRate),
+                  ),
+                ),
+                Expanded(
+                  child: _StatTile(
+                    label: '규칙 준수 시',
+                    value: formatProfitPercent(report.ruleFollowedProfitRate),
+                    color: context.profitColor(report.ruleFollowedProfitRate),
+                  ),
+                ),
+                Expanded(
+                  child: _StatTile(
+                    label: '위반',
+                    value: '${report.totalViolations}건',
+                    color: report.totalViolations > 0 ? colors.negative : null,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatTile extends StatelessWidget {
+  const _StatTile({required this.label, required this.value, this.color});
+
+  final String label;
+  final String value;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 2),
+        NumericText(value, size: 16, weight: FontWeight.w700, color: color),
+      ],
+    );
+  }
+}
+
+/// 시뮬레이션이 가중치 보간 근사임을 알리는 유일한 장치다. 상태와 무관하게 항상 붙는다.
+class _Disclaimer extends StatelessWidget {
+  const _Disclaimer();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          TryptoSpacing.screen,
+          0,
+          TryptoSpacing.screen,
+          TryptoSpacing.sm,
+        ),
+        child: Text(
+          _kDisclaimer,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
       ),
     );
   }

--- a/mobile/lib/features/regret/regret_repository.dart
+++ b/mobile/lib/features/regret/regret_repository.dart
@@ -39,3 +39,36 @@ class RegretRepository {
 final regretRepositoryProvider = Provider<RegretRepository>(
   (ref) => RegretRepository(ref.watch(dioProvider)),
 );
+
+/// 라운드와 거래소가 함께 바뀌므로 키는 값 동등 레코드다. 거래소를 바꾸면 provider 키가 바뀌어
+/// 이전 리포트가 화면에 남지 않는다.
+typedef RegretRequest = ({int roundId, int exchangeId});
+
+/// 리포트와 차트는 항상 함께 쓰인다. 하나만 오면 히어로와 차트의 기준이 어긋난다.
+class RegretBundle {
+  const RegretBundle({required this.report, required this.chart});
+
+  final RegretReport report;
+  final RegretChart chart;
+}
+
+final regretProvider = FutureProvider.family<RegretBundle, RegretRequest>((
+  ref,
+  request,
+) async {
+  final repository = ref.watch(regretRepositoryProvider);
+  final results = await Future.wait<Object>([
+    repository.getReport(
+      roundId: request.roundId,
+      exchangeId: request.exchangeId,
+    ),
+    repository.getChart(
+      roundId: request.roundId,
+      exchangeId: request.exchangeId,
+    ),
+  ]);
+  return RegretBundle(
+    report: results[0] as RegretReport,
+    chart: results[1] as RegretChart,
+  );
+});

--- a/mobile/lib/features/regret/regret_simulation.dart
+++ b/mobile/lib/features/regret/regret_simulation.dart
@@ -1,0 +1,102 @@
+import 'dart:math' as math;
+
+import '../../models/enums.dart';
+import '../../models/regret.dart';
+
+/// 복기 화면의 순수 계산 전량. 위젯 없이 테스트한다.
+///
+/// **웹과 값이 일치해야 한다**(사양서 §6.3.4). 가중치·보간식·반올림을 그대로 이식한다.
+
+/// 합계 1.0. 5종 전부 켜면 서버의 `ruleFollowedAsset` 과 정확히 같아진다.
+const Map<RuleType, double> ruleImpactWeights = {
+  RuleType.lossCut: 0.30,
+  RuleType.chaseBuyBan: 0.25,
+  RuleType.profitTake: 0.20,
+  RuleType.overtradingLimit: 0.15,
+  RuleType.averagingDownLimit: 0.10,
+};
+
+double totalRuleWeight(Set<RuleType> enabled) {
+  var total = 0.0;
+  for (final rule in enabled) {
+    total += ruleImpactWeights[rule] ?? 0;
+  }
+  return total;
+}
+
+/// `sim[i] = round(actual[i] + (ruleFollowed[i] - actual[i]) × totalWeight)`
+///
+/// 실제 곡선과 규칙 준수 곡선 사이를 가중치 합만큼 선형 보간한 **근사값**이다. 서버 재계산은
+/// 일어나지 않는다.
+List<double> simulationLine(
+  List<AssetHistoryPoint> history,
+  Set<RuleType> enabled,
+) {
+  final weight = totalRuleWeight(enabled);
+  return [
+    for (final point in history)
+      (point.actualAsset +
+              (point.ruleFollowedAsset - point.actualAsset) * weight)
+          .roundToDouble(),
+  ];
+}
+
+/// BTC 홀드 벤치마크 수익률. 웹은 이 값을 `0%` 로 하드코딩해 두었다(사양서 §6.3.4).
+/// 스냅샷이 2개 미만이거나 시작 평가액이 0 이면 계산할 수 없다.
+double? btcHoldProfitRate(List<AssetHistoryPoint> history) {
+  if (history.length < 2) return null;
+  final first = history.first.btcHoldAsset;
+  if (first == 0) return null;
+  return (history.last.btcHoldAsset / first - 1) * 100;
+}
+
+/// X축 라벨 간격(일). 기간이 길수록 성기게 찍는다(사양서 §6.4.2).
+int labelTickInterval(int totalDays) {
+  if (totalDays <= 14) return 1;
+  if (totalDays <= 60) return 7;
+  if (totalDays <= 180) return 14;
+  return 30;
+}
+
+/// 표시 중인 **모든 시리즈**의 min/max 에 `(max-min) × 0.1` 을 덧댄다. 범위가 0이면 패딩은 1이다.
+({double min, double max}) chartYRange(List<List<double>> series) {
+  var min = double.infinity;
+  var max = double.negativeInfinity;
+  for (final line in series) {
+    for (final value in line) {
+      min = math.min(min, value);
+      max = math.max(max, value);
+    }
+  }
+  if (min == double.infinity) return (min: 0, max: 1);
+
+  final range = max - min;
+  final padding = range == 0 ? 1.0 : range * 0.1;
+  return (min: min - padding, max: max + padding);
+}
+
+/// 위반 거래 필터. **`profitLoss == 0` 은 수익으로 분류된다**(사양서 §6.3.5).
+enum ViolationFilter {
+  all('전체'),
+  loss('손실'),
+  profit('수익');
+
+  const ViolationFilter(this.label);
+
+  final String label;
+
+  bool matches(ViolationDetail violation) => switch (this) {
+    ViolationFilter.all => true,
+    ViolationFilter.loss => violation.profitLoss < 0,
+    ViolationFilter.profit => violation.profitLoss >= 0,
+  };
+}
+
+/// 정렬하지 않는다 — 서버 순서 그대로다(주문 단위 위반 먼저, 모니터링 위반 뒤).
+List<ViolationDetail> filterViolations(
+  List<ViolationDetail> violations,
+  ViolationFilter filter,
+) => [
+  for (final violation in violations)
+    if (filter.matches(violation)) violation,
+];

--- a/mobile/lib/features/regret/rule_chips.dart
+++ b/mobile/lib/features/regret/rule_chips.dart
@@ -1,0 +1,282 @@
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../core/format/formatters.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../models/enums.dart';
+import '../../models/regret.dart';
+import '../round/round_rules.dart';
+import 'regret_chart.dart';
+
+/// 규칙별 색과 아이콘(사양서 §6.3.3). 라벨·단위는 [ruleLabels]·[ruleUnits] 가 단일 출처다.
+const Map<RuleType, Color> ruleColors = {
+  RuleType.lossCut: Color(0xFFED4B9E),
+  RuleType.profitTake: Color(0xFF31D0AA),
+  RuleType.chaseBuyBan: Color(0xFFFFB237),
+  RuleType.averagingDownLimit: Color(0xFFE84142),
+  RuleType.overtradingLimit: Color(0xFF1FC7D4),
+};
+
+const Map<RuleType, IconData> ruleIcons = {
+  RuleType.lossCut: LucideIcons.trendingDown,
+  RuleType.profitTake: LucideIcons.trendingUp,
+  RuleType.chaseBuyBan: LucideIcons.ban,
+  RuleType.averagingDownLimit: LucideIcons.layers,
+  RuleType.overtradingLimit: LucideIcons.timer,
+};
+
+Color ruleColor(BuildContext context, RuleType? rule) =>
+    ruleColors[rule] ?? Theme.of(context).colorScheme.onSurfaceVariant;
+
+IconData ruleIcon(RuleType? rule) => ruleIcons[rule] ?? LucideIcons.circleDot;
+
+/// 임계값 표기 — `+10%`, `3회`. 서버 `thresholdUnit` 을 쓰지 않고 프론트 상수 표로 정한다(§6.3.3).
+String ruleThresholdLabel(RuleType? rule, double? value) {
+  if (value == null || value == 0) return '';
+  final unit = ruleUnits[rule] ?? '';
+  final sign = value > 0 && unit == '%' ? '+' : '';
+  final amount = value == value.roundToDouble()
+      ? value.toInt().toString()
+      : value.toString();
+  return '$sign$amount$unit';
+}
+
+/// MeVsMe 의 세로 체크박스 리스트를 가로 스크롤 칩 행으로 압축한다(사양서 §6.6.2-4).
+///
+/// 토글은 화면 로컬 상태이며 서버에 저장되지 않는다. 바뀌는 것은 **차트의 시뮬레이션 라인
+/// 하나뿐**이다 — 상단 3-stat 타일은 서버 요약이므로 토글과 무관하다.
+class RuleChips extends StatelessWidget {
+  const RuleChips({
+    super.key,
+    required this.impacts,
+    required this.enabled,
+    required this.btcEnabled,
+    required this.btcProfitRate,
+    required this.onToggleRule,
+    required this.onToggleBtc,
+  });
+
+  final List<RuleImpact> impacts;
+  final Set<RuleType> enabled;
+  final bool btcEnabled;
+
+  /// 웹은 이 값을 `0%` 로 하드코딩했다. 스냅샷이 모자라면 null 이다.
+  final double? btcProfitRate;
+
+  final void Function(RuleType rule) onToggleRule;
+  final VoidCallback onToggleBtc;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    if (impacts.isEmpty) {
+      return Text(
+        '설정한 투자 원칙이 없습니다.',
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      );
+    }
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          for (final impact in impacts) ...[
+            _RuleChip(
+              impact: impact,
+              selected:
+                  impact.ruleType != null && enabled.contains(impact.ruleType),
+              onTap: impact.ruleType == null
+                  ? null
+                  : () => onToggleRule(impact.ruleType!),
+              onLongPress: () => _showRuleDetail(context, impact),
+            ),
+            const SizedBox(width: TryptoSpacing.sm),
+          ],
+          FilterChip(
+            selected: btcEnabled,
+            onSelected: (_) => onToggleBtc(),
+            avatar: Icon(LucideIcons.bitcoin, size: 14, color: btcHoldColor),
+            label: Text(
+              btcProfitRate == null
+                  ? 'BTC만 홀드한 나'
+                  : 'BTC만 홀드한 나 ${formatProfitPercent(btcProfitRate!)}',
+            ),
+            side: BorderSide(
+              color: btcEnabled ? btcHoldColor : TryptoPalette.border,
+            ),
+            selectedColor: btcHoldColor.withValues(alpha: 0.12),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RuleChip extends StatelessWidget {
+  const _RuleChip({
+    required this.impact,
+    required this.selected,
+    required this.onTap,
+    required this.onLongPress,
+  });
+
+  final RuleImpact impact;
+  final bool selected;
+  final VoidCallback? onTap;
+  final VoidCallback onLongPress;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+    final rule = impact.ruleType;
+    final color = ruleColor(context, rule);
+
+    return GestureDetector(
+      onLongPress: onLongPress,
+      child: FilterChip(
+        selected: selected,
+        onSelected: onTap == null ? null : (_) => onTap!(),
+        avatar: Icon(ruleIcon(rule), size: 14, color: color),
+        side: BorderSide(color: selected ? color : TryptoPalette.border),
+        selectedColor: color.withValues(alpha: 0.12),
+        label: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(ruleLabels[rule] ?? '알 수 없는 원칙'),
+            if (impact.violationCount > 0) ...[
+              const SizedBox(width: TryptoSpacing.xs),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+                decoration: BoxDecoration(
+                  color: colors.negative.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+                child: NumericText(
+                  '${impact.violationCount}',
+                  size: 10,
+                  weight: FontWeight.w700,
+                  color: colors.negative,
+                ),
+              ),
+            ],
+          ],
+        ),
+        labelStyle: theme.textTheme.labelMedium,
+      ),
+    );
+  }
+}
+
+/// 칩 롱프레스 → 임계값·영향도 상세. 좁은 칩에 다 담을 수 없는 값을 여기서 편다.
+Future<void> _showRuleDetail(BuildContext context, RuleImpact impact) {
+  return showModalBottomSheet<void>(
+    context: context,
+    useSafeArea: true,
+    builder: (context) {
+      final theme = Theme.of(context);
+      final colors = context.tryptoColors;
+      final rule = impact.ruleType;
+      final color = ruleColor(context, rule);
+      final threshold = ruleThresholdLabel(rule, impact.thresholdValue);
+      final loss = impact.totalLossAmount;
+      final gap = impact.impactGap;
+
+      return SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(
+            TryptoSpacing.screen,
+            0,
+            TryptoSpacing.screen,
+            TryptoSpacing.screen,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    width: 32,
+                    height: 32,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: color.withValues(alpha: 0.12),
+                      borderRadius: BorderRadius.circular(TryptoRadius.md),
+                    ),
+                    child: Icon(ruleIcon(rule), size: 16, color: color),
+                  ),
+                  const SizedBox(width: TryptoSpacing.md),
+                  Expanded(
+                    child: Text(
+                      ruleLabels[rule] ?? '알 수 없는 원칙',
+                      style: theme.textTheme.titleLarge,
+                    ),
+                  ),
+                  if (threshold.isNotEmpty)
+                    NumericText(threshold, size: 16, color: color),
+                ],
+              ),
+              const SizedBox(height: TryptoSpacing.lg),
+              _DetailRow(
+                label: '위반 횟수',
+                value: '${impact.violationCount}건',
+                color: impact.violationCount > 0 ? colors.negative : null,
+              ),
+              if (loss != null)
+                _DetailRow(label: '누적 손실', value: formatKRWCompact(loss)),
+              if (gap != null)
+                _DetailRow(
+                  label: '영향도',
+                  value: formatProfitPercent(gap),
+                  color: context.profitColor(gap),
+                ),
+              const SizedBox(height: TryptoSpacing.sm),
+              Text(
+                '칩을 눌러 이 원칙을 시뮬레이션에서 켜고 끌 수 있습니다.',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({required this.label, required this.value, this.color});
+
+  final String label;
+  final String value;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: TryptoSpacing.xs),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              label,
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          NumericText(value, size: 13, color: color),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/regret/violation_list.dart
+++ b/mobile/lib/features/regret/violation_list.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../core/format/formatters.dart';
+import '../../core/format/server_time.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/exchange_segment.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../models/enums.dart';
+import '../../models/regret.dart';
+import '../round/round_rules.dart';
+import 'regret_simulation.dart';
+import 'rule_chips.dart';
+
+final DateFormat _monthDay = DateFormat('M/d', 'en_US');
+
+/// 필터 세그먼트. 라벨에 건수를 함께 싣는다(사양서 §6.3.5).
+class ViolationFilterBar extends StatelessWidget {
+  const ViolationFilterBar({
+    super.key,
+    required this.violations,
+    required this.filter,
+    required this.onChanged,
+  });
+
+  final List<ViolationDetail> violations;
+  final ViolationFilter filter;
+  final ValueChanged<ViolationFilter> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return ExchangeSegment<ViolationFilter>(
+      items: [
+        for (final value in ViolationFilter.values)
+          SegmentItem(
+            value,
+            '${value.label} ${filterViolations(violations, value).length}',
+          ),
+      ],
+      value: filter,
+      onChanged: onChanged,
+    );
+  }
+}
+
+/// 2행 레이아웃 — 1행: 코인·날짜·손익 / 2행: 규칙 태그 가로 스크롤(사양서 §6.6.2-7).
+/// 한 행에 규칙 태그가 여러 개면 가로가 부족하다.
+class ViolationTile extends StatelessWidget {
+  const ViolationTile({
+    super.key,
+    required this.violation,
+    required this.currency,
+  });
+
+  final ViolationDetail violation;
+  final String currency;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final profitLoss = violation.profitLoss;
+
+    return Card(
+      child: InkWell(
+        onTap: () => _showViolationDetail(context, violation, currency),
+        child: Padding(
+          padding: const EdgeInsets.all(TryptoSpacing.md),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Text(violation.coinSymbol, style: TryptoText.symbol),
+                  const SizedBox(width: TryptoSpacing.sm),
+                  Text(
+                    _monthDay.format(violation.occurredAt),
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const Spacer(),
+                  NumericText(
+                    // profitLoss == 0 은 수익으로 분류되지만 부호는 붙이지 않는다.
+                    '${profitLoss > 0 ? '+' : ''}'
+                    '${formatCurrencyCompact(profitLoss, currency)}',
+                    color: context.profitColor(profitLoss),
+                  ),
+                ],
+              ),
+              const SizedBox(height: TryptoSpacing.sm),
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: [
+                    for (final rule in violation.violatedRules) ...[
+                      RuleTag(rule: rule),
+                      const SizedBox(width: TryptoSpacing.xs),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class RuleTag extends StatelessWidget {
+  const RuleTag({super.key, required this.rule});
+
+  final RuleType rule;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = ruleColor(context, rule);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(TryptoRadius.sm),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(ruleIcon(rule), size: 11, color: color),
+          const SizedBox(width: 3),
+          Text(
+            ruleLabels[rule] ?? '알 수 없는 원칙',
+            style: theme.textTheme.labelSmall?.copyWith(color: color),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 감정 배지는 구현하지 않는다 — 서버 응답에 대응 필드가 없다(사양서 §6.3.5).
+Future<void> _showViolationDetail(
+  BuildContext context,
+  ViolationDetail violation,
+  String currency,
+) {
+  return showModalBottomSheet<void>(
+    context: context,
+    useSafeArea: true,
+    builder: (context) {
+      final theme = Theme.of(context);
+      final profitLoss = violation.profitLoss;
+
+      return SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(
+            TryptoSpacing.screen,
+            0,
+            TryptoSpacing.screen,
+            TryptoSpacing.screen,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    LucideIcons.triangleAlert,
+                    size: 16,
+                    color: context.tryptoColors.warning,
+                  ),
+                  const SizedBox(width: TryptoSpacing.sm),
+                  Text(
+                    '${violation.coinSymbol} 위반 거래',
+                    style: theme.textTheme.titleLarge,
+                  ),
+                ],
+              ),
+              const SizedBox(height: TryptoSpacing.lg),
+              _DetailRow(
+                label: '손익',
+                value:
+                    '${profitLoss > 0 ? '+' : ''}'
+                    '${formatCurrencyCompact(profitLoss, currency)}',
+                color: context.profitColor(profitLoss),
+              ),
+              _DetailRow(
+                label: '체결 시각',
+                value: ServerTime.formatDateTime(violation.occurredAt),
+              ),
+              _DetailRow(
+                label: '주문 번호',
+                // orderId 가 없으면 주문이 아니라 모니터링에서 잡힌 위반이다.
+                value: violation.orderId?.toString() ?? '모니터링 위반',
+              ),
+              const SizedBox(height: TryptoSpacing.md),
+              Text('위반한 원칙', style: theme.textTheme.titleMedium),
+              const SizedBox(height: TryptoSpacing.sm),
+              Wrap(
+                spacing: TryptoSpacing.xs,
+                runSpacing: TryptoSpacing.xs,
+                children: [
+                  for (final rule in violation.violatedRules)
+                    RuleTag(rule: rule),
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({required this.label, required this.value, this.color});
+
+  final String label;
+  final String value;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: TryptoSpacing.xs),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              label,
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          NumericText(value, size: 13, color: color),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/round/emergency_funding_sheet.dart
+++ b/mobile/lib/features/round/emergency_funding_sheet.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../core/constants/exchanges.dart';
+import '../../core/format/formatters.dart';
+import '../../core/theme/theme.dart';
+import '../../core/widgets/app_snackbar.dart';
+import '../../core/widgets/numeric_text.dart';
+import 'round_controller.dart';
+import 'round_rules.dart';
+
+/// 웹의 다이얼로그를 바텀시트로 옮긴 것(계획서 §4.6.1). 성공하면 투입 금액을 돌려주고 닫힌다.
+Future<int?> showEmergencyFundingSheet(
+  BuildContext context, {
+  required Exchange exchange,
+}) {
+  return showModalBottomSheet<int>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    builder: (context) => EmergencyFundingSheet(exchange: exchange),
+  );
+}
+
+class EmergencyFundingSheet extends ConsumerStatefulWidget {
+  const EmergencyFundingSheet({super.key, required this.exchange});
+
+  /// 자금은 **지금 보고 있는 거래소** 지갑으로 들어간다(사양서 §4.5).
+  final Exchange exchange;
+
+  @override
+  ConsumerState<EmergencyFundingSheet> createState() =>
+      _EmergencyFundingSheetState();
+}
+
+class _EmergencyFundingSheetState extends ConsumerState<EmergencyFundingSheet> {
+  final TextEditingController _input = TextEditingController();
+
+  /// **UUID v4 필수** — 서버가 `java.util.UUID` 로 역직렬화해 형식이 틀리면 400 이 아니라
+  /// 500 을 낸다(사양서 R8-1). 실패해 다시 누를 때 **같은 키를 재사용**한다.
+  final String _idempotencyKey = const Uuid().v4();
+
+  int _amount = 0;
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _input.dispose();
+    super.dispose();
+  }
+
+  void _setAmount(int amount) {
+    setState(() => _amount = amount);
+    final text = amount == 0 ? '' : formatGrouped(amount);
+    if (_input.text == text) return;
+    _input.value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+  }
+
+  Future<void> _submit() async {
+    if (_submitting) return;
+    setState(() => _submitting = true);
+
+    final error = await ref
+        .read(roundControllerProvider.notifier)
+        .chargeEmergencyFunding(
+          exchangeId: widget.exchange.id,
+          amount: _amount,
+          idempotencyKey: _idempotencyKey,
+        );
+    if (!mounted) return;
+    setState(() => _submitting = false);
+
+    // 웹은 실패해도 화면에 아무 표시를 하지 않는다(콘솔 로그만). 반드시 알린다(R9).
+    if (error != null) {
+      showAppSnackbar(context, error, isError: true);
+      return;
+    }
+    Navigator.of(context).pop(_amount);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final round = ref.watch(
+      roundControllerProvider.select((state) => state.activeRound),
+    );
+    if (round == null) return const SizedBox.shrink();
+
+    final limit = round.emergencyFundingLimit.toInt();
+    final error = EmergencyFundingPolicy.validateCharge(_amount, limit);
+    final exhausted = round.emergencyChargeCount <= 0;
+
+    // 시트가 자체 ScaffoldMessenger 를 갖는다. 바깥 Scaffold 의 스낵바는 시트 뒤로 가려진다.
+    return ScaffoldMessenger(
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: Padding(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.viewInsetsOf(context).bottom,
+          ),
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(
+              TryptoSpacing.screen,
+              0,
+              TryptoSpacing.screen,
+              TryptoSpacing.screen,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('긴급 자금 투입', style: theme.textTheme.titleLarge),
+                const SizedBox(height: TryptoSpacing.xs),
+                Text(
+                  '${widget.exchange.name} 지갑으로 들어갑니다. '
+                  '남은 횟수 ${round.emergencyChargeCount}회 · '
+                  '1회 상한 ${formatKRW(round.emergencyFundingLimit)}',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: TryptoSpacing.lg),
+                TextField(
+                  controller: _input,
+                  autofocus: true,
+                  textAlign: TextAlign.right,
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  style: TryptoText.numeric(size: 20, weight: FontWeight.w700),
+                  onChanged: (text) => setState(
+                    () => _amount = int.tryParse(text.replaceAll(',', '')) ?? 0,
+                  ),
+                  decoration: const InputDecoration(
+                    hintText: '0',
+                    suffixText: '원',
+                  ),
+                ),
+                const SizedBox(height: TryptoSpacing.sm),
+                Row(
+                  children: [
+                    for (final preset in EmergencyFundingPolicy.presets(limit))
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.only(
+                            right: TryptoSpacing.xs,
+                          ),
+                          child: OutlinedButton(
+                            onPressed: () => _setAmount(preset),
+                            child: Text(formatKRWCompact(preset.toDouble())),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: TryptoSpacing.sm),
+                SizedBox(
+                  height: 20,
+                  child: _amount > 0 && error != null
+                      ? Text(
+                          error,
+                          style: theme.textTheme.labelMedium?.copyWith(
+                            color: theme.colorScheme.error,
+                          ),
+                        )
+                      : NumericText(
+                          _amount > 0 ? formatKRW(_amount.toDouble()) : '',
+                          size: 12,
+                          weight: FontWeight.w500,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                ),
+                const SizedBox(height: TryptoSpacing.lg),
+                SizedBox(
+                  width: double.infinity,
+                  height: 48,
+                  child: FilledButton(
+                    onPressed: error == null && !exhausted && !_submitting
+                        ? _submit
+                        : null,
+                    child: _submitting
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('투입 확정'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/round/round_controller.dart
+++ b/mobile/lib/features/round/round_controller.dart
@@ -56,6 +56,40 @@ class RoundController extends Notifier<RoundState> {
 
   Future<void> refresh() => _load(_generation);
 
+  /// 성공하면 `null`, 실패하면 사용자에게 보일 메시지를 돌려준다. 웹은 서버 오류를 삼키고
+  /// "입력값을 다시 확인해 주세요" 한 줄로 뭉갠다(사양서 §7.3.3) — 여기서는 그대로 노출한다.
+  ///
+  /// 생성 응답에는 `userId` 가 없어 [ActiveRound] 를 그대로 만들 수 없다(R4-3). 서버 진실을
+  /// 들이려고 재조회한다. 로딩 상태로 되돌리지 않으므로 가드가 스플래시를 스치지 않는다.
+  Future<String?> createRound(StartRoundRequest request) async {
+    try {
+      await ref.read(roundRepositoryProvider).startRound(request);
+    } on ApiException catch (error) {
+      return error.userMessage;
+    }
+    await _load(_generation);
+    if (state.hasActive) return null;
+    return state.errorMessage ?? '라운드를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.';
+  }
+
+  Future<String?> endRound() async {
+    final round = state.activeRound;
+    if (round == null) return null;
+    try {
+      await ref.read(roundRepositoryProvider).endRound(round.roundId);
+    } on ApiException catch (error) {
+      return error.userMessage;
+    }
+    clearRound();
+    return null;
+  }
+
+  /// 서버를 부르지 않고 로컬 활성 라운드만 비운다. `totalRoundCount` 는 유지된다 — 라운드를
+  /// 끝낸 사용자는 생성 화면으로 밀려나지 않고 '라운드 없이 둘러보기' 상태가 된다(§7.4.3).
+  void clearRound() {
+    state = RoundState(isLoading: false, totalRoundCount: state.totalRoundCount);
+  }
+
   /// 활성 라운드와 누적 라운드 수를 병렬로 읽는다. 활성 라운드가 없으면 repository 가
   /// `ROUND_NOT_ACTIVE` 를 `null` 로 바꿔 준다 — 예외가 아니다.
   Future<void> _load(int generation) async {

--- a/mobile/lib/features/round/round_controller.dart
+++ b/mobile/lib/features/round/round_controller.dart
@@ -3,9 +3,11 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/api/api_exception.dart';
+import '../../models/enums.dart';
 import '../../models/round.dart';
 import '../auth/auth_controller.dart';
 import 'round_repository.dart';
+import 'round_rules.dart';
 
 /// 라우트 가드의 입력(사양서 §2.7.1). `hasActive`(지금 활성 라운드가 있는가)와
 /// `hasEverStarted`(한 번이라도 시작한 적 있는가)는 **별개**다 — 신규 사용자는 라운드 생성을
@@ -70,6 +72,54 @@ class RoundController extends Notifier<RoundState> {
     await _load(_generation);
     if (state.hasActive) return null;
     return state.errorMessage ?? '라운드를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.';
+  }
+
+  /// 긴급 자금 투입. 성공하면 `null`, 실패하면 사용자에게 보일 메시지를 돌려준다.
+  ///
+  /// 로컬 선검사에 걸리면 **네트워크 호출을 하지 않는다**(사양서 §4.5). [idempotencyKey] 는
+  /// UUID v4 여야 하며(형식이 틀리면 서버가 500 을 낸다) 재시도 시 같은 값을 재사용한다 —
+  /// 호출부가 화면 상태에 보관한다.
+  Future<String?> chargeEmergencyFunding({
+    required int exchangeId,
+    required int amount,
+    required String idempotencyKey,
+  }) async {
+    final round = state.activeRound;
+    if (round == null) return '진행 중인 라운드가 없습니다.';
+    if (round.status != RoundStatus.active) {
+      return '진행 중인 라운드가 아닙니다.';
+    }
+    if (round.emergencyChargeCount <= 0) {
+      return '긴급 자금 투입 횟수를 모두 사용했습니다.';
+    }
+    final invalid = EmergencyFundingPolicy.validateCharge(
+      amount,
+      round.emergencyFundingLimit.toInt(),
+    );
+    if (invalid != null) return invalid;
+
+    try {
+      final response = await ref
+          .read(roundRepositoryProvider)
+          .chargeEmergencyFunding(
+            round.roundId,
+            ChargeEmergencyFundingRequest(
+              exchangeId: exchangeId,
+              amount: amount.toDouble(),
+              idempotencyKey: idempotencyKey,
+            ),
+          );
+      state = RoundState(
+        isLoading: false,
+        activeRound: round.withEmergencyChargeCount(
+          response.remainingChargeCount,
+        ),
+        totalRoundCount: state.totalRoundCount,
+      );
+    } on ApiException catch (error) {
+      return error.userMessage;
+    }
+    return null;
   }
 
   Future<String?> endRound() async {

--- a/mobile/lib/features/round/round_create_page.dart
+++ b/mobile/lib/features/round/round_create_page.dart
@@ -2,31 +2,732 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
-import '../../core/widgets/empty_view.dart';
+import '../../core/format/formatters.dart';
+import '../../core/theme/theme.dart';
+import '../../core/widgets/app_snackbar.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../models/enums.dart';
 import '../auth/auth_controller.dart';
+import 'round_controller.dart';
+import 'round_rules.dart';
 
-/// 시드·긴급자금·원칙 2단계 입력은 7단위에서 붙는다. 신규 사용자는 가드에 의해 이 화면에
-/// 묶이므로, 그동안 빠져나갈 수 있도록 로그아웃만 열어 둔다.
-class RoundCreatePage extends ConsumerWidget {
+enum _AmountField { seed, emergency }
+
+/// 2단계 스텝 + 하단 고정 CTA(계획서 §5.3). 검증은 **입력 단계에서** 한다 — 웹은 제출 시점에
+/// 서버 400·500 을 받고 그 메시지마저 버린다.
+class RoundCreatePage extends ConsumerStatefulWidget {
   const RoundCreatePage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<RoundCreatePage> createState() => _RoundCreatePageState();
+}
+
+class _RoundCreatePageState extends ConsumerState<RoundCreatePage> {
+  static const List<int> _seedPresets = [1000000, 5000000, 10000000, 50000000];
+  static const List<int> _emergencyPresets = [100000, 500000, 1000000];
+
+  int _step = 0;
+  int _seed = 0;
+  int _emergencyLimit = 0;
+  _AmountField _target = _AmountField.seed;
+  bool _submitting = false;
+
+  final Map<RuleType, int> _values = {
+    for (final config in ruleConfigs) config.ruleType: config.defaultValue,
+  };
+  final Set<RuleType> _enabled = {};
+
+  RoundDraft get _draft => RoundDraft(
+    seed: _seed,
+    emergencyLimit: _emergencyLimit,
+    rules: {for (final type in _enabled) type: _values[type]!},
+  );
+
+  bool get _fundingReady =>
+      _draft.seedError == null && _draft.emergencyError == null;
+
+  void _key(String key) {
+    setState(() {
+      final current = _target == _AmountField.seed ? _seed : _emergencyLimit;
+      final next = key == '<' ? current ~/ 10 : _append(current, key);
+      if (_target == _AmountField.seed) {
+        _seed = next;
+      } else {
+        _emergencyLimit = next;
+      }
+    });
+  }
+
+  int _append(int current, String digits) {
+    final text = '$current$digits';
+    if (text.length > 11) return current;
+    return int.parse(text);
+  }
+
+  Future<void> _submit() async {
+    final draft = _draft;
+    if (!draft.canSubmit || _submitting) return;
+
+    setState(() => _submitting = true);
+    final error = await ref
+        .read(roundControllerProvider.notifier)
+        .createRound(draft.toRequest());
+    if (!mounted) return;
+    setState(() => _submitting = false);
+
+    // 성공 시 화면 이동은 하지 않는다 — 활성 라운드가 생기면 가드가 /market 으로 보낸다.
+    if (error != null) showAppSnackbar(context, error, isError: true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('라운드 시작'),
+        leading: _step == 0
+            ? null
+            : IconButton(
+                icon: const Icon(LucideIcons.arrowLeft),
+                onPressed: () => setState(() => _step = 0),
+              ),
+        title: const Text('투자 라운드 시작'),
         actions: [
           IconButton(
             icon: const Icon(LucideIcons.logOut),
             tooltip: '로그아웃',
-            onPressed: () =>
-                ref.read(authControllerProvider.notifier).logout(),
+            onPressed: () => ref.read(authControllerProvider.notifier).logout(),
           ),
         ],
       ),
-      body: const EmptyView(
-        icon: LucideIcons.flag,
-        message: '라운드 생성은 7단위에서 붙는다.',
+      body: SafeArea(
+        child: Column(
+          children: [
+            _StepBar(step: _step),
+            Expanded(
+              child: _step == 0 ? _buildFundingStep(theme) : _buildRulesStep(),
+            ),
+            _Cta(
+              label: _step == 0 ? '다음' : '라운드 시작하기',
+              icon: _step == 0 ? null : LucideIcons.rocket,
+              hint: _step == 0
+                  ? (_fundingReady ? null : '시드머니와 긴급 자금 상한을 설정해 주세요.')
+                  : _draft.rulesError,
+              busy: _submitting,
+              onPressed: _step == 0
+                  ? (_fundingReady ? () => setState(() => _step = 1) : null)
+                  : (_draft.canSubmit ? _submit : null),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFundingStep(ThemeData theme) {
+    return Column(
+      children: [
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(TryptoSpacing.screen),
+            children: [
+              Text(
+                '시드머니와 투자 원칙을 설정하고 모의투자를 시작하세요.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: TryptoSpacing.lg),
+              _AmountCard(
+                icon: LucideIcons.wallet,
+                title: '시작 자금',
+                description: '모의투자에 사용할 초기 자본금',
+                amount: _seed,
+                presets: _seedPresets,
+                selected: _target == _AmountField.seed,
+                error: _seed > 0 ? _draft.seedError : null,
+                onSelect: () => setState(() => _target = _AmountField.seed),
+                onPreset: (value) => setState(() {
+                  _seed = value;
+                  _target = _AmountField.seed;
+                }),
+              ),
+              const SizedBox(height: TryptoSpacing.md),
+              _AmountCard(
+                icon: LucideIcons.shieldPlus,
+                title: '긴급 자금 투입 상한',
+                description: '1회당 최대 투입 금액',
+                amount: _emergencyLimit,
+                presets: _emergencyPresets,
+                selected: _target == _AmountField.emergency,
+                error: _emergencyLimit > 0 ? _draft.emergencyError : null,
+                note:
+                    '라운드 진행 중 최대 ${EmergencyFundingPolicy.chargeCount}회까지 '
+                    '긴급 자금을 투입할 수 있습니다',
+                onSelect: () => setState(() => _target = _AmountField.emergency),
+                onPreset: (value) => setState(() {
+                  _emergencyLimit = value;
+                  _target = _AmountField.emergency;
+                }),
+              ),
+            ],
+          ),
+        ),
+        _Keypad(onKey: _key),
+      ],
+    );
+  }
+
+  Widget _buildRulesStep() {
+    final theme = Theme.of(context);
+
+    return ListView(
+      padding: const EdgeInsets.all(TryptoSpacing.screen),
+      children: [
+        Row(
+          children: [
+            Text('투자 원칙', style: theme.textTheme.titleMedium),
+            const Spacer(),
+            if (_enabled.isEmpty)
+              Text(
+                '최소 1개 이상',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              )
+            else
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+                child: Text(
+                  '${_enabled.length}개 활성',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: TryptoSpacing.md),
+        for (final config in ruleConfigs) ...[
+          _RuleCard(
+            config: config,
+            enabled: _enabled.contains(config.ruleType),
+            value: _values[config.ruleType]!,
+            onToggle: () => setState(() {
+              if (!_enabled.remove(config.ruleType)) {
+                _enabled.add(config.ruleType);
+              }
+            }),
+            onChanged: (value) => setState(
+              () => _values[config.ruleType] = config.clamp(value),
+            ),
+          ),
+          const SizedBox(height: TryptoSpacing.md),
+        ],
+      ],
+    );
+  }
+}
+
+class _StepBar extends StatelessWidget {
+  const _StepBar({required this.step});
+
+  final int step;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        TryptoSpacing.screen,
+        TryptoSpacing.md,
+        TryptoSpacing.screen,
+        0,
+      ),
+      child: Row(
+        children: [
+          for (var i = 0; i < 2; i++) ...[
+            Expanded(
+              child: Container(
+                height: 4,
+                decoration: BoxDecoration(
+                  color: i <= step
+                      ? theme.colorScheme.primary
+                      : TryptoPalette.secondary,
+                  borderRadius: BorderRadius.circular(TryptoRadius.xs),
+                ),
+              ),
+            ),
+            const SizedBox(width: TryptoSpacing.xs),
+          ],
+          Text(
+            '${step + 1}/2',
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AmountCard extends StatelessWidget {
+  const _AmountCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.amount,
+    required this.presets,
+    required this.selected,
+    required this.onSelect,
+    required this.onPreset,
+    this.error,
+    this.note,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final int amount;
+  final List<int> presets;
+  final bool selected;
+  final VoidCallback onSelect;
+  final ValueChanged<int> onPreset;
+  final String? error;
+  final String? note;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final empty = amount == 0;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onSelect,
+      child: Container(
+        padding: const EdgeInsets.all(TryptoSpacing.lg),
+        decoration: BoxDecoration(
+          color: TryptoPalette.card,
+          borderRadius: BorderRadius.circular(TryptoRadius.xl),
+          border: Border.all(
+            color: selected ? theme.colorScheme.primary : TryptoPalette.border,
+            width: selected ? 1.5 : 1,
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, size: 16, color: theme.colorScheme.primary),
+                const SizedBox(width: TryptoSpacing.sm),
+                Text(title, style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: TryptoSpacing.xs),
+            Text(
+              description,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.md),
+            NumericText(
+              '₩${formatGrouped(amount)}',
+              size: 28,
+              weight: FontWeight.w700,
+              color: empty
+                  ? theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.4)
+                  : theme.colorScheme.onSurface,
+            ),
+            if (!empty) ...[
+              const SizedBox(height: TryptoSpacing.xs),
+              Text(
+                formatKRW(amount.toDouble()),
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+            if (error != null) ...[
+              const SizedBox(height: TryptoSpacing.sm),
+              Text(
+                error!,
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
+            ],
+            const SizedBox(height: TryptoSpacing.md),
+            Row(
+              children: [
+                for (final preset in presets) ...[
+                  Expanded(
+                    child: _PresetButton(
+                      value: preset,
+                      active: preset == amount,
+                      onTap: () => onPreset(preset),
+                    ),
+                  ),
+                  if (preset != presets.last)
+                    const SizedBox(width: TryptoSpacing.xs),
+                ],
+              ],
+            ),
+            if (note != null) ...[
+              const SizedBox(height: TryptoSpacing.sm),
+              Text(
+                note!,
+                style: TryptoText.micro.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 프리셋은 토글이 아니라 값 덮어쓰기다(사양서 §7.3.1). 현재 값과 정확히 일치할 때만 활성 모양이다.
+class _PresetButton extends StatelessWidget {
+  const _PresetButton({
+    required this.value,
+    required this.active,
+    required this.onTap,
+  });
+
+  final int value;
+  final bool active;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: 32,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: active
+              ? theme.colorScheme.primary
+              : TryptoPalette.secondary,
+          borderRadius: BorderRadius.circular(TryptoRadius.md),
+        ),
+        child: Text(
+          formatKRWCompact(value.toDouble()),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: active
+                ? theme.colorScheme.onPrimary
+                : theme.colorScheme.onSurface,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 금액 입력 전용 키패드. 시스템 키보드를 띄우면 카드 두 장이 화면 밖으로 밀린다.
+class _Keypad extends StatelessWidget {
+  const _Keypad({required this.onKey});
+
+  final ValueChanged<String> onKey;
+
+  static const List<List<String>> _rows = [
+    ['1', '2', '3'],
+    ['4', '5', '6'],
+    ['7', '8', '9'],
+    ['00', '0', '<'],
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: TryptoSpacing.sm,
+        vertical: TryptoSpacing.sm,
+      ),
+      decoration: const BoxDecoration(
+        color: TryptoPalette.secondary,
+        border: Border(top: BorderSide(color: TryptoPalette.border)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (final row in _rows)
+            Row(
+              children: [
+                for (final key in row)
+                  Expanded(
+                    child: InkWell(
+                      onTap: () => onKey(key),
+                      borderRadius: BorderRadius.circular(TryptoRadius.md),
+                      child: SizedBox(
+                        height: 48,
+                        child: Center(
+                          child: key == '<'
+                              ? const Icon(LucideIcons.delete, size: 20)
+                              : NumericText(
+                                  key,
+                                  size: 20,
+                                  color: theme.colorScheme.onSurface,
+                                ),
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 카드 전체가 스위치다(사양서 §7.3.2).
+class _RuleCard extends StatelessWidget {
+  const _RuleCard({
+    required this.config,
+    required this.enabled,
+    required this.value,
+    required this.onToggle,
+    required this.onChanged,
+  });
+
+  final RuleConfig config;
+  final bool enabled;
+  final int value;
+  final VoidCallback onToggle;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.onSurfaceVariant;
+
+    return Semantics(
+      toggled: enabled,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onToggle,
+        child: AnimatedContainer(
+          duration: TryptoMotion.colorTransition,
+          padding: const EdgeInsets.all(TryptoSpacing.lg),
+          decoration: BoxDecoration(
+            color: enabled
+                ? TryptoPalette.card
+                : TryptoPalette.secondary.withValues(alpha: 0.3),
+            borderRadius: BorderRadius.circular(TryptoRadius.xl),
+            border: Border.all(
+              color: enabled
+                  ? theme.colorScheme.primary.withValues(alpha: 0.5)
+                  : Colors.transparent,
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          config.label,
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            color: enabled
+                                ? theme.colorScheme.onSurface
+                                : muted,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          config.description,
+                          style: theme.textTheme.labelMedium?.copyWith(
+                            color: muted,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Switch(value: enabled, onChanged: (_) => onToggle()),
+                ],
+              ),
+              if (enabled) ...[
+                const SizedBox(height: TryptoSpacing.md),
+                if (config.input == RuleInputKind.slider)
+                  _SliderInput(
+                    config: config,
+                    value: value,
+                    onChanged: onChanged,
+                  )
+                else
+                  _StepperInput(
+                    config: config,
+                    value: value,
+                    onChanged: onChanged,
+                  ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SliderInput extends StatelessWidget {
+  const _SliderInput({
+    required this.config,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final RuleConfig config;
+  final int value;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Slider(
+            value: value.toDouble(),
+            min: config.min.toDouble(),
+            max: config.max.toDouble(),
+            divisions: config.max - config.min,
+            onChanged: (next) => onChanged(next.round()),
+          ),
+        ),
+        SizedBox(
+          width: 64,
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: NumericText('$value${config.unit}', size: 16),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StepperInput extends StatelessWidget {
+  const _StepperInput({
+    required this.config,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final RuleConfig config;
+  final int value;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text('${config.min} ~ ${config.max}${config.unit}'),
+        Row(
+          children: [
+            IconButton.outlined(
+              icon: const Icon(LucideIcons.minus, size: 16),
+              onPressed: value > config.min ? () => onChanged(value - 1) : null,
+            ),
+            SizedBox(
+              width: 72,
+              child: Center(
+                child: NumericText('$value${config.unit}', size: 16),
+              ),
+            ),
+            IconButton.outlined(
+              icon: const Icon(LucideIcons.plus, size: 16),
+              onPressed: value < config.max ? () => onChanged(value + 1) : null,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _Cta extends StatelessWidget {
+  const _Cta({
+    required this.label,
+    required this.busy,
+    required this.onPressed,
+    this.icon,
+    this.hint,
+  });
+
+  final String label;
+  final bool busy;
+  final VoidCallback? onPressed;
+  final IconData? icon;
+  final String? hint;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(TryptoSpacing.screen),
+      decoration: const BoxDecoration(
+        color: TryptoPalette.background,
+        border: Border(top: BorderSide(color: TryptoPalette.border)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (hint != null) ...[
+            Text(
+              hint!,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.sm),
+          ],
+          SizedBox(
+            width: double.infinity,
+            height: 48,
+            child: FilledButton(
+              onPressed: busy ? null : onPressed,
+              child: busy
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        if (icon != null) ...[
+                          Icon(icon, size: 16),
+                          const SizedBox(width: TryptoSpacing.sm),
+                        ],
+                        Text(label),
+                      ],
+                    ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/features/round/round_end_sheet.dart
+++ b/mobile/lib/features/round/round_end_sheet.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../core/router/guard.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/app_snackbar.dart';
+import 'round_controller.dart';
+
+/// 확인은 **하단 시트 + 파괴적 액션**, 완료 안내는 **다이얼로그**다(사양서 §7.4.3).
+///
+/// 종료하면 지갑이 사라지므로 포트폴리오·입출금·복기가 전부 빈 상태가 된다. 웹은 실패해도
+/// 아무 표시가 없다(R9) — 여기서는 스낵바로 알린다.
+Future<void> confirmEndRound(BuildContext context, WidgetRef ref) async {
+  final confirmed = await showModalBottomSheet<bool>(
+    context: context,
+    useSafeArea: true,
+    builder: (context) => const _EndRoundSheet(),
+  );
+  if (confirmed != true || !context.mounted) return;
+
+  final error = await ref.read(roundControllerProvider.notifier).endRound();
+  if (!context.mounted) return;
+  if (error != null) {
+    showAppSnackbar(context, error, isError: true);
+    return;
+  }
+
+  await showDialog<void>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('라운드를 종료했습니다'),
+      content: const Text('투자 복기에서 이번 라운드를 돌아볼 수 있습니다.\n새 라운드는 언제든 다시 시작할 수 있습니다.'),
+      actions: [
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('확인'),
+        ),
+      ],
+    ),
+  );
+  if (!context.mounted) return;
+  context.go(Routes.market);
+}
+
+class _EndRoundSheet extends StatelessWidget {
+  const _EndRoundSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          TryptoSpacing.screen,
+          0,
+          TryptoSpacing.screen,
+          TryptoSpacing.screen,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(LucideIcons.triangleAlert, size: 18, color: colors.negative),
+                const SizedBox(width: TryptoSpacing.sm),
+                Text('라운드를 종료할까요?', style: theme.textTheme.titleLarge),
+              ],
+            ),
+            const SizedBox(height: TryptoSpacing.md),
+            Text(
+              '종료하면 보유 코인과 잔고가 정산되고 더 이상 거래할 수 없습니다.\n'
+              '이번 라운드의 기록은 투자 복기에 남습니다.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.xl),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                style: TryptoButtons.destructive,
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('라운드 종료'),
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.sm),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('취소'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/round/round_rules.dart
+++ b/mobile/lib/features/round/round_rules.dart
@@ -1,0 +1,180 @@
+import '../../core/constants/exchanges.dart';
+import '../../models/enums.dart';
+import '../../models/round.dart';
+
+/// 라운드 생성의 입력 규칙 전량. 위젯 없이 테스트한다 — 웹은 이 검증을 전혀 하지 않아
+/// 제출 시점에 400·500 으로 실패한다(사양서 R8, §7.3.1).
+
+enum RuleInputKind { slider, stepper }
+
+/// 사양서 §7.3.2 의 규칙 표 그대로. 생성 화면에서 고를 수 있는 것은 서버에 위반 판정 로직이
+/// 있는 3종뿐이다(`LOSS_CUT`·`PROFIT_TAKE` 은 `check()` 가 항상 비어 있다).
+class RuleConfig {
+  const RuleConfig({
+    required this.ruleType,
+    required this.label,
+    required this.description,
+    required this.defaultValue,
+    required this.min,
+    required this.max,
+    required this.unit,
+    required this.input,
+  });
+
+  final RuleType ruleType;
+  final String label;
+  final String description;
+  final int defaultValue;
+  final int min;
+  final int max;
+  final String unit;
+  final RuleInputKind input;
+
+  int clamp(int value) {
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+  }
+}
+
+const List<RuleConfig> ruleConfigs = [
+  RuleConfig(
+    ruleType: RuleType.chaseBuyBan,
+    label: '추격 매수 금지',
+    description: '급등 코인 매수를 방지',
+    defaultValue: 15,
+    min: 1,
+    max: 50,
+    unit: '%',
+    input: RuleInputKind.slider,
+  ),
+  RuleConfig(
+    ruleType: RuleType.averagingDownLimit,
+    label: '물타기 제한',
+    description: '손실 중인 코인의 추가 매수 횟수 제한',
+    defaultValue: 3,
+    min: 1,
+    max: 10,
+    unit: '회',
+    input: RuleInputKind.stepper,
+  ),
+  RuleConfig(
+    ruleType: RuleType.overtradingLimit,
+    label: '과매매 제한',
+    description: '하루 거래 횟수 제한',
+    defaultValue: 10,
+    min: 1,
+    max: 50,
+    unit: '회/일',
+    input: RuleInputKind.stepper,
+  ),
+];
+
+/// 표시 계층은 5종을 전부 처리해야 한다 — 과거 라운드가 손절·익절을 갖고 있을 수 있다(§7.3.2).
+const Map<RuleType, String> ruleLabels = {
+  RuleType.lossCut: '손절',
+  RuleType.profitTake: '익절',
+  RuleType.chaseBuyBan: '추격 매수 금지',
+  RuleType.averagingDownLimit: '물타기 제한',
+  RuleType.overtradingLimit: '과매매 제한',
+  RuleType.unknown: '알 수 없는 원칙',
+};
+
+const Map<RuleType, String> ruleUnits = {
+  RuleType.lossCut: '%',
+  RuleType.profitTake: '%',
+  RuleType.chaseBuyBan: '%',
+  RuleType.averagingDownLimit: '회',
+  RuleType.overtradingLimit: '회/일',
+  RuleType.unknown: '',
+};
+
+/// 서버 `SeedAmountPolicy`(사양서 §1.6.4). 0 은 '배정 안 함' 이라 범위 검사를 건너뛴다.
+abstract final class SeedPolicy {
+  static const int domesticMin = 1000000;
+  static const int domesticMax = 50000000;
+  static const int foreignMin = 100;
+  static const int foreignMax = 50000;
+
+  /// 시드머니를 몰아 주는 지갑. 웹과 같이 업비트에 전액, 나머지 거래소에 0 을 보낸다(§7.3.3).
+  static const int seedExchangeId = ExchangeIds.upbit;
+
+  static bool isDomestic(int exchangeId) =>
+      ExchangeIds.byId(exchangeId)?.baseCurrency != 'USDT';
+
+  static String? validate(int exchangeId, int amount) {
+    if (amount < 0) return '시드머니는 0 이상이어야 합니다.';
+    if (amount == 0) return null;
+    if (isDomestic(exchangeId)) {
+      if (amount < domesticMin || amount > domesticMax) {
+        return '시드머니는 100만원 이상 5,000만원 이하여야 합니다.';
+      }
+      return null;
+    }
+    if (amount < foreignMin || amount > foreignMax) {
+      return '시드머니는 100 USDT 이상 50,000 USDT 이하여야 합니다.';
+    }
+    return null;
+  }
+}
+
+/// 서버 `EmergencyFundingAllowance`(§1.6.4). 상한 초과는 400 `INVALID_EMERGENCY_FUNDING_LIMIT` 다.
+abstract final class EmergencyFundingPolicy {
+  static const int maxLimit = 1000000;
+  static const int chargeCount = 3;
+
+  static String? validate(int limit) {
+    if (limit <= 0) return '긴급 자금 상한을 입력해 주세요.';
+    if (limit > maxLimit) return '긴급 자금 상한은 100만원입니다.';
+    return null;
+  }
+}
+
+/// 라운드 생성 화면의 입력값. [rules] 가 `Map` 이므로 같은 `ruleType` 이 두 번 실릴 수
+/// **구조적으로** 없다 — 중복을 보내면 서버가 400 이 아니라 500 을 낸다(R8-2).
+class RoundDraft {
+  const RoundDraft({
+    required this.seed,
+    required this.emergencyLimit,
+    required this.rules,
+  });
+
+  final int seed;
+  final int emergencyLimit;
+  final Map<RuleType, int> rules;
+
+  String? get seedError {
+    if (seed <= 0) return '시드머니를 입력해 주세요.';
+    return SeedPolicy.validate(SeedPolicy.seedExchangeId, seed);
+  }
+
+  String? get emergencyError => EmergencyFundingPolicy.validate(emergencyLimit);
+
+  String? get rulesError =>
+      rules.isEmpty ? '최소 1개 이상의 원칙을 활성화해 주세요.' : null;
+
+  bool get canSubmit =>
+      seedError == null && emergencyError == null && rulesError == null;
+
+  StartRoundRequest toRequest() {
+    return StartRoundRequest(
+      seeds: [
+        for (final exchange in ExchangeIds.all)
+          SeedRequest(
+            exchangeId: exchange.id,
+            amount: exchange.id == SeedPolicy.seedExchangeId
+                ? seed.toDouble()
+                : 0,
+          ),
+      ],
+      emergencyFundingLimit: emergencyLimit.toDouble(),
+      rules: [
+        for (final entry in rules.entries)
+          RuleRequest(
+            ruleType: entry.key,
+            thresholdValue: entry.value.toDouble(),
+          ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/round/round_rules.dart
+++ b/mobile/lib/features/round/round_rules.dart
@@ -1,4 +1,5 @@
 import '../../core/constants/exchanges.dart';
+import '../../core/format/formatters.dart';
 import '../../models/enums.dart';
 import '../../models/round.dart';
 
@@ -128,6 +129,22 @@ abstract final class EmergencyFundingPolicy {
     if (limit > maxLimit) return '긴급 자금 상한은 100만원입니다.';
     return null;
   }
+
+  /// 투입 금액 검증 — `0 < amount <= limit`(§4.5). **입력 단계에서** 막는다. 웹은 제출 시점에
+  /// `INVALID_EMERGENCY_FUNDING_AMOUNT` 를 받고도 화면에 아무 표시를 하지 않는다.
+  static String? validateCharge(int amount, int limit) {
+    if (limit <= 0) return '이 라운드는 긴급 자금을 쓸 수 없습니다.';
+    if (amount <= 0) return '투입 금액을 입력해 주세요.';
+    if (amount > limit) {
+      return '상한을 초과했습니다. ${formatGrouped(limit)}원 이하로 입력해주세요.';
+    }
+    return null;
+  }
+
+  /// 프리셋은 상한의 25% / 50% / 100% 이며 각각 내림한다(§4.5).
+  static List<int> presets(int limit) => [
+    for (final ratio in [25, 50, 100]) limit * ratio ~/ 100,
+  ];
 }
 
 /// 라운드 생성 화면의 입력값. [rules] 가 `Map` 이므로 같은 `ruleType` 이 두 번 실릴 수

--- a/mobile/lib/features/wallet/asset_detail_sheet.dart
+++ b/mobile/lib/features/wallet/asset_detail_sheet.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../core/constants/exchanges.dart';
+import '../../core/format/formatters.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/app_snackbar.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../core/widgets/profit_badge.dart';
+import '../../models/transfer.dart';
+import 'transfer_history_page.dart';
+import 'transfer_wizard/step1_destination.dart';
+import 'transfer_wizard/transfer_draft.dart';
+import 'wallet_assets.dart';
+
+/// 자산 카드 탭 → 상세. 송금이 성공하면 그 결과를 돌려주고 닫힌다(지갑 화면이 재조회한다).
+Future<TransferOutcome?> showAssetDetailSheet(
+  BuildContext context, {
+  required WalletAsset asset,
+  required Exchange exchange,
+  required int walletId,
+  required List<TransferDestination> destinations,
+  required List<TransferHistoryItem> transfers,
+}) {
+  return showModalBottomSheet<TransferOutcome>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    builder: (context) => AssetDetailSheet(
+      asset: asset,
+      exchange: exchange,
+      walletId: walletId,
+      destinations: destinations,
+      transfers: transfers,
+    ),
+  );
+}
+
+class AssetDetailSheet extends StatelessWidget {
+  const AssetDetailSheet({
+    super.key,
+    required this.asset,
+    required this.exchange,
+    required this.walletId,
+    required this.destinations,
+    required this.transfers,
+  });
+
+  final WalletAsset asset;
+  final Exchange exchange;
+  final int walletId;
+  final List<TransferDestination> destinations;
+
+  /// 최근 송금 20건. 여기서 이 코인 것만 골라 보여준다 — 서버에 코인 필터가 없다.
+  final List<TransferHistoryItem> transfers;
+
+  Future<void> _withdraw(BuildContext context) async {
+    if (destinations.isEmpty) {
+      showAppSnackbar(context, '보낼 수 있는 다른 거래소 지갑이 없습니다.', isError: true);
+      return;
+    }
+
+    final outcome = await startTransfer(
+      context,
+      TransferDraft(
+        fromWalletId: walletId,
+        fromExchange: exchange,
+        coinId: asset.coinId!,
+        symbol: asset.symbol,
+        available: asset.available,
+        destinations: destinations,
+      ),
+    );
+    if (outcome != null && context.mounted) {
+      Navigator.of(context).pop(outcome);
+    }
+  }
+
+  void _openHistory(BuildContext context) {
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute<void>(
+        builder: (context) => TransferHistoryPage(
+          walletId: walletId,
+          exchangeName: exchange.name,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final base = exchange.baseCurrency;
+    final history = [
+      for (final item in transfers)
+        if (item.coinId == asset.coinId) item,
+    ];
+
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.6,
+      maxChildSize: 0.9,
+      builder: (context, controller) => ListView(
+        controller: controller,
+        padding: const EdgeInsets.fromLTRB(
+          TryptoSpacing.screen,
+          0,
+          TryptoSpacing.screen,
+          TryptoSpacing.screen,
+        ),
+        children: [
+          Row(
+            children: [
+              Text(asset.symbol, style: theme.textTheme.titleLarge),
+              const SizedBox(width: TryptoSpacing.sm),
+              Expanded(
+                child: Text(
+                  asset.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: TryptoSpacing.lg),
+          NumericText(
+            asset.isBase
+                ? formatGrouped(asset.total)
+                : formatQuantity(asset.total),
+            size: 24,
+            weight: FontWeight.w700,
+          ),
+          if (!asset.isBase) ...[
+            const SizedBox(height: TryptoSpacing.xs),
+            NumericText(
+              formatFiatEstimate(asset.totalValue, base),
+              size: 13,
+              weight: FontWeight.w500,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ],
+          const SizedBox(height: TryptoSpacing.lg),
+          // 출금은 코인만 가능하다. 기준통화(KRW/USDT)는 송금할 수 없고, 입금 버튼은 웹에도
+          // 서버에도 없다(사양서 §5.2.5).
+          if (!asset.isBase)
+            SizedBox(
+              width: double.infinity,
+              height: 44,
+              child: FilledButton.icon(
+                onPressed: asset.available > 0
+                    ? () => _withdraw(context)
+                    : null,
+                icon: const Icon(LucideIcons.arrowUpRight, size: 16),
+                label: const Text('출금'),
+              ),
+            ),
+          const SizedBox(height: TryptoSpacing.xl),
+          Text('잔고 상세', style: theme.textTheme.titleMedium),
+          const SizedBox(height: TryptoSpacing.sm),
+          _BalanceRow(
+            label: '사용 가능',
+            value: asset.isBase
+                ? formatGrouped(asset.available)
+                : formatQuantity(asset.available),
+          ),
+          _BalanceRow(
+            label: '잠금',
+            value: asset.locked > 0
+                ? (asset.isBase
+                      ? formatGrouped(asset.locked)
+                      : formatQuantity(asset.locked))
+                : '—',
+            locked: asset.locked > 0,
+          ),
+          const SizedBox(height: TryptoSpacing.xl),
+          Row(
+            children: [
+              Text('입출금 내역', style: theme.textTheme.titleMedium),
+              const Spacer(),
+              TextButton(
+                style: TryptoButtons.link,
+                onPressed: () => _openHistory(context),
+                child: const Text('전체 보기'),
+              ),
+            ],
+          ),
+          if (history.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: TryptoSpacing.lg),
+              child: Text(
+                '최근 입출금 내역이 없습니다.',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            )
+          else
+            for (final item in history) TransferTile(item: item),
+        ],
+      ),
+    );
+  }
+}
+
+class _BalanceRow extends StatelessWidget {
+  const _BalanceRow({
+    required this.label,
+    required this.value,
+    this.locked = false,
+  });
+
+  final String label;
+  final String value;
+  final bool locked;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: TryptoSpacing.xs),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              label,
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          if (locked) ...[
+            const WarningBadge(label: '주문 대기', icon: LucideIcons.lock),
+            const SizedBox(width: TryptoSpacing.sm),
+          ],
+          NumericText(
+            value,
+            size: 13,
+            weight: FontWeight.w600,
+            color: locked ? context.tryptoColors.warning : null,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/wallet/transfer_history_page.dart
+++ b/mobile/lib/features/wallet/transfer_history_page.dart
@@ -1,0 +1,376 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../core/api/api_exception.dart';
+import '../../core/format/formatters.dart';
+import '../../core/format/server_time.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/app_snackbar.dart';
+import '../../core/widgets/empty_view.dart';
+import '../../core/widgets/exchange_segment.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../core/widgets/profit_badge.dart';
+import '../../models/cursor_page.dart';
+import '../../models/enums.dart';
+import '../../models/transfer.dart';
+import 'transfer_repository.dart';
+
+const int _kPageSize = 20;
+
+/// 전체 송금 내역. 웹은 코인을 선택해야만 내역을 볼 수 있어 접근성이 나빴다(사양서 §5.4.5).
+///
+/// 웹의 결함 셋을 여기서 걷어낸다.
+/// - 거래소 필터를 두지 않는다. 내역은 이미 `walletId` 로 조회되며, 웹의 필터는 항상
+///   공집합이 되는 결함이었다(R9-1).
+/// - 유형 필터는 클라이언트가 아니라 **서버 파라미터 `type`** 으로 넘긴다.
+/// - 상태 필터를 두지 않는다. 서버 `TransferStatus` 는 `SUCCESS` 단일값이다(R9-2).
+class TransferHistoryPage extends ConsumerStatefulWidget {
+  const TransferHistoryPage({
+    super.key,
+    required this.walletId,
+    required this.exchangeName,
+  });
+
+  final int walletId;
+  final String exchangeName;
+
+  @override
+  ConsumerState<TransferHistoryPage> createState() =>
+      _TransferHistoryPageState();
+}
+
+class _TransferHistoryPageState extends ConsumerState<TransferHistoryPage> {
+  final ScrollController _scroll = ScrollController();
+
+  TransferType _type = TransferType.all;
+  List<TransferHistoryItem> _items = [];
+  int? _cursor;
+  bool _hasNext = false;
+  bool _loading = true;
+  bool _loadingMore = false;
+  String? _error;
+  int _generation = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _scroll.addListener(_onScroll);
+    _reload();
+  }
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!_scroll.hasClients || !_hasNext || _loadingMore || _loading) return;
+    if (_scroll.position.pixels < _scroll.position.maxScrollExtent - 200) return;
+    _loadMore();
+  }
+
+  /// 커서 이름은 **`cursorTransferId`(int)** 다. 웹은 `cursor`(문자열)를 보내 페이지네이션이
+  /// 아예 동작하지 않았다(R9-4).
+  Future<CursorPage<TransferHistoryItem>> _fetch({required int? cursor}) => ref
+      .read(transferRepositoryProvider)
+      .getTransferHistory(
+        walletId: widget.walletId,
+        type: _type == TransferType.all ? null : _type,
+        cursorTransferId: cursor,
+        size: _kPageSize,
+      );
+
+  Future<void> _reload() async {
+    final generation = ++_generation;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final page = await _fetch(cursor: null);
+      if (!mounted || generation != _generation) return;
+      setState(() {
+        _items = page.content;
+        _cursor = page.nextCursor;
+        _hasNext = page.hasNext;
+        _loading = false;
+      });
+    } on ApiException catch (error) {
+      if (!mounted || generation != _generation) return;
+      setState(() {
+        _items = [];
+        _hasNext = false;
+        _error = error.userMessage;
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _loadMore() async {
+    final generation = _generation;
+    setState(() => _loadingMore = true);
+    try {
+      final page = await _fetch(cursor: _cursor);
+      if (!mounted || generation != _generation) return;
+      setState(() {
+        _items = [..._items, ...page.content];
+        _cursor = page.nextCursor;
+        _hasNext = page.hasNext;
+        _loadingMore = false;
+      });
+    } on ApiException catch (error) {
+      if (!mounted || generation != _generation) return;
+      setState(() => _loadingMore = false);
+      showAppSnackbar(context, error.userMessage, isError: true);
+    }
+  }
+
+  void _setType(TransferType type) {
+    if (_type == type) return;
+    setState(() => _type = type);
+    _reload();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('${widget.exchangeName} 입출금 내역')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(TryptoSpacing.screen),
+            child: ExchangeSegment<TransferType>(
+              items: const [
+                SegmentItem(TransferType.all, '전체'),
+                SegmentItem(TransferType.deposit, '입금'),
+                SegmentItem(TransferType.withdraw, '출금'),
+              ],
+              value: _type,
+              onChanged: _setType,
+            ),
+          ),
+          Expanded(child: _body()),
+        ],
+      ),
+    );
+  }
+
+  Widget _body() {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+
+    final error = _error;
+    if (error != null) {
+      return EmptyView(
+        icon: LucideIcons.circleAlert,
+        message: error,
+        action: OutlinedButton(onPressed: _reload, child: const Text('다시 시도')),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _reload,
+      child: _items.isEmpty
+          ? ListView(
+              children: const [
+                SizedBox(height: 80),
+                EmptyView(
+                  icon: LucideIcons.arrowLeftRight,
+                  message: '입출금 내역이 없습니다.',
+                ),
+              ],
+            )
+          : ListView.builder(
+              controller: _scroll,
+              itemCount: _items.length + (_hasNext ? 1 : 0),
+              itemBuilder: (context, index) {
+                if (index == _items.length) {
+                  return const Padding(
+                    padding: EdgeInsets.all(TryptoSpacing.lg),
+                    child: Center(
+                      child: SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    ),
+                  );
+                }
+                return TransferTile(item: _items[index]);
+              },
+            ),
+    );
+  }
+}
+
+/// 송금 내역 한 줄. 전체 내역 화면과 자산 상세 시트가 같은 줄을 쓴다.
+class TransferTile extends StatelessWidget {
+  const TransferTile({super.key, required this.item});
+
+  final TransferHistoryItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = context.tryptoColors;
+    final deposit = item.type == TransferType.deposit;
+    final color = deposit ? colors.positive : colors.negative;
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(
+        horizontal: TryptoSpacing.screen,
+        vertical: TryptoSpacing.xs,
+      ),
+      leading: Container(
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.12),
+          shape: BoxShape.circle,
+        ),
+        child: Icon(
+          deposit ? LucideIcons.arrowDownLeft : LucideIcons.arrowUpRight,
+          size: 16,
+          color: color,
+        ),
+      ),
+      title: NumericText(
+        '${formatQuantity(item.amount)} ${item.coinSymbol}',
+        size: 14,
+        weight: FontWeight.w600,
+      ),
+      subtitle: Text(
+        '${deposit ? '입금' : '출금'} · '
+        '${ServerTime.formatDateTime(item.createdAt)}',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+      trailing: TransferStatusBadge(status: item.status),
+      onTap: () => _showDetail(context, item),
+    );
+  }
+}
+
+/// 서버 상태는 `SUCCESS` 단일값이다. 웹이 가정한 6종(대기·처리중·반환·지연…)은 존재하지
+/// 않으며, 그 매핑은 전부 `undefined` 로 떨어졌다(사양서 §5.2.8-2).
+class TransferStatusBadge extends StatelessWidget {
+  const TransferStatusBadge({super.key, required this.status});
+
+  final TransferStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.tryptoColors;
+    if (status != TransferStatus.success) {
+      return const WarningBadge(label: '확인 필요');
+    }
+    return TryptoBadge(
+      label: '완료',
+      foreground: colors.positive,
+      background: colors.positive.withValues(alpha: 0.15),
+    );
+  }
+}
+
+Future<void> _showDetail(BuildContext context, TransferHistoryItem item) {
+  return showModalBottomSheet<void>(
+    context: context,
+    useSafeArea: true,
+    builder: (context) => _TransferDetailSheet(item: item),
+  );
+}
+
+class _TransferDetailSheet extends StatelessWidget {
+  const _TransferDetailSheet({required this.item});
+
+  final TransferHistoryItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final deposit = item.type == TransferType.deposit;
+    final completedAt = item.completedAt;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          TryptoSpacing.screen,
+          0,
+          TryptoSpacing.screen,
+          TryptoSpacing.screen,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(
+                  '${item.coinSymbol} ${deposit ? '입금' : '출금'} 상세',
+                  style: theme.textTheme.titleLarge,
+                ),
+                const Spacer(),
+                TransferStatusBadge(status: item.status),
+              ],
+            ),
+            const SizedBox(height: TryptoSpacing.lg),
+            _DetailRow(
+              label: '수량',
+              value: '${formatQuantity(item.amount)} ${item.coinSymbol}',
+            ),
+            _DetailRow(
+              label: '요청 시각',
+              value: ServerTime.formatDateTime(item.createdAt),
+            ),
+            // 송금은 동기·즉시 완료라 completedAt == createdAt 이다.
+            if (completedAt != null)
+              _DetailRow(
+                label: '완료 시각',
+                value: ServerTime.formatDateTime(completedAt),
+              ),
+            const SizedBox(height: TryptoSpacing.sm),
+            // 응답에 상대 지갑 정보가 없다. 웹은 빈 칸을 그려 놓았다(사양서 §5.2.8-5).
+            Text(
+              '상대 거래소 정보는 서버 응답에 포함되지 않습니다.',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: TryptoSpacing.xs),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              label,
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          NumericText(value, size: 13, weight: FontWeight.w600),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/wallet/transfer_wizard/step1_destination.dart
+++ b/mobile/lib/features/wallet/transfer_wizard/step1_destination.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../../core/format/formatters.dart';
+import '../../../core/theme/theme.dart';
+import '../../../core/widgets/numeric_text.dart';
+import 'step2_amount.dart';
+import 'transfer_draft.dart';
+
+/// 웹의 단일 모달을 전체 화면 3단계 마법사로 바꾼다(사양서 §5.4.4) — 모바일에서는 숫자
+/// 키패드가 화면 절반을 덮어 모달 안에 셀렉트·입력·오류·버튼을 함께 두면 조작할 수 없다.
+///
+/// 후보가 하나면 1단계를 건너뛰고 자동 선택한다.
+Future<TransferOutcome?> startTransfer(
+  BuildContext context,
+  TransferDraft draft,
+) {
+  if (draft.destinations.isEmpty) return Future.value();
+
+  final navigator = Navigator.of(context, rootNavigator: true);
+  if (draft.destinations.length == 1) {
+    return navigator.push<TransferOutcome>(
+      MaterialPageRoute(
+        builder: (context) => TransferAmountPage(
+          draft: draft,
+          destination: draft.destinations.single,
+        ),
+      ),
+    );
+  }
+  return navigator.push<TransferOutcome>(
+    MaterialPageRoute(builder: (context) => TransferDestinationPage(draft: draft)),
+  );
+}
+
+class TransferDestinationPage extends StatelessWidget {
+  const TransferDestinationPage({super.key, required this.draft});
+
+  final TransferDraft draft;
+
+  Future<void> _select(
+    BuildContext context,
+    TransferDestination destination,
+  ) async {
+    final outcome = await Navigator.of(context).push<TransferOutcome>(
+      MaterialPageRoute(
+        builder: (context) =>
+            TransferAmountPage(draft: draft, destination: destination),
+      ),
+    );
+    // 성공은 마법사 밖(자산 상세 시트)까지 그대로 올려 보낸다.
+    if (outcome != null && context.mounted) Navigator.of(context).pop(outcome);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: Text('${draft.symbol} 출금')),
+      body: ListView(
+        padding: const EdgeInsets.all(TryptoSpacing.screen),
+        children: [
+          Text('도착 거래소', style: theme.textTheme.titleMedium),
+          const SizedBox(height: TryptoSpacing.xs),
+          Text(
+            '${draft.fromExchange.name}에서 보낼 거래소를 고르세요. '
+            '가용 ${formatQuantity(draft.available)} ${draft.symbol}',
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: TryptoSpacing.lg),
+          for (final destination in draft.destinations) ...[
+            Card(
+              child: ListTile(
+                title: Text(
+                  destination.exchange.name,
+                  style: theme.textTheme.titleMedium,
+                ),
+                subtitle: Text(
+                  '${destination.exchange.baseCurrency} 마켓',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                trailing: const Icon(LucideIcons.chevronRight, size: 16),
+                onTap: () => _select(context, destination),
+              ),
+            ),
+            const SizedBox(height: TryptoSpacing.sm),
+          ],
+          const SizedBox(height: TryptoSpacing.sm),
+          Row(
+            children: [
+              Icon(
+                LucideIcons.info,
+                size: 14,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: TryptoSpacing.xs),
+              Expanded(
+                child: Text(
+                  '같은 라운드의 다른 거래소 지갑으로만 보낼 수 있습니다.',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 마법사 상단의 진행 표시. 3단계 중 어디인지 한 줄로 알린다.
+class TransferStepHeader extends StatelessWidget {
+  const TransferStepHeader({
+    super.key,
+    required this.step,
+    required this.title,
+    required this.description,
+  });
+
+  final int step;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        NumericText(
+          '$step / 3',
+          size: 11,
+          weight: FontWeight.w500,
+          color: theme.colorScheme.primary,
+        ),
+        const SizedBox(height: TryptoSpacing.xs),
+        Text(title, style: theme.textTheme.titleLarge),
+        const SizedBox(height: TryptoSpacing.xs),
+        Text(
+          description,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/wallet/transfer_wizard/step2_amount.dart
+++ b/mobile/lib/features/wallet/transfer_wizard/step2_amount.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../core/format/formatters.dart';
+import '../../../core/theme/theme.dart';
+import 'step1_destination.dart';
+import 'step3_confirm.dart';
+import 'transfer_draft.dart';
+
+/// 소수점 하나까지만 허용한다. 서버 수량은 소수 8자리다.
+final RegExp _kAmountPattern = RegExp(r'^\d*\.?\d*$');
+
+class TransferAmountPage extends StatefulWidget {
+  const TransferAmountPage({
+    super.key,
+    required this.draft,
+    required this.destination,
+  });
+
+  final TransferDraft draft;
+  final TransferDestination destination;
+
+  @override
+  State<TransferAmountPage> createState() => _TransferAmountPageState();
+}
+
+class _TransferAmountPageState extends State<TransferAmountPage> {
+  final TextEditingController _input = TextEditingController();
+
+  /// **2단계 진입 시 1회 생성해 화면 상태에 보관한다**(사양서 §5.4.4). 재시도할 때 키를 다시
+  /// 만들면 멱등성이 깨져 같은 송금이 두 번 실행될 수 있다. UUID v4 가 아니면 서버가 500 을
+  /// 낸다(R8-1).
+  final String _idempotencyKey = const Uuid().v4();
+
+  String _amount = '';
+
+  @override
+  void dispose() {
+    _input.dispose();
+    super.dispose();
+  }
+
+  void _setRatio(double ratio) {
+    final text = transferAmountOfRatio(widget.draft.available, ratio);
+    _input.value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+    setState(() => _amount = text);
+  }
+
+  Future<void> _next() async {
+    final amount = parseTransferAmount(_amount);
+    if (amount == null) return;
+
+    final outcome = await Navigator.of(context).push<TransferOutcome>(
+      MaterialPageRoute(
+        builder: (context) => TransferConfirmPage(
+          draft: widget.draft,
+          destination: widget.destination,
+          amount: amount,
+          idempotencyKey: _idempotencyKey,
+        ),
+      ),
+    );
+    if (outcome != null && mounted) Navigator.of(context).pop(outcome);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final draft = widget.draft;
+    final error = validateTransferAmount(_amount, draft.available);
+
+    return Scaffold(
+      appBar: AppBar(title: Text('${draft.symbol} 출금')),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.all(TryptoSpacing.screen),
+                children: [
+                  TransferStepHeader(
+                    step: 2,
+                    title: '출금 수량',
+                    description:
+                        '${draft.fromExchange.name} → '
+                        '${widget.destination.exchange.name}',
+                  ),
+                  const SizedBox(height: TryptoSpacing.xl),
+                  TextField(
+                    controller: _input,
+                    autofocus: true,
+                    textAlign: TextAlign.right,
+                    keyboardType: const TextInputType.numberWithOptions(
+                      decimal: true,
+                    ),
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(_kAmountPattern),
+                    ],
+                    style: TryptoText.numeric(size: 24, weight: FontWeight.w700),
+                    onChanged: (text) => setState(() => _amount = text),
+                    decoration: InputDecoration(
+                      hintText: '0',
+                      suffixText: draft.symbol,
+                    ),
+                  ),
+                  const SizedBox(height: TryptoSpacing.sm),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          '가용 ${formatQuantity(draft.available)} ${draft.symbol}',
+                          style: theme.textTheme.labelMedium?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                      // 입력 즉시 검증한다. 빈 입력에서는 오류를 띄우지 않는다.
+                      if (_amount.isNotEmpty && error != null)
+                        Text(
+                          error,
+                          style: theme.textTheme.labelMedium?.copyWith(
+                            color: theme.colorScheme.error,
+                          ),
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: TryptoSpacing.lg),
+                  Row(
+                    children: [
+                      for (final (label, ratio) in const [
+                        ('25%', 0.25),
+                        ('50%', 0.5),
+                        ('최대', 1.0),
+                      ])
+                        Expanded(
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                              right: TryptoSpacing.xs,
+                            ),
+                            child: OutlinedButton(
+                              onPressed: draft.available > 0
+                                  ? () => _setRatio(ratio)
+                                  : null,
+                              child: Text(label),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(TryptoSpacing.screen),
+              child: SizedBox(
+                width: double.infinity,
+                height: 48,
+                child: FilledButton(
+                  onPressed: error == null ? _next : null,
+                  child: const Text('다음'),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/wallet/transfer_wizard/step3_confirm.dart
+++ b/mobile/lib/features/wallet/transfer_wizard/step3_confirm.dart
@@ -1,0 +1,244 @@
+import 'package:decimal/decimal.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../../core/api/api_exception.dart';
+import '../../../core/format/formatters.dart';
+import '../../../core/json/decimal_x.dart';
+import '../../../core/theme/theme.dart';
+import '../../../core/widgets/app_snackbar.dart';
+import '../../../core/widgets/numeric_text.dart';
+import '../../../models/transfer.dart';
+import '../transfer_repository.dart';
+import 'step1_destination.dart';
+import 'transfer_draft.dart';
+
+/// 웹에 없는 단계다(사양서 §5.4.4). 모의투자라도 실전 리허설이 제품 목적이므로 확인 단계를
+/// 둔다 — 출발·도착·수량·출금 후 남는 잔고를 한 화면에서 보고 확정한다.
+class TransferConfirmPage extends ConsumerStatefulWidget {
+  const TransferConfirmPage({
+    super.key,
+    required this.draft,
+    required this.destination,
+    required this.amount,
+    required this.idempotencyKey,
+  });
+
+  final TransferDraft draft;
+  final TransferDestination destination;
+  final Decimal amount;
+
+  /// 2단계에서 만든 키를 그대로 받는다. 실패 후 다시 누를 때도 같은 키를 보낸다.
+  final String idempotencyKey;
+
+  @override
+  ConsumerState<TransferConfirmPage> createState() =>
+      _TransferConfirmPageState();
+}
+
+class _TransferConfirmPageState extends ConsumerState<TransferConfirmPage> {
+  bool _submitting = false;
+
+  Future<void> _submit() async {
+    if (_submitting) return;
+    setState(() => _submitting = true);
+
+    final draft = widget.draft;
+    try {
+      final response = await ref
+          .read(transferRepositoryProvider)
+          .transfer(
+            TransferCoinRequest(
+              idempotencyKey: widget.idempotencyKey,
+              fromWalletId: draft.fromWalletId,
+              toWalletId: widget.destination.walletId,
+              coinId: draft.coinId,
+              amount: widget.amount.toDouble(),
+            ),
+          );
+      if (!mounted) return;
+      Navigator.of(context).pop(
+        TransferOutcome(
+          transferId: response.transferId,
+          amount: widget.amount.toDouble(),
+          symbol: draft.symbol,
+        ),
+      );
+    } on ApiException catch (error) {
+      if (!mounted) return;
+      setState(() => _submitting = false);
+      // 웹은 서버 메시지를 버리고 "송금에 실패했습니다." 한 줄만 붉게 띄운다(R9).
+      showAppSnackbar(context, transferErrorMessage(error), isError: true);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final draft = widget.draft;
+    final amount = widget.amount.toDouble();
+    final remaining = (draft.available.dec - widget.amount).toDouble();
+
+    return Scaffold(
+      appBar: AppBar(title: Text('${draft.symbol} 출금')),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.all(TryptoSpacing.screen),
+                children: [
+                  const TransferStepHeader(
+                    step: 3,
+                    title: '출금 확인',
+                    description: '아래 내용으로 송금합니다.',
+                  ),
+                  const SizedBox(height: TryptoSpacing.xl),
+                  Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(TryptoSpacing.lg),
+                      child: Column(
+                        children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: _Endpoint(
+                                  label: '출발',
+                                  name: draft.fromExchange.name,
+                                ),
+                              ),
+                              Icon(
+                                LucideIcons.arrowRight,
+                                size: 16,
+                                color: theme.colorScheme.primary,
+                              ),
+                              Expanded(
+                                child: _Endpoint(
+                                  label: '도착',
+                                  name: widget.destination.exchange.name,
+                                  alignEnd: true,
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: TryptoSpacing.lg),
+                          const Divider(),
+                          const SizedBox(height: TryptoSpacing.lg),
+                          _Row(
+                            label: '출금 수량',
+                            value:
+                                '${formatQuantity(amount)} ${draft.symbol}',
+                            emphasized: true,
+                          ),
+                          const SizedBox(height: TryptoSpacing.md),
+                          _Row(
+                            label: '출금 후 가용 잔고',
+                            value:
+                                '${formatQuantity(remaining)} ${draft.symbol}',
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: TryptoSpacing.md),
+                  Text(
+                    '* 모의투자 데이터입니다. 실제 자산이 아닙니다.',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(TryptoSpacing.screen),
+              child: SizedBox(
+                width: double.infinity,
+                height: 48,
+                child: FilledButton(
+                  onPressed: _submitting ? null : _submit,
+                  child: _submitting
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('출금하기'),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Endpoint extends StatelessWidget {
+  const _Endpoint({
+    required this.label,
+    required this.name,
+    this.alignEnd = false,
+  });
+
+  final String label;
+  final String name;
+  final bool alignEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: alignEnd
+          ? CrossAxisAlignment.end
+          : CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(name, style: theme.textTheme.titleMedium),
+      ],
+    );
+  }
+}
+
+class _Row extends StatelessWidget {
+  const _Row({
+    required this.label,
+    required this.value,
+    this.emphasized = false,
+  });
+
+  final String label;
+  final String value;
+  final bool emphasized;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            label,
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        NumericText(
+          value,
+          size: emphasized ? 18 : 14,
+          weight: emphasized ? FontWeight.w700 : FontWeight.w500,
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/wallet/transfer_wizard/transfer_draft.dart
+++ b/mobile/lib/features/wallet/transfer_wizard/transfer_draft.dart
@@ -1,0 +1,78 @@
+import 'package:decimal/decimal.dart';
+
+import '../../../core/api/api_exception.dart';
+import '../../../core/constants/exchanges.dart';
+import '../../../core/json/decimal_x.dart';
+
+/// 도착 후보. 라운드가 가진 지갑 중 현재 거래소를 제외한 전부다(사양서 §5.2.6).
+class TransferDestination {
+  const TransferDestination({required this.walletId, required this.exchange});
+
+  final int walletId;
+  final Exchange exchange;
+}
+
+/// 마법사 3단계가 공유하는 입력값. 코인만 송금할 수 있다 — 기준통화는 `coinId` 가 없다.
+class TransferDraft {
+  const TransferDraft({
+    required this.fromWalletId,
+    required this.fromExchange,
+    required this.coinId,
+    required this.symbol,
+    required this.available,
+    required this.destinations,
+  });
+
+  final int fromWalletId;
+  final Exchange fromExchange;
+
+  /// 송금 API 는 `exchangeCoinId` 가 아니라 **`coinId`** 를 받는다.
+  final int coinId;
+
+  final String symbol;
+  final double available;
+  final List<TransferDestination> destinations;
+}
+
+class TransferOutcome {
+  const TransferOutcome({
+    required this.transferId,
+    required this.amount,
+    required this.symbol,
+  });
+
+  final int transferId;
+  final double amount;
+  final String symbol;
+}
+
+Decimal? parseTransferAmount(String raw) => Decimal.tryParse(raw.trim());
+
+/// 웹은 제출을 한 번 시도한 뒤에만 오류를 보여준다(사양서 §5.2.6). 여기서는 입력 즉시 검증하고
+/// 위반이면 다음 단계 버튼을 비활성화한다.
+String? validateTransferAmount(String raw, double available) {
+  final amount = parseTransferAmount(raw);
+  if (amount == null || amount <= Decimal.zero) return '수량을 입력해 주세요.';
+  if (amount > available.dec) return '가용 잔고를 초과합니다.';
+  return null;
+}
+
+/// 비율 버튼 `[25%] [50%] [최대]` 의 입력값. 반올림이 가용 잔고를 넘기지 않도록 **내림**한다
+/// (코인 수량은 소수 8자리다). 최대는 잔고를 그대로 쓴다.
+String transferAmountOfRatio(double available, double ratio) {
+  if (ratio >= 1) return available.dec.toString();
+  return (available.dec * ratio.dec).floor(scale: 8).toString();
+}
+
+/// 송금 화면 하나만 문맥 문구를 갖는다(계획서 §4.1.4). 표에 없는 코드는 서버 메시지를 그대로
+/// 보여준다 — 이미 한국어 완성문이다.
+const Map<String, String> _kTransferErrors = {
+  'INSUFFICIENT_BALANCE': '가용 잔고가 부족합니다.',
+  'SAME_WALLET_TRANSFER': '같은 거래소로는 송금할 수 없습니다.',
+  'DIFFERENT_ROUND_TRANSFER': '다른 라운드의 지갑으로는 송금할 수 없습니다.',
+  'WALLET_NOT_OWNED': '접근 권한이 없는 지갑입니다.',
+  'WALLET_ACCESS_DENIED': '접근 권한이 없는 지갑입니다.',
+};
+
+String transferErrorMessage(ApiException error) =>
+    _kTransferErrors[error.code] ?? error.userMessage;

--- a/mobile/lib/features/wallet/wallet_assets.dart
+++ b/mobile/lib/features/wallet/wallet_assets.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/format/formatters.dart';
+import '../../core/format/hangul.dart';
+import '../../models/cursor_page.dart';
+import '../../models/transfer.dart';
+import '../../models/wallet.dart';
+import '../market/market_controller.dart';
+import 'transfer_repository.dart';
+import 'wallet_repository.dart';
+
+/// 지갑 목록의 한 행. 잔고 응답에는 심볼도 이름도 현재가도 없다 — 거래소 코인 목록과
+/// `coinId` 로 합쳐야 화면이 된다.
+class WalletAsset {
+  const WalletAsset({
+    required this.coinId,
+    required this.symbol,
+    required this.name,
+    required this.index,
+    required this.available,
+    required this.locked,
+    required this.currentPrice,
+  });
+
+  /// 기준통화 행은 `null` 이다. 기준통화는 송금할 수 없다(사양서 §5.2.5).
+  final int? coinId;
+
+  final String symbol;
+  final String name;
+  final HangulIndex index;
+  final double available;
+  final double locked;
+
+  /// 웹은 코인의 이 값을 **0 으로 고정**해 총자산·환산액·소액 제외·정렬이 전부 무의미해졌다
+  /// (사양서 R9-3). 상장 목록(`GET /api/exchanges/{id}/coins`)의 `price` 를 그대로 쓴다.
+  final double currentPrice;
+
+  bool get isBase => coinId == null;
+
+  double get total => available + locked;
+
+  double get totalValue => total * currentPrice;
+
+  bool get hasBalance => total > 0;
+}
+
+/// 잔고 + 상장 코인 전량. 잔고가 없는 코인도 0 으로 포함한다(사양서 §5.2.2-3).
+/// 기준통화가 맨 앞, 이어서 평가액 내림차순이다.
+List<WalletAsset> buildWalletAssets({
+  required WalletBalances balances,
+  required List<CoinEntry> coins,
+}) {
+  final byCoinId = {
+    for (final balance in balances.balances) balance.coinId: balance,
+  };
+  final base = balances.baseCurrencySymbol;
+  final baseName = base == 'KRW' ? '원화' : base;
+
+  final assets = [
+    for (final entry in coins)
+      WalletAsset(
+        coinId: entry.coin.coinId,
+        symbol: entry.symbol,
+        name: entry.name,
+        index: entry.index,
+        available: byCoinId[entry.coin.coinId]?.available ?? 0,
+        locked: byCoinId[entry.coin.coinId]?.locked ?? 0,
+        currentPrice: entry.price,
+      ),
+  ]..sort((a, b) {
+    final byValue = b.totalValue.compareTo(a.totalValue);
+    return byValue != 0 ? byValue : a.symbol.compareTo(b.symbol);
+  });
+
+  return [
+    WalletAsset(
+      coinId: null,
+      symbol: base,
+      name: baseName,
+      index: HangulIndex(baseName),
+      available: balances.baseCurrencyAvailable,
+      locked: balances.baseCurrencyLocked,
+      currentPrice: 1,
+    ),
+    ...assets,
+  ];
+}
+
+/// 검색(심볼·한글명) + 소액 제외(KRW 1,000 / USDT 1 미만). 기준통화 행도 같은 규칙을 받는다.
+List<WalletAsset> applyWalletFilter(
+  List<WalletAsset> assets, {
+  String query = '',
+  bool hideSmall = false,
+  required String baseCurrency,
+}) {
+  final search = HangulQuery(query);
+  final threshold = smallAmountThreshold(baseCurrency);
+
+  return [
+    for (final asset in assets)
+      if (search.matches(asset.symbol, asset.index) &&
+          (!hideSmall || asset.totalValue >= threshold))
+        asset,
+  ];
+}
+
+/// 거래소 총 자산 = Σ((사용가능 + 잠금) × 현재가). 기준통화 포함.
+double totalAssetValue(List<WalletAsset> assets) =>
+    assets.fold(0, (sum, asset) => sum + asset.totalValue);
+
+class WalletSnapshot {
+  const WalletSnapshot({
+    required this.baseCurrency,
+    required this.assets,
+    required this.recentTransfers,
+  });
+
+  final String baseCurrency;
+  final List<WalletAsset> assets;
+
+  /// 자산 상세 시트가 코인별로 걸러 쓴다. 전체 내역은 별도 화면이 커서로 읽는다.
+  final List<TransferHistoryItem> recentTransfers;
+
+  double get totalValue => totalAssetValue(assets);
+
+  WalletAsset get baseAsset => assets.first;
+}
+
+typedef WalletKey = ({int exchangeId, int walletId});
+
+/// 잔고·상장 코인·최근 송금을 한 번에 읽는다(사양서 §5.2.2). 코인 목록은 마켓 탭이 이미
+/// 받아 둔 카탈로그를 그대로 재사용한다 — 같은 거래소를 두 번 내려받지 않는다.
+final walletSnapshotProvider = FutureProvider.family<WalletSnapshot, WalletKey>(
+  (ref, key) async {
+    final results = await Future.wait<Object?>([
+      ref.watch(walletRepositoryProvider).getBalances(key.walletId),
+      ref.watch(marketCoinsProvider(key.exchangeId).future),
+      ref
+          .watch(transferRepositoryProvider)
+          .getTransferHistory(walletId: key.walletId, size: 20),
+    ]);
+
+    final balances = results[0] as WalletBalances;
+    final coins = results[1] as List<CoinEntry>;
+    final transfers = results[2] as CursorPage<TransferHistoryItem>;
+
+    return WalletSnapshot(
+      baseCurrency: balances.baseCurrencySymbol,
+      assets: buildWalletAssets(balances: balances, coins: coins),
+      recentTransfers: transfers.content,
+    );
+  },
+);

--- a/mobile/lib/features/wallet/wallet_page.dart
+++ b/mobile/lib/features/wallet/wallet_page.dart
@@ -1,19 +1,429 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
+import '../../core/constants/exchanges.dart';
+import '../../core/format/formatters.dart';
+import '../../core/router/guard.dart';
+import '../../core/theme/theme.dart';
+import '../../core/theme/trypto_colors.dart';
+import '../../core/widgets/app_snackbar.dart';
+import '../../core/widgets/async_view.dart';
 import '../../core/widgets/empty_view.dart';
+import '../../core/widgets/exchange_segment.dart';
 import '../../core/widgets/mypage_button.dart';
+import '../../core/widgets/no_round_notice.dart';
+import '../../core/widgets/numeric_text.dart';
+import '../../models/round.dart';
+import '../market/coin_search_field.dart';
+import '../round/round_controller.dart';
+import 'asset_detail_sheet.dart';
+import 'transfer_history_page.dart';
+import 'transfer_wizard/transfer_draft.dart';
+import 'wallet_assets.dart';
 
-class WalletPage extends StatelessWidget {
+const double _kAssetRowHeight = 72;
+
+/// 지갑 자산 목록과 송금. 선택 거래소는 라우트 쿼리(`/wallet?exchange=upbit`)에 둔다.
+class WalletPage extends ConsumerStatefulWidget {
   const WalletPage({super.key});
 
   @override
+  ConsumerState<WalletPage> createState() => _WalletPageState();
+}
+
+class _WalletPageState extends ConsumerState<WalletPage> {
+  final TextEditingController _search = TextEditingController();
+
+  String _query = '';
+  bool _hideSmall = false;
+  bool _hidden = false;
+
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
+  void _switchExchange(Exchange exchange) {
+    _search.clear();
+    setState(() => _query = '');
+    context.go('${Routes.wallet}?exchange=${exchange.key}');
+  }
+
+  /// 도착 후보 = 이 라운드의 지갑 중 현재 거래소를 뺀 전부(사양서 §5.2.6).
+  List<TransferDestination> _destinations(ActiveRound round, Exchange current) {
+    return [
+      for (final wallet in round.wallets)
+        if (wallet.exchangeId != current.id)
+          if (ExchangeIds.byId(wallet.exchangeId) case final exchange?)
+            TransferDestination(walletId: wallet.walletId, exchange: exchange),
+    ];
+  }
+
+  Future<void> _openAsset(
+    WalletAsset asset,
+    WalletSnapshot snapshot,
+    Exchange exchange,
+    int walletId,
+    ActiveRound round,
+  ) async {
+    final outcome = await showAssetDetailSheet(
+      context,
+      asset: asset,
+      exchange: exchange,
+      walletId: walletId,
+      destinations: _destinations(round, exchange),
+      transfers: snapshot.recentTransfers,
+    );
+    if (outcome == null || !mounted) return;
+
+    // 출발·도착 두 지갑의 잔고가 모두 바뀐다. family 전체를 무효화해 다음 조회에서 새로 읽는다.
+    ref.invalidate(walletSnapshotProvider);
+    showAppSnackbar(
+      context,
+      '${formatQuantity(outcome.amount)} ${outcome.symbol} 출금 완료',
+    );
+  }
+
+  void _openHistory(int walletId, Exchange exchange) {
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute<void>(
+        builder: (context) => TransferHistoryPage(
+          walletId: walletId,
+          exchangeName: exchange.name,
+        ),
+      ),
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final exchange = ExchangeIds.byKey(
+      GoRouterState.of(context).uri.queryParameters['exchange'],
+    );
+    final round = ref.watch(
+      roundControllerProvider.select((state) => state.activeRound),
+    );
+    final walletId = round?.walletIdOf(exchange.id);
+
     return Scaffold(
-      appBar: AppBar(title: const Text('입출금'), actions: const [MypageButton()]),
-      body: const EmptyView(
-        icon: LucideIcons.arrowLeftRight,
-        message: '지갑과 송금은 14단위에서 붙는다.',
+      appBar: AppBar(
+        title: const Text('입출금'),
+        actions: [
+          if (walletId != null)
+            IconButton(
+              icon: const Icon(LucideIcons.history),
+              tooltip: '입출금 내역',
+              onPressed: () => _openHistory(walletId, exchange),
+            ),
+          const MypageButton(),
+        ],
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              TryptoSpacing.screen,
+              TryptoSpacing.md,
+              TryptoSpacing.screen,
+              TryptoSpacing.sm,
+            ),
+            child: Column(
+              children: [
+                ExchangeSegment<int>(
+                  items: [
+                    for (final item in ExchangeIds.all)
+                      SegmentItem(item.id, item.name),
+                  ],
+                  value: exchange.id,
+                  onChanged: (id) =>
+                      _switchExchange(ExchangeIds.byId(id) ?? exchange),
+                ),
+                const SizedBox(height: TryptoSpacing.sm),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '자산 관리 · 입금/출금 내역 확인',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(child: _body(exchange, round, walletId)),
+        ],
+      ),
+    );
+  }
+
+  Widget _body(Exchange exchange, ActiveRound? round, int? walletId) {
+    if (round == null) {
+      return const NoRoundNotice(message: '진행 중인 라운드가 없어 지갑이 비어 있습니다.');
+    }
+    if (walletId == null) {
+      return EmptyView(
+        icon: LucideIcons.wallet,
+        message: '${exchange.name} 지갑이 없습니다.',
+        description: '이 라운드에서 자금을 배정하지 않은 거래소입니다.',
+      );
+    }
+
+    final key = (exchangeId: exchange.id, walletId: walletId);
+    return AsyncView<WalletSnapshot>(
+      value: ref.watch(walletSnapshotProvider(key)),
+      onRetry: () => ref.invalidate(walletSnapshotProvider(key)),
+      builder: (snapshot) {
+        final assets = applyWalletFilter(
+          snapshot.assets,
+          query: _query,
+          hideSmall: _hideSmall,
+          baseCurrency: snapshot.baseCurrency,
+        );
+
+        return Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: TryptoSpacing.screen,
+              ),
+              child: _SummaryCard(
+                snapshot: snapshot,
+                exchange: exchange,
+                hidden: _hidden,
+                onToggle: () => setState(() => _hidden = !_hidden),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                TryptoSpacing.screen,
+                TryptoSpacing.md,
+                TryptoSpacing.screen,
+                TryptoSpacing.sm,
+              ),
+              child: Column(
+                children: [
+                  CoinSearchField(
+                    controller: _search,
+                    onChanged: (query) => setState(() => _query = query),
+                  ),
+                  const SizedBox(height: TryptoSpacing.sm),
+                  Row(
+                    children: [
+                      Text('보유 자산', style: Theme.of(context).textTheme.titleMedium),
+                      const Spacer(),
+                      FilterChip(
+                        label: const Text('소액 제외'),
+                        selected: _hideSmall,
+                        onSelected: (selected) =>
+                            setState(() => _hideSmall = selected),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: RefreshIndicator(
+                onRefresh: () => ref.refresh(walletSnapshotProvider(key).future),
+                child: assets.isEmpty
+                    ? ListView(
+                        children: const [
+                          SizedBox(height: 80),
+                          EmptyView(
+                            icon: LucideIcons.search,
+                            message: '조건에 맞는 자산이 없습니다.',
+                          ),
+                        ],
+                      )
+                    : ListView.builder(
+                        // 상장 코인 전량(600여 행)이 들어온다. 자식을 측정하지 않는다.
+                        itemExtent: _kAssetRowHeight,
+                        itemCount: assets.length,
+                        itemBuilder: (context, index) => _AssetRow(
+                          asset: assets[index],
+                          baseCurrency: snapshot.baseCurrency,
+                          onTap: () => _openAsset(
+                            assets[index],
+                            snapshot,
+                            exchange,
+                            walletId,
+                            round,
+                          ),
+                        ),
+                      ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  const _SummaryCard({
+    required this.snapshot,
+    required this.exchange,
+    required this.hidden,
+    required this.onToggle,
+  });
+
+  final WalletSnapshot snapshot;
+  final Exchange exchange;
+  final bool hidden;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final base = snapshot.baseCurrency;
+    final baseAsset = snapshot.baseAsset;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(TryptoSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(
+                  '${exchange.name} 총 자산',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const Spacer(),
+                IconButton(
+                  icon: Icon(
+                    hidden ? LucideIcons.eyeOff : LucideIcons.eye,
+                    size: 16,
+                  ),
+                  tooltip: hidden ? '잔액 표시' : '잔액 숨기기',
+                  onPressed: onToggle,
+                ),
+              ],
+            ),
+            const SizedBox(height: TryptoSpacing.xs),
+            // 코인 평가액은 상장 목록의 `price` 로 계산한다. 웹은 0 고정이라 이 숫자가 사실상
+            // 기준통화 잔고였다(사양서 R9-3).
+            NumericText(
+              hidden ? '••••••••' : formatCurrency(snapshot.totalValue, base),
+              size: 26,
+              weight: FontWeight.w700,
+            ),
+            const SizedBox(height: TryptoSpacing.sm),
+            Text(
+              hidden
+                  ? '보유 $base ••••••••'
+                  : '보유 $base ${formatCurrency(baseAsset.total, base)}',
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            if (!hidden && baseAsset.locked > 0) ...[
+              const SizedBox(height: 2),
+              Text(
+                '(사용 가능 ${formatCurrency(baseAsset.available, base)} / '
+                '잠금 ${formatCurrency(baseAsset.locked, base)})',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AssetRow extends StatelessWidget {
+  const _AssetRow({
+    required this.asset,
+    required this.baseCurrency,
+    required this.onTap,
+  });
+
+  final WalletAsset asset;
+  final String baseCurrency;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    // 잔고 0 인 코인은 흐리게 그린다. 알파는 색으로만 준다(계획서 §4.2.5-8).
+    final alpha = asset.hasBalance || asset.isBase ? 1.0 : 0.4;
+    final onSurface = theme.colorScheme.onSurface.withValues(alpha: alpha);
+    final muted = theme.colorScheme.onSurfaceVariant.withValues(alpha: alpha);
+    final quantity = asset.isBase
+        ? formatGrouped(asset.total)
+        : formatQuantity(asset.total);
+
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: TryptoSpacing.screen),
+        decoration: const BoxDecoration(
+          border: Border(bottom: BorderSide(color: TryptoPalette.border)),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    asset.symbol,
+                    style: TryptoText.symbol.copyWith(color: onSurface),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    asset.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.labelSmall?.copyWith(color: muted),
+                  ),
+                ],
+              ),
+            ),
+            if (asset.locked > 0) ...[
+              Icon(
+                LucideIcons.lock,
+                size: 12,
+                color: context.tryptoColors.warning,
+              ),
+              const SizedBox(width: TryptoSpacing.xs),
+            ],
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                NumericText(
+                  asset.hasBalance ? quantity : '—',
+                  size: 14,
+                  weight: FontWeight.w600,
+                  color: onSurface,
+                ),
+                const SizedBox(height: 2),
+                NumericText(
+                  asset.isBase || !asset.hasBalance
+                      ? ''
+                      : formatFiatEstimate(asset.totalValue, baseCurrency),
+                  size: 11,
+                  weight: FontWeight.w500,
+                  color: muted,
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/models/round.dart
+++ b/mobile/lib/models/round.dart
@@ -165,6 +165,22 @@ class ActiveRound {
     }
     return null;
   }
+
+  /// 긴급 자금 충전 응답의 `remainingChargeCount` 를 들인다. 서버가 중복 요청(같은 멱등키)을
+  /// 감지하면 재차감 없이 현재 잔여 횟수를 돌려주므로 그 값을 그대로 덮어쓴다.
+  ActiveRound withEmergencyChargeCount(int count) => ActiveRound(
+    roundId: roundId,
+    userId: userId,
+    roundNumber: roundNumber,
+    status: status,
+    initialSeed: initialSeed,
+    emergencyFundingLimit: emergencyFundingLimit,
+    emergencyChargeCount: count,
+    startedAt: startedAt,
+    endedAt: endedAt,
+    rules: rules,
+    wallets: wallets,
+  );
 }
 
 /// `POST /api/rounds/{roundId}/end` — 요청 바디가 없다(서버가 읽지 않는다, R4-4).

--- a/mobile/test/candle_scale_test.dart
+++ b/mobile/test/candle_scale_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/features/market/candle_painter.dart';
+import 'package:trypto/features/market/candle_scale.dart';
+import 'package:trypto/models/candle.dart';
+import 'package:trypto/models/enums.dart';
+
+/// 스케일·히트테스트·뷰포트는 위젯 없이 고정한다(계획서 §7-6). `shouldRepaint` 게이트는
+/// 10단위 완료 조건 ③⑤의 증거다 — 실시간 봉이 화면 밖이면 repaint 가 0이다.
+void main() {
+  const padding = EdgeInsets.only(left: 20, top: 20, right: 124, bottom: 42);
+  const size = Size(960, 440);
+
+  Candle candle(int minute, double low, double high) => Candle(
+    time: DateTime(2026, 7, 15, 10, minute),
+    open: low,
+    high: high,
+    low: low,
+    close: high,
+  );
+
+  group('CandleScale', () {
+    final visible = [candle(0, 100, 200), candle(1, 120, 180)];
+    final scale = CandleScale.of(size, padding, visible);
+
+    test('플롯 영역과 슬롯 폭은 패딩을 뺀 값이다', () {
+      expect(scale.plotWidth, 816);
+      expect(scale.plotHeight, 378);
+      expect(scale.slotWidth, 408);
+      // clamp(slotWidth × 0.62, 6, 16)
+      expect(scale.candleWidth, 16);
+    });
+
+    test('가격 범위에 8% 여백을 준다', () {
+      // range = 200 - 100 = 100
+      expect(scale.paddedMin, 92);
+      expect(scale.paddedMax, 208);
+    });
+
+    test('저가가 0 이어도 paddedMin 은 음수가 되지 않는다', () {
+      final zeroed = CandleScale.of(size, padding, [candle(0, 0, 10)]);
+      expect(zeroed.paddedMin, 0);
+    });
+
+    test('모든 값이 같으면 range 는 최댓값의 2% 다', () {
+      final flat = CandleScale.of(size, padding, [candle(0, 100, 100)]);
+      expect(flat.paddedMax - flat.paddedMin, closeTo(2 * 0.08 * 2, 1e-9));
+    });
+
+    test('getX 는 슬롯 중앙이고 getY 는 위가 고가다', () {
+      expect(scale.getX(0), 20 + 0.5 * 408);
+      expect(scale.getX(1), 20 + 1.5 * 408);
+      expect(scale.getY(scale.paddedMax), 20);
+      expect(scale.getY(scale.paddedMin), 20 + 378);
+    });
+
+    test('히트 테스트 허용 오차는 slotWidth 다 — 손가락이 캔들을 가린다', () {
+      expect(scale.hitTest(scale.getX(0)), 0);
+      expect(scale.hitTest(scale.getX(1)), 1);
+      // 캔들 중심에서 candleWidth(16) 를 한참 벗어나도 같은 슬롯이면 잡힌다.
+      expect(scale.hitTest(scale.getX(1) - 100), 1);
+      expect(scale.hitTest(-500), isNull);
+      expect(scale.hitTest(5000), isNull);
+    });
+
+    test('드래그 거리를 캔들 개수로 바꾼다', () {
+      expect(scale.movedCandles(408 * 2), 2);
+      expect(scale.movedCandles(-408), -1);
+      expect(scale.movedCandles(10), 0);
+    });
+  });
+
+  group('CandleViewport', () {
+    const total = 100;
+    const viewport = CandleViewport(visibleCount: 32);
+
+    test('기본값은 최신 봉 추종이다', () {
+      expect(viewport.endIndexOf(total), total);
+      expect(viewport.startIndexOf(total), 68);
+
+      // 새 봉이 열려 배열이 길어져도 오른쪽 끝을 따라간다.
+      expect(viewport.endIndexOf(total + 1), total + 1);
+    });
+
+    test('과거로 패닝하면 추종을 멈추고 그 구간에 머문다', () {
+      final panned = viewport.withEnd(80, total);
+
+      expect(panned.followingLatest, isFalse);
+      expect(panned.endIndexOf(total), 80);
+      // 실시간 봉이 늘어나도 보고 있는 구간은 흔들리지 않는다.
+      expect(panned.endIndexOf(total + 4), 80);
+    });
+
+    test('오른쪽 끝까지 되밀면 추종이 재개된다', () {
+      final panned = viewport.withEnd(80, total);
+      final back = panned.withEnd(total, total);
+
+      expect(back.followingLatest, isTrue);
+    });
+
+    test('최신 봉보다 오른쪽으로는 넘어가지 못하고 표시 개수보다 왼쪽으로도 못 간다', () {
+      expect(viewport.withEnd(500, total).endIndexOf(total), total);
+      expect(viewport.withEnd(0, total).endIndexOf(total), 32);
+    });
+
+    test('재조정으로 캔들이 줄면 앵커가 배열 밖을 가리키지 않는다', () {
+      final panned = viewport.withEnd(90, total);
+      expect(panned.endIndexOf(60), 60);
+    });
+
+    test('줌은 표시 개수를 [12, 전체] 로 가두고 앵커 비율을 유지한다', () {
+      final zoomedIn = viewport.zoom(total: total, scale: 4, focusRatio: 0.5);
+      expect(zoomedIn.visibleCount, 12);
+
+      final zoomedOut = viewport.zoom(total: total, scale: 0.1, focusRatio: 0.5);
+      expect(zoomedOut.visibleCount, total);
+
+      // 왼쪽 끝을 앵커로 잡고 확대하면 그 봉이 계속 왼쪽 끝에 남는다.
+      final anchored = viewport.zoom(total: total, scale: 2, focusRatio: 0);
+      expect(anchored.startIndexOf(total), viewport.startIndexOf(total));
+      expect(anchored.visibleCount, 16);
+    });
+  });
+
+  group('CandlePainter.shouldRepaint', () {
+    const theme = CandleChartTheme(
+      positive: Color(0xFF2ECC87),
+      negative: Color(0xFFE85D75),
+      grid: Color(0xFFE8E6E1),
+      label: Color(0xFF7C7C8A),
+      crosshair: Color(0xFF1A1A2E),
+      baseCurrency: 'KRW',
+    );
+
+    final server = [candle(0, 100, 200), candle(1, 120, 180)];
+
+    CandlePainter painter({
+      required bool liveVisible,
+      required int revision,
+      int endIndex = 2,
+      List<Candle>? candles,
+    }) => CandlePainter(
+      server: candles ?? server,
+      visible: candles ?? server,
+      startIndex: 0,
+      endIndex: endIndex,
+      liveVisible: liveVisible,
+      revision: revision,
+      interval: CandleInterval.day1,
+      theme: theme,
+    );
+
+    test('실시간 봉이 화면 밖이면 값이 바뀌어도 다시 칠하지 않는다', () {
+      final before = painter(liveVisible: false, revision: 7);
+      final after = painter(liveVisible: false, revision: 8);
+
+      expect(after.shouldRepaint(before), isFalse);
+    });
+
+    test('실시간 봉이 보이면 revision 이 오를 때만 다시 칠한다', () {
+      final before = painter(liveVisible: true, revision: 7);
+
+      expect(painter(liveVisible: true, revision: 7).shouldRepaint(before), isFalse);
+      expect(painter(liveVisible: true, revision: 8).shouldRepaint(before), isTrue);
+    });
+
+    test('서버 캔들 교체와 뷰포트 이동은 항상 다시 칠한다', () {
+      final before = painter(liveVisible: false, revision: 7);
+
+      expect(
+        painter(
+          liveVisible: false,
+          revision: 7,
+          candles: [candle(0, 100, 200), candle(1, 120, 180)],
+        ).shouldRepaint(before),
+        isTrue,
+      );
+      expect(
+        painter(liveVisible: false, revision: 7, endIndex: 1)
+            .shouldRepaint(before),
+        isTrue,
+      );
+    });
+
+    test('크로스헤어 레이어는 손가락이 없으면 칠하지 않는다', () {
+      const idle = CrosshairPainter(
+        visible: [],
+        index: null,
+        revision: 1,
+        theme: theme,
+      );
+      const ticked = CrosshairPainter(
+        visible: [],
+        index: null,
+        revision: 2,
+        theme: theme,
+      );
+
+      expect(ticked.shouldRepaint(idle), isFalse);
+    });
+  });
+}

--- a/mobile/test/live_candles_test.dart
+++ b/mobile/test/live_candles_test.dart
@@ -1,0 +1,293 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/core/realtime/ticker_store.dart';
+import 'package:trypto/features/market/live_candles.dart';
+import 'package:trypto/models/candle.dart';
+import 'package:trypto/models/enums.dart';
+import 'package:trypto/models/exchange_coin.dart';
+import 'package:trypto/models/ticker.dart';
+
+/// 10단위 완료 조건 ①②(계획서 §6). 봉 접기와 합성은 위젯 없이 고정한다.
+void main() {
+  const request = CandleRequest(
+    exchangeCode: 'UPBIT',
+    symbol: 'BTC',
+    interval: CandleInterval.minute1,
+  );
+
+  DateTime at(int hour, int minute, [int second = 0]) =>
+      DateTime(2026, 7, 15, hour, minute, second);
+
+  Ticker tick(double price, DateTime time, {String symbol = 'BTC'}) => Ticker(
+    coinId: 1,
+    symbol: symbol,
+    price: price,
+    changeRate: 0,
+    quoteTurnover: 0,
+    timestamp: time.millisecondsSinceEpoch,
+  );
+
+  Candle candle(
+    DateTime time,
+    double open,
+    double high,
+    double low,
+    double close,
+  ) => Candle(time: time, open: open, high: high, low: low, close: close);
+
+  group('normalizeCandleTime', () {
+    final sample = DateTime(2026, 7, 15, 13, 47, 31, 456);
+
+    test('간격별로 봉 시각을 절삭한다', () {
+      expect(
+        normalizeCandleTime(sample, CandleInterval.minute1),
+        DateTime(2026, 7, 15, 13, 47),
+      );
+      expect(
+        normalizeCandleTime(sample, CandleInterval.hour1),
+        DateTime(2026, 7, 15, 13),
+      );
+      // 0, 4, 8, 12, 16, 20 시로 내림.
+      expect(
+        normalizeCandleTime(sample, CandleInterval.hour4),
+        DateTime(2026, 7, 15, 12),
+      );
+      expect(
+        normalizeCandleTime(sample, CandleInterval.day1),
+        DateTime(2026, 7, 15),
+      );
+      expect(
+        normalizeCandleTime(sample, CandleInterval.month1),
+        DateTime(2026, 7),
+      );
+    });
+
+    test('주봉은 그 주 월요일 자정이다', () {
+      // 2026-07-15 는 수요일이다.
+      expect(
+        normalizeCandleTime(sample, CandleInterval.week1),
+        DateTime(2026, 7, 13),
+      );
+      // 일요일은 6일을 되돌려 같은 주 월요일로 간다.
+      expect(
+        normalizeCandleTime(DateTime(2026, 7, 19, 23), CandleInterval.week1),
+        DateTime(2026, 7, 13),
+      );
+      // 월을 넘겨도 성립한다(2026-08-02 는 일요일).
+      expect(
+        normalizeCandleTime(DateTime(2026, 8, 2, 5), CandleInterval.week1),
+        DateTime(2026, 7, 27),
+      );
+    });
+
+    test('서버 캔들의 UTC time 과 티커의 epoch millis 가 같은 봉으로 떨어진다', () {
+      final server = DateTime(2026, 7, 15, 13, 47).toUtc();
+      final ticked = DateTime(2026, 7, 15, 13, 47, 59).millisecondsSinceEpoch;
+
+      expect(
+        normalizeCandleTime(server, CandleInterval.minute1),
+        normalizeTickTime(ticked, CandleInterval.minute1),
+      );
+    });
+  });
+
+  group('LiveCandleFolder.fold', () {
+    test('한 봉 안의 체결 [100, 130, 90, 110] 이 high=130 low=90 close=110 이 된다', () {
+      final folder = LiveCandleFolder(request);
+      final bucket = at(10, 0);
+
+      for (final price in [100.0, 130.0, 90.0, 110.0]) {
+        folder.onTick(tick(price, bucket.add(const Duration(seconds: 5))));
+      }
+
+      expect(folder.live, hasLength(1));
+      final live = folder.live.single;
+      expect(live.open, 100);
+      expect(live.high, 130);
+      expect(live.low, 90);
+      expect(live.close, 110);
+    });
+
+    test('이미 닫힌 봉에 뒤늦게 도착한 체결은 버린다', () {
+      final folder = LiveCandleFolder(request);
+      folder.onTick(tick(100, at(10, 0)));
+      folder.onTick(tick(200, at(10, 1)));
+
+      folder.onTick(tick(999, at(10, 0, 30)));
+
+      expect(folder.live, hasLength(2));
+      expect(folder.live.first.close, 100);
+      expect(folder.live.last.close, 200);
+    });
+
+    test('새 봉은 네 값이 모두 그 체결가이고 최근 4개만 남는다', () {
+      final folder = LiveCandleFolder(request);
+      for (var minute = 0; minute < 6; minute++) {
+        folder.onTick(tick(100.0 + minute, at(10, minute)));
+      }
+
+      expect(folder.live, hasLength(kLiveCandleLimit));
+      expect(folder.live.first.bucket, at(10, 2));
+      final last = folder.live.last;
+      expect([last.open, last.high, last.low, last.close], [105, 105, 105, 105]);
+    });
+
+    test('다른 심볼과 유효하지 않은 가격은 접지 않는다', () {
+      final folder = LiveCandleFolder(request);
+      folder.onTick(tick(100, at(10, 0), symbol: 'ETH'));
+      folder.onTick(tick(0, at(10, 0)));
+      folder.onTick(tick(double.nan, at(10, 0)));
+
+      expect(folder.live, isEmpty);
+    });
+
+    test('openedBucket 은 봉이 바뀔 때만 발화한다 — 재조정 타이머가 틱마다 재무장하지 않는다', () {
+      final folder = LiveCandleFolder(request);
+      var fired = 0;
+      folder.openedBucket.addListener(() => fired++);
+
+      for (var i = 0; i < 50; i++) {
+        folder.onTick(tick(100.0 + i, at(10, 0, i)));
+      }
+      expect(fired, 1);
+
+      folder.onTick(tick(300, at(10, 1)));
+      expect(fired, 2);
+    });
+  });
+
+  group('MergedCandles', () {
+    test('서버 캔들이 기준이고 같은 봉은 서버 open + 실시간 high/low/close 다', () {
+      final server = [
+        candle(at(10, 0), 100, 110, 90, 105),
+        candle(at(10, 1), 105, 115, 100, 108),
+      ];
+      final folder = LiveCandleFolder(request);
+      folder.onTick(tick(120, at(10, 1, 10)));
+      folder.onTick(tick(95, at(10, 1, 20)));
+      folder.onTick(tick(112, at(10, 1, 30)));
+
+      final merged = MergedCandles(server, folder.live);
+      expect(merged.length, 2);
+
+      final last = merged[1];
+      expect(last.open, 105, reason: '시가는 서버 값이다');
+      expect(last.high, 120);
+      expect(last.low, 95);
+      expect(last.close, 112, reason: '종가는 최신 체결가다');
+
+      // 과거 봉은 서버 값 그대로다.
+      expect(merged[0].close, 105);
+    });
+
+    test('서버보다 미래의 봉은 뒤에 붙이고 이전 봉은 무시한다', () {
+      final server = [candle(at(10, 1), 105, 115, 100, 108)];
+      final folder = LiveCandleFolder(request);
+      // 서버가 이미 확정한 과거 구간 — 재조정 뒤 남아 있는 낡은 실시간 봉이다.
+      folder.onTick(tick(999, at(10, 0)));
+      folder.onTick(tick(130, at(10, 2)));
+      folder.onTick(tick(140, at(10, 3)));
+
+      final merged = MergedCandles(server, folder.live);
+
+      expect(merged.length, 3);
+      expect(merged[0].close, 108);
+      expect(merged[1].time, at(10, 2));
+      expect(merged[2].close, 140);
+      expect(merged.liveFromIndex, 1);
+    });
+
+    test('서버 캔들이 0개여도 실시간 봉만으로 그린다', () {
+      final folder = LiveCandleFolder(request);
+      folder.onTick(tick(100, at(10, 0)));
+      folder.onTick(tick(130, at(10, 1)));
+
+      final merged = MergedCandles(const [], folder.live);
+
+      expect(merged.length, 2);
+      expect(merged[0].open, 100);
+      expect(merged[1].close, 130);
+      expect(merged.liveFromIndex, 0);
+    });
+
+    test('실시간 봉이 없으면 서버 배열 그대로다', () {
+      final server = [candle(at(10, 0), 100, 110, 90, 105)];
+      final merged = MergedCandles(server, const []);
+
+      expect(merged.length, 1);
+      expect(identical(merged[0], server[0]), isTrue);
+      expect(merged.liveFromIndex, 1, reason: '반영되는 실시간 봉이 없다');
+    });
+
+    test('실시간 봉이 전부 과거면 반영 지점이 없다', () {
+      final server = [
+        candle(at(10, 5), 100, 110, 90, 105),
+        candle(at(10, 6), 105, 115, 100, 108),
+      ];
+      final folder = LiveCandleFolder(request);
+      folder.onTick(tick(999, at(10, 1)));
+
+      final merged = MergedCandles(server, folder.live);
+
+      expect(merged.length, 2);
+      expect(merged.liveFromIndex, merged.length);
+    });
+  });
+
+  group('normalizeCandles', () {
+    test('유한하지 않은 캔들을 버리고 봉 시각을 절삭해 오름차순 정렬한다', () {
+      final result = normalizeCandles([
+        candle(DateTime(2026, 7, 15, 10, 1, 40), 105, 115, 100, 108),
+        candle(DateTime(2026, 7, 15, 10, 0, 20), 100, 110, 90, 105),
+        candle(DateTime(2026, 7, 15, 10, 2), 108, double.infinity, 100, 110),
+      ], CandleInterval.minute1);
+
+      expect(result, hasLength(2));
+      expect(result.first.time, at(10, 0));
+      expect(result.last.time, at(10, 1));
+    });
+  });
+
+  /// **프레임 버퍼로 접으면 실패하는 테스트다.** 한 프레임 안에 들어온 네 체결을 마지막 값만
+  /// 보고 접으면 high=low=close=110 이 된다.
+  testWidgets('TickerStore 를 통과한 한 프레임의 체결이 봉의 고가·저가를 지킨다', (tester) async {
+    final store = TickerStore()
+      ..switchExchange([
+        const ExchangeCoin(
+          exchangeCoinId: 1,
+          coinId: 1,
+          coinSymbol: 'BTC',
+          coinName: '비트코인',
+          price: 100,
+          changeRate: 0,
+          volume: 0,
+        ),
+      ]);
+    addTearDown(store.dispose);
+
+    final folder = LiveCandleFolder(request);
+    store.setRawObserver(folder);
+
+    final bucket = at(10, 0);
+    for (final price in [100.0, 130.0, 90.0, 110.0]) {
+      store.ingest([tick(price, bucket.add(const Duration(seconds: 1)))]);
+    }
+    // 아직 프레임을 밀지 않았다. 접기는 이미 끝나 있어야 한다.
+    expect(folder.live.single.high, 130);
+    expect(folder.live.single.low, 90);
+    expect(folder.live.single.close, 110);
+    expect(folder.revision.value, 0);
+
+    await tester.pump();
+    expect(folder.revision.value, 1, reason: '그리기 알림은 프레임당 1회다');
+
+    // 같은 프레임에 다시 100틱이 들어와도 알림은 한 번뿐이다.
+    for (var i = 0; i < 100; i++) {
+      store.ingest([
+        tick(120.0 + i, bucket.add(Duration(milliseconds: 2000 + i * 10))),
+      ]);
+    }
+    await tester.pump();
+    expect(folder.revision.value, 2);
+    expect(folder.live.single.high, 219);
+  });
+}

--- a/mobile/test/market_view_test.dart
+++ b/mobile/test/market_view_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/features/market/market_controller.dart';
+import 'package:trypto/models/exchange_coin.dart';
+
+/// 검색·필터·정렬은 위젯 없이 고정한다. 특히 초성은 `startsWith`, 자모는 `contains` 라는
+/// 비대칭(사양서 §4.2.5)이 깨지면 사용자는 "안 나온다" 로만 체감하고 원인을 못 찾는다.
+void main() {
+  CoinEntry coin(
+    String symbol,
+    String name, {
+    double price = 100,
+    double changeRate = 0,
+    double volume = 0,
+  }) => CoinEntry(
+    ExchangeCoin(
+      exchangeCoinId: 1,
+      coinId: 1,
+      coinSymbol: symbol,
+      coinName: name,
+      price: price,
+      changeRate: changeRate,
+      volume: volume,
+    ),
+  );
+
+  final btc = coin('BTC', '비트코인', price: 96000000, changeRate: 0.012, volume: 900);
+  final eth = coin('ETH', '이더리움', price: 5300000, changeRate: -0.004, volume: 500);
+  final xrp = coin('XRP', '리플', price: 3200, changeRate: 0, volume: 700);
+  final doge = coin('DOGE', '도지코인', price: 300, changeRate: 0.08, volume: 100);
+  final all = [btc, eth, xrp, doge];
+
+  List<String> symbols(MarketView view) =>
+      applyMarketView(all, view).map((entry) => entry.symbol).toList();
+
+  group('검색', () {
+    test('심볼 부분 일치 (대소문자 무시)', () {
+      expect(symbols(const MarketView(query: 'bt')), ['BTC']);
+      expect(symbols(const MarketView(query: 'og')), ['DOGE']);
+    });
+
+    test('초성 질의는 앞부분 일치다', () {
+      expect(symbols(const MarketView(query: 'ㅂㅌ')), ['BTC']);
+      expect(symbols(const MarketView(query: 'ㄷㅈ')), ['DOGE']);
+    });
+
+    test('초성 질의가 중간부터 맞는 것은 잡지 않는다 (contains 가 아니다)', () {
+      // '도지코인' → ㄷㅈㅋㅇ. 'ㅈㅋ' 는 contains 면 잡히고 startsWith 면 잡히지 않는다.
+      expect(symbols(const MarketView(query: 'ㅈㅋ')), isEmpty);
+    });
+
+    test('자모 질의는 부분 일치다', () {
+      expect(symbols(const MarketView(query: '비트')), ['BTC']);
+      expect(symbols(const MarketView(query: '코인')), ['BTC', 'DOGE']);
+    });
+
+    test('조합 중인 글자도 맞아떨어진다', () {
+      // '빝' → ㅂㅣㅌ 은 '비트코인' → ㅂㅣㅌㅡ… 의 앞부분이다.
+      expect(symbols(const MarketView(query: '빝')), ['BTC']);
+    });
+
+    test('빈 질의는 전부 통과시킨다', () {
+      expect(symbols(const MarketView()).length, all.length);
+    });
+  });
+
+  group('필터', () {
+    test('상승은 changeRate > 0 만 남긴다', () {
+      expect(
+        symbols(const MarketView(filter: MarketFilter.rising)).toSet(),
+        {'BTC', 'DOGE'},
+      );
+    });
+
+    test('하락은 changeRate < 0 만 남긴다', () {
+      expect(symbols(const MarketView(filter: MarketFilter.falling)), ['ETH']);
+    });
+
+    test('changeRate == 0 은 상승·하락 어느 쪽에도 잡히지 않는다', () {
+      expect(
+        symbols(const MarketView(filter: MarketFilter.rising)),
+        isNot(contains('XRP')),
+      );
+      expect(
+        symbols(const MarketView(filter: MarketFilter.falling)),
+        isNot(contains('XRP')),
+      );
+      expect(symbols(const MarketView()), contains('XRP'));
+    });
+  });
+
+  group('정렬', () {
+    test('기본값은 거래대금 내림차순이다', () {
+      expect(const MarketView().sortKey, MarketSortKey.volume);
+      expect(const MarketView().descending, isTrue);
+      expect(symbols(const MarketView()), ['BTC', 'XRP', 'ETH', 'DOGE']);
+    });
+
+    test('이름 정렬은 한글명이 아니라 심볼 사전순이다', () {
+      expect(
+        symbols(const MarketView(sortKey: MarketSortKey.name, descending: false)),
+        ['BTC', 'DOGE', 'ETH', 'XRP'],
+      );
+    });
+
+    test('현재가·변동률 정렬', () {
+      expect(
+        symbols(const MarketView(sortKey: MarketSortKey.price)),
+        ['BTC', 'ETH', 'XRP', 'DOGE'],
+      );
+      expect(
+        symbols(const MarketView(sortKey: MarketSortKey.change)),
+        ['DOGE', 'BTC', 'XRP', 'ETH'],
+      );
+    });
+
+    test('같은 키를 다시 누르면 방향만 뒤집는다', () {
+      final toggled = const MarketView().sortBy(MarketSortKey.volume);
+      expect(toggled.sortKey, MarketSortKey.volume);
+      expect(toggled.descending, isFalse);
+      expect(toggled.sortBy(MarketSortKey.volume).descending, isTrue);
+    });
+
+    test('다른 키를 누르면 그 키로 바꾸고 방향을 desc 로 되돌린다', () {
+      final ascending = const MarketView().sortBy(MarketSortKey.volume);
+      final switched = ascending.sortBy(MarketSortKey.price);
+      expect(switched.sortKey, MarketSortKey.price);
+      expect(switched.descending, isTrue);
+    });
+  });
+
+  group('거래소 전환', () {
+    test('검색어와 필터는 초기화하고 정렬은 유지한다', () {
+      const before = MarketView(
+        query: '비트',
+        filter: MarketFilter.rising,
+        sortKey: MarketSortKey.change,
+        descending: false,
+      );
+      final after = before.forExchangeSwitch();
+
+      expect(after.query, isEmpty);
+      expect(after.filter, MarketFilter.all);
+      expect(after.sortKey, MarketSortKey.change);
+      expect(after.descending, isFalse);
+    });
+  });
+
+  group('검색 → 필터 → 정렬 순서', () {
+    test('세 조건이 겹쳐도 결과가 좁혀진다', () {
+      expect(
+        symbols(
+          const MarketView(
+            query: '코인',
+            filter: MarketFilter.rising,
+            sortKey: MarketSortKey.change,
+          ),
+        ),
+        ['DOGE', 'BTC'],
+      );
+    });
+  });
+}

--- a/mobile/test/mypage_validation_test.dart
+++ b/mobile/test/mypage_validation_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/features/mypage/feedback_card.dart';
+import 'package:trypto/features/mypage/nickname_sheet.dart';
+
+void main() {
+  group('validateNickname', () {
+    test('2~20자만 통과한다', () {
+      expect(validateNickname('가나'), isNull);
+      expect(validateNickname('가' * 20), isNull);
+    });
+
+    test('경계 밖은 막는다', () {
+      expect(validateNickname('가'), isNotNull);
+      expect(validateNickname(''), isNotNull);
+      expect(validateNickname('가' * 21), isNotNull);
+    });
+
+    // 서버도 strip 후 길이를 잰다. 공백만 채워 통과시킬 수 없다.
+    test('길이는 trim 기준이다', () {
+      expect(validateNickname('  가  '), isNotNull);
+      expect(validateNickname('  가나  '), isNull);
+    });
+  });
+
+  group('validateFeedback', () {
+    test('trim 기준 20~1000자만 통과한다', () {
+      expect(validateFeedback('가' * 19), isNotNull);
+      expect(validateFeedback('가' * 20), isNull);
+      expect(validateFeedback('가' * 1000), isNull);
+      expect(validateFeedback('가' * 1001), isNotNull);
+    });
+
+    test('공백은 길이에 들어가지 않는다', () {
+      expect(validateFeedback('${'가' * 19} '), isNotNull);
+      expect(validateFeedback('  ${'가' * 20}  '), isNull);
+    });
+  });
+}

--- a/mobile/test/order_form_test.dart
+++ b/mobile/test/order_form_test.dart
@@ -1,0 +1,377 @@
+import 'package:decimal/decimal.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/core/constants/exchanges.dart';
+import 'package:trypto/features/market/market_controller.dart';
+import 'package:trypto/features/market/order_form.dart';
+import 'package:trypto/features/market/order_target.dart';
+import 'package:trypto/models/enums.dart';
+import 'package:trypto/models/exchange_coin.dart';
+
+/// 계획서 §7-⑤ — `MARKET+BUY` 는 `volume` 금지·`price` = 총액, `MARKET+SELL` 은 `price` 금지.
+/// 4조합 + 각 위반. 틀리면 서버가 400 이다.
+void main() {
+  final upbit = ExchangeIds.byId(ExchangeIds.upbit)!;
+  final binance = ExchangeIds.byId(ExchangeIds.binance)!;
+
+  Decimal dec(String value) => Decimal.parse(value);
+
+  OrderContext ctx({
+    Exchange? exchange,
+    String price = '100000000',
+    String buy = '10000000',
+    String sell = '2',
+  }) => OrderContext(
+    exchange: exchange ?? upbit,
+    currentPrice: dec(price),
+    availableBuy: dec(buy),
+    availableSell: dec(sell),
+  );
+
+  const target = OrderTarget(
+    exchange: Exchange(
+      id: 1,
+      key: 'upbit',
+      name: '업비트',
+      baseCurrency: 'KRW',
+      feeRate: 0.0005,
+      candleCode: 'UPBIT',
+    ),
+    symbol: 'BTC',
+    walletId: 100,
+    exchangeCoinId: 7,
+  );
+
+  CoinEntry entry(int id, String symbol) => CoinEntry(
+    ExchangeCoin(
+      exchangeCoinId: id,
+      coinId: id,
+      coinSymbol: symbol,
+      coinName: symbol,
+      price: 1,
+      changeRate: 0,
+      volume: 0,
+    ),
+  );
+
+  group('주문 대상 해석', () {
+    test('라운드가 없으면 NO_ROUND 다', () {
+      final result = resolveOrderTarget(
+        exchange: upbit,
+        symbol: 'BTC',
+        walletId: null,
+        coins: [entry(7, 'BTC')],
+      );
+
+      expect(result.target, isNull);
+      expect(result.failure, OrderTargetFailure.noRound);
+    });
+
+    test('코인 목록 조회가 실패하면 LOOKUP_FAILED 다', () {
+      final result = resolveOrderTarget(
+        exchange: upbit,
+        symbol: 'BTC',
+        walletId: 100,
+        coins: null,
+      );
+
+      expect(result.failure, OrderTargetFailure.lookupFailed);
+    });
+
+    test('상장 목록에 없으면 COIN_UNLISTED 다', () {
+      final result = resolveOrderTarget(
+        exchange: upbit,
+        symbol: 'DOGE',
+        walletId: 100,
+        coins: [entry(7, 'BTC')],
+      );
+
+      expect(result.failure, OrderTargetFailure.coinUnlisted);
+    });
+
+    test('심볼은 대소문자를 무시하고 매칭한다', () {
+      final result = resolveOrderTarget(
+        exchange: upbit,
+        symbol: 'btc',
+        walletId: 100,
+        coins: [entry(7, 'BTC')],
+      );
+
+      expect(result.target?.exchangeCoinId, 7);
+      expect(result.target?.walletId, 100);
+      // 어느 (거래소, 코인) 의 것인지 함께 들고 다닌다.
+      expect(result.target?.key, 'upbit:BTC');
+    });
+  });
+
+  group('바디 조립', () {
+    test('시장가 매수 — volume 이 없고 price 에 총액이 실린다', () {
+      final form = OrderForm.empty(
+        side: Side.buy,
+        orderType: OrderType.market,
+      ).withTotal(dec('50000'), ctx());
+
+      final json = form
+          .toRequest(target: target, clientOrderId: 'key')
+          .toJson();
+
+      expect(json.containsKey('volume'), isFalse);
+      expect(json['price'], 50000.0);
+      expect(json['orderType'], 'MARKET');
+      expect(json['side'], 'BUY');
+      expect(json['walletId'], 100);
+      expect(json['exchangeCoinId'], 7);
+    });
+
+    test('시장가 매도 — price 가 없고 volume 에 수량이 실린다', () {
+      final form = OrderForm.empty(
+        side: Side.sell,
+        orderType: OrderType.market,
+      ).withQuantity(dec('0.005'), ctx());
+
+      final json = form
+          .toRequest(target: target, clientOrderId: 'key')
+          .toJson();
+
+      expect(json.containsKey('price'), isFalse);
+      expect(json['volume'], 0.005);
+    });
+
+    test('지정가 매수 — price 는 지정가고 volume 은 수량이다', () {
+      final form = OrderForm.empty(side: Side.buy)
+          .withPrice(dec('95000000'), ctx())
+          .withQuantity(dec('0.001'), ctx());
+
+      final json = form
+          .toRequest(target: target, clientOrderId: 'key')
+          .toJson();
+
+      expect(json['price'], 95000000.0);
+      expect(json['volume'], 0.001);
+      expect(json['orderType'], 'LIMIT');
+    });
+
+    test('지정가 매도 — price·volume 을 모두 보낸다', () {
+      final form = OrderForm.empty(side: Side.sell)
+          .withPrice(dec('95000000'), ctx())
+          .withQuantity(dec('0.5'), ctx());
+
+      final json = form
+          .toRequest(target: target, clientOrderId: 'key')
+          .toJson();
+
+      expect(json['price'], 95000000.0);
+      expect(json['volume'], 0.5);
+      expect(json['side'], 'SELL');
+    });
+
+    test('시장가 매수로 바꿔도 남아 있던 수량이 volume 으로 새지 않는다', () {
+      final form = OrderForm.empty(side: Side.buy)
+          .withPrice(dec('95000000'), ctx())
+          .withQuantity(dec('0.001'), ctx())
+          .withOrderType(OrderType.market, ctx());
+
+      final json = form
+          .toRequest(target: target, clientOrderId: 'key')
+          .toJson();
+
+      expect(json.containsKey('volume'), isFalse);
+      // 지정가에서 연동된 총액(0.001 × 95,000,000)이 그대로 총 주문 금액이 된다.
+      expect(json['price'], 95000.0);
+    });
+
+    test('소수 8자리 수량이 double 왕복에서 뭉개지지 않는다', () {
+      final form = OrderForm.empty(
+        side: Side.sell,
+        orderType: OrderType.market,
+      ).withQuantity(dec('0.00000001'), ctx());
+
+      final json = form
+          .toRequest(target: target, clientOrderId: 'key')
+          .toJson();
+
+      expect(json['volume'], 1e-8);
+    });
+  });
+
+  group('수량↔총액 연동', () {
+    test('지정가에서 수량을 넣으면 총액이 따라온다', () {
+      final form = OrderForm.empty(side: Side.buy)
+          .withPrice(dec('95000000'), ctx())
+          .withQuantity(dec('0.001'), ctx());
+
+      expect(form.total, dec('95000'));
+    });
+
+    test('지정가에서 총액을 넣으면 수량이 6자리로 따라온다', () {
+      final form = OrderForm.empty(side: Side.buy)
+          .withPrice(dec('95000000'), ctx())
+          .withTotal(dec('100000'), ctx());
+
+      // 100,000 / 95,000,000 = 0.00105263… → 6자리 반올림
+      expect(form.quantity, dec('0.001053'));
+    });
+
+    test('가격이 바뀌면 마지막으로 손댄 쪽을 기준으로 반대편을 다시 계산한다', () {
+      final form = OrderForm.empty(side: Side.buy)
+          .withPrice(dec('95000000'), ctx())
+          .withQuantity(dec('0.001'), ctx())
+          .withPrice(dec('90000000'), ctx());
+
+      expect(form.quantity, dec('0.001'));
+      expect(form.total, dec('90000'));
+    });
+
+    test('시장가에서는 연동하지 않는다', () {
+      final form = OrderForm.empty(
+        side: Side.buy,
+        orderType: OrderType.market,
+      ).withTotal(dec('50000'), ctx());
+
+      expect(form.quantity, Decimal.zero);
+    });
+
+    test('가격이 비어 있으면 스텝 버튼의 기준값은 현재가이고 0 아래로 내려가지 않는다', () {
+      final context = ctx(price: '500');
+      final up = OrderForm.empty(side: Side.buy).stepPrice(1, context);
+      final down = OrderForm.empty(side: Side.buy).stepPrice(-1, context);
+
+      expect(up.price, dec('1500'));
+      expect(down.price, Decimal.zero);
+    });
+  });
+
+  group('비율 버튼', () {
+    test('매수 50% 는 주문 가능 금액의 절반이다', () {
+      final form = OrderForm.empty(
+        side: Side.buy,
+        orderType: OrderType.market,
+      ).applyRatio(50, ctx());
+
+      expect(form.total, dec('5000000'));
+    });
+
+    test('매수 100% 는 수수료까지 내고 살 수 있는 최대치로 가둔다', () {
+      final context = ctx();
+      final form = OrderForm.empty(
+        side: Side.buy,
+        orderType: OrderType.market,
+      ).applyRatio(100, context);
+
+      // 10,000,000 을 그대로 채우면 수수료가 위에 더 붙어 서버가 INSUFFICIENT_BALANCE 를 낸다.
+      expect(form.total < dec('10000000'), isTrue);
+      expect(form.validate(context), isNull);
+    });
+
+    test('매도 100% 는 보유 수량 전량이다', () {
+      final form = OrderForm.empty(
+        side: Side.sell,
+        orderType: OrderType.market,
+      ).applyRatio(100, ctx(sell: '1.23456789'));
+
+      // 수량은 6자리로 내림한다 — 올리면 보유 수량을 넘는다.
+      expect(form.quantity, dec('1.234567'));
+    });
+  });
+
+  group('검증', () {
+    test('시장가 매수는 총액을, 나머지는 수량을 먼저 본다', () {
+      final buy = OrderForm.empty(side: Side.buy, orderType: OrderType.market);
+      final sell = OrderForm.empty(
+        side: Side.sell,
+        orderType: OrderType.market,
+      );
+
+      expect(buy.validate(ctx()), '주문 총액을 입력해 주세요.');
+      expect(sell.validate(ctx()), '주문 수량을 입력해 주세요.');
+    });
+
+    test('지정가는 가격이 없으면 막는다', () {
+      final form = OrderForm.empty(
+        side: Side.buy,
+      ).withQuantity(dec('0.001'), ctx());
+
+      expect(form.validate(ctx()), '지정가를 입력해 주세요.');
+    });
+
+    test('최소 주문 금액을 밑돌면 막는다 — KRW 5,000', () {
+      final form = OrderForm.empty(
+        side: Side.buy,
+        orderType: OrderType.market,
+      ).withTotal(dec('4999'), ctx());
+
+      expect(form.validate(ctx()), '최소 주문 금액은 5,000 KRW 입니다.');
+    });
+
+    test('최소 주문 금액은 거래소 기준통화를 따른다 — USDT 5', () {
+      final context = ctx(exchange: binance, price: '60000', buy: '1000');
+      final form = OrderForm.empty(
+        side: Side.buy,
+        orderType: OrderType.market,
+      ).withTotal(dec('4'), context);
+
+      // 웹은 하드코딩이라 바이낸스에서도 "최소 주문 5,000 USDT" 로 나온다.
+      expect(form.validate(context), '최소 주문 금액은 5.00 USDT 입니다.');
+    });
+
+    test('KRW 상한 10억을 넘으면 막는다', () {
+      final context = ctx(buy: '2000000000');
+      final form = OrderForm.empty(
+        side: Side.buy,
+        orderType: OrderType.market,
+      ).withTotal(dec('1000000001'), context);
+
+      expect(form.validate(context), '최대 주문 금액은 1,000,000,000 KRW 입니다.');
+    });
+
+    test('매수는 수수료를 포함해 잔고를 검사한다', () {
+      final context = ctx(buy: '100000');
+      final form = OrderForm.empty(
+        side: Side.buy,
+        orderType: OrderType.market,
+      ).withTotal(dec('100000'), context);
+
+      // 차감액 = 100,000 × (1 + 0.0005) = 100,050 > 100,000
+      expect(form.validate(context), startsWith('주문 가능 금액을 초과했습니다.'));
+    });
+
+    test('매도는 보유 수량을 넘으면 막는다', () {
+      final context = ctx(sell: '0.5');
+      final form = OrderForm.empty(
+        side: Side.sell,
+        orderType: OrderType.market,
+      ).withQuantity(dec('0.6'), context);
+
+      expect(form.validate(context), '보유 수량을 초과했습니다.');
+    });
+
+    test('예상 수수료는 주문 총액 × 거래소 수수료율이다', () {
+      final context = ctx();
+      final form = OrderForm.empty(
+        side: Side.buy,
+        orderType: OrderType.market,
+      ).withTotal(dec('1000000'), context);
+
+      // 업비트 0.05%
+      expect(form.feeOf(context), dec('500'));
+    });
+
+    test('빗썸은 0.25% 다 — 수수료율은 거래소마다 다르다', () {
+      final context = ctx(exchange: ExchangeIds.byId(ExchangeIds.bithumb)!);
+      final form = OrderForm.empty(
+        side: Side.buy,
+        orderType: OrderType.market,
+      ).withTotal(dec('1000000'), context);
+
+      expect(form.feeOf(context), dec('2500'));
+    });
+  });
+
+  group('입력 파싱', () {
+    test('콤마를 제거하고, 숫자가 아니면 0 으로 본다', () {
+      expect(parseAmountInput('1,234,567'), dec('1234567'));
+      expect(parseAmountInput(''), Decimal.zero);
+      expect(parseAmountInput('.'), Decimal.zero);
+      expect(parseAmountInput('0.00000001'), dec('0.00000001'));
+    });
+  });
+}

--- a/mobile/test/portfolio_summary_test.dart
+++ b/mobile/test/portfolio_summary_test.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/features/portfolio/donut_painter.dart';
+import 'package:trypto/features/portfolio/portfolio_summary.dart';
+import 'package:trypto/models/portfolio.dart';
+
+HoldingSnapshot _holding(
+  String symbol, {
+  required double quantity,
+  required double avgBuyPrice,
+  required double currentPrice,
+}) => HoldingSnapshot(
+  coinId: symbol.hashCode,
+  coinSymbol: symbol,
+  coinName: symbol,
+  quantity: quantity,
+  avgBuyPrice: avgBuyPrice,
+  currentPrice: currentPrice,
+);
+
+MyHoldings _my(List<HoldingSnapshot> holdings, {double cash = 0}) => MyHoldings(
+  exchangeId: 1,
+  baseCurrencyBalance: cash,
+  baseCurrencySymbol: 'KRW',
+  holdings: holdings,
+);
+
+void main() {
+  group('PortfolioSummary', () {
+    test('서버가 주지 않는 합계를 holdings 로 계산한다', () {
+      final summary = PortfolioSummary.of(
+        _my([
+          _holding('BTC', quantity: 0.5, avgBuyPrice: 100, currentPrice: 200),
+          _holding('ETH', quantity: 2, avgBuyPrice: 50, currentPrice: 25),
+        ], cash: 1000),
+      );
+
+      expect(summary.totalBuy.toDouble(), 150); // 0.5×100 + 2×50
+      expect(summary.totalEval.toDouble(), 150); // 0.5×200 + 2×25
+      expect(summary.totalAsset.toDouble(), 1150);
+      expect(summary.profitLoss.toDouble(), 0);
+      expect(summary.profitRate, 0);
+    });
+
+    test('수익률은 퍼센트 값 그 자체다', () {
+      final summary = PortfolioSummary.of(
+        _my([
+          _holding('BTC', quantity: 1, avgBuyPrice: 1000, currentPrice: 1250),
+        ]),
+      );
+
+      expect(summary.profitLoss.toDouble(), 250);
+      expect(summary.profitRate, closeTo(25, 1e-9));
+      expect(summary.holdings.single.profitRate, closeTo(25, 1e-9));
+    });
+
+    test('매수금액이 0이면 수익률은 0이다 (0으로 나누지 않는다)', () {
+      final summary = PortfolioSummary.of(_my([], cash: 500));
+
+      expect(summary.totalBuy.toDouble(), 0);
+      expect(summary.profitRate, 0);
+      expect(summary.totalAsset.toDouble(), 500);
+    });
+
+    test('8자리 수량 × 원 단위 가격을 Decimal 로 누산한다', () {
+      final summary = PortfolioSummary.of(
+        _my([
+          for (var i = 0; i < 3; i++)
+            _holding(
+              'C$i',
+              quantity: 0.1,
+              avgBuyPrice: 0.1,
+              currentPrice: 0.1,
+            ),
+        ]),
+      );
+
+      // double 로 누산하면 0.030000000000000002 가 된다.
+      expect(summary.totalEval.toString(), '0.03');
+    });
+  });
+
+  group('sortHoldings', () {
+    final holdings = [
+      HoldingView(
+        _holding('AAA', quantity: 1, avgBuyPrice: 10, currentPrice: 30),
+      ),
+      HoldingView(
+        _holding('BBB', quantity: 1, avgBuyPrice: 10, currentPrice: 5),
+      ),
+      HoldingView(
+        _holding('CCC', quantity: 1, avgBuyPrice: 10, currentPrice: 20),
+      ),
+    ];
+
+    test('기본은 평가금액 내림차순이다', () {
+      final sorted = sortHoldings(holdings, HoldingSortKey.evalAmount);
+
+      expect([for (final h in sorted) h.symbol], ['AAA', 'CCC', 'BBB']);
+    });
+
+    test('오름차순 토글과 코인명 정렬', () {
+      final byRate = sortHoldings(
+        holdings,
+        HoldingSortKey.profitRate,
+        descending: false,
+      );
+      expect([for (final h in byRate) h.symbol], ['BBB', 'CCC', 'AAA']);
+
+      final byName = sortHoldings(
+        holdings,
+        HoldingSortKey.name,
+        descending: false,
+      );
+      expect([for (final h in byName) h.symbol], ['AAA', 'BBB', 'CCC']);
+    });
+
+    test('원본 목록을 뒤집지 않는다', () {
+      sortHoldings(holdings, HoldingSortKey.name);
+
+      expect([for (final h in holdings) h.symbol], ['AAA', 'BBB', 'CCC']);
+    });
+  });
+
+  group('buildDonutSegments', () {
+    test('총자산이 0이면 조각이 없다', () {
+      expect(buildDonutSegments(PortfolioSummary.of(_my([]))), isEmpty);
+    });
+
+    test('현금만 있으면 현금 한 조각이 100% 다', () {
+      final segments = buildDonutSegments(
+        PortfolioSummary.of(_my([], cash: 1000)),
+      );
+
+      expect(segments, hasLength(1));
+      expect(segments.single.label, 'KRW');
+      expect(segments.single.ratio, 1);
+    });
+
+    test('현금이 맨 앞, 코인은 평가금액 내림차순이다', () {
+      final segments = buildDonutSegments(
+        PortfolioSummary.of(
+          _my([
+            _holding('ETH', quantity: 1, avgBuyPrice: 1, currentPrice: 200),
+            _holding('BTC', quantity: 1, avgBuyPrice: 1, currentPrice: 700),
+          ], cash: 100),
+        ),
+      );
+
+      expect([for (final s in segments) s.label], ['KRW', 'BTC', 'ETH']);
+      expect(segments[1].ratio, closeTo(0.7, 1e-9));
+      expect(segments[0].color, const Color(0xFFC2B8AB));
+      expect(segments[1].color, const Color(0xFFF7931A)); // BTC 고유색
+    });
+
+    test('현금이 0이면 현금 조각을 생략한다', () {
+      final segments = buildDonutSegments(
+        PortfolioSummary.of(
+          _my([
+            _holding('BTC', quantity: 1, avgBuyPrice: 1, currentPrice: 100),
+          ]),
+        ),
+      );
+
+      expect([for (final s in segments) s.label], ['BTC']);
+    });
+
+    test('평가금액이 0인 코인은 조각이 되지 않는다', () {
+      final segments = buildDonutSegments(
+        PortfolioSummary.of(
+          _my([
+            _holding('BTC', quantity: 1, avgBuyPrice: 1, currentPrice: 100),
+            _holding('DUST', quantity: 0, avgBuyPrice: 1, currentPrice: 100),
+          ]),
+        ),
+      );
+
+      expect([for (final s in segments) s.label], ['BTC']);
+    });
+
+    test('코인이 7개 이상이면 상위 5개 + 기타로 접는다', () {
+      final segments = buildDonutSegments(
+        PortfolioSummary.of(
+          _my([
+            for (var i = 1; i <= 8; i++)
+              _holding(
+                'C$i',
+                quantity: 1,
+                avgBuyPrice: 1,
+                currentPrice: i * 10,
+              ),
+          ]),
+        ),
+      );
+
+      expect([for (final s in segments) s.label], [
+        'C8',
+        'C7',
+        'C6',
+        'C5',
+        'C4',
+        '기타',
+      ]);
+      // 나머지 C3·C2·C1 의 합
+      expect(segments.last.value, 60);
+      expect(
+        segments.fold<double>(0, (sum, s) => sum + s.ratio),
+        closeTo(1, 1e-9),
+      );
+    });
+
+    test('코인이 정확히 6개면 접지 않는다', () {
+      final segments = buildDonutSegments(
+        PortfolioSummary.of(
+          _my([
+            for (var i = 1; i <= 6; i++)
+              _holding(
+                'C$i',
+                quantity: 1,
+                avgBuyPrice: 1,
+                currentPrice: i * 10,
+              ),
+          ]),
+        ),
+      );
+
+      expect(segments, hasLength(6));
+      expect(segments.map((s) => s.label), isNot(contains('기타')));
+    });
+  });
+}

--- a/mobile/test/ranking_view_test.dart
+++ b/mobile/test/ranking_view_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/features/ranking/ranker_portfolio_sheet.dart';
+
+void main() {
+  group('asRatio', () {
+    // 서버가 비중을 0.35 로 주든 35 로 주든 35.0% 여야 한다(사양서 §6.2.7).
+    test('1 이하는 비율 그대로 본다', () {
+      expect(asRatio(0.35), 0.35);
+      expect(asRatio(0), 0);
+      expect(asRatio(1), 1);
+    });
+
+    test('1 초과는 퍼센트로 보고 100 으로 나눈다', () {
+      expect(asRatio(35), 0.35);
+      expect(asRatio(100), 1);
+    });
+  });
+
+  group('canViewRankerPortfolio', () {
+    test('100위까지만 열람할 수 있다', () {
+      expect(canViewRankerPortfolio(1), isTrue);
+      expect(canViewRankerPortfolio(100), isTrue);
+      // 101위 이상은 서버가 403 을 낸다. 요청 자체를 보내지 않는다.
+      expect(canViewRankerPortfolio(101), isFalse);
+    });
+  });
+}

--- a/mobile/test/regret_simulation_test.dart
+++ b/mobile/test/regret_simulation_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/features/regret/regret_simulation.dart';
+import 'package:trypto/models/enums.dart';
+import 'package:trypto/models/regret.dart';
+
+AssetHistoryPoint _point(double actual, double ruleFollowed, double btc) =>
+    AssetHistoryPoint(
+      snapshotDate: DateTime(2026, 7, 15),
+      actualAsset: actual,
+      ruleFollowedAsset: ruleFollowed,
+      btcHoldAsset: btc,
+    );
+
+ViolationDetail _violation(double profitLoss) => ViolationDetail(
+  violationDetailId: 1,
+  coinSymbol: 'BTC',
+  violatedRules: const [RuleType.chaseBuyBan],
+  profitLoss: profitLoss,
+  occurredAt: DateTime(2026, 7, 15),
+);
+
+void main() {
+  group('가중치', () {
+    test('5종의 합이 정확히 1.0 이다', () {
+      expect(totalRuleWeight(ruleImpactWeights.keys.toSet()), 1.0);
+    });
+
+    test('알 수 없는 규칙은 가중치가 0 이다', () {
+      expect(totalRuleWeight({RuleType.unknown}), 0);
+    });
+
+    test('부분 집합의 가중치를 더한다', () {
+      expect(
+        totalRuleWeight({RuleType.lossCut, RuleType.chaseBuyBan}),
+        closeTo(0.55, 1e-9),
+      );
+    });
+  });
+
+  group('simulationLine', () {
+    final history = [
+      _point(1000000, 1200000, 1100000),
+      _point(900000, 1300000, 1150000),
+    ];
+
+    test('전부 켜면 서버의 규칙 준수 곡선과 정확히 일치한다', () {
+      final line = simulationLine(history, ruleImpactWeights.keys.toSet());
+      expect(line, [1200000, 1300000]);
+    });
+
+    test('전부 끄면 실제 곡선과 같다', () {
+      expect(simulationLine(history, {}), [1000000, 900000]);
+    });
+
+    test('가중치 합만큼 선형 보간하고 반올림한다', () {
+      // 0.30 + 0.25 = 0.55
+      final line = simulationLine(history, {
+        RuleType.lossCut,
+        RuleType.chaseBuyBan,
+      });
+      // 1000000 + (1200000-1000000)*0.55 = 1110000
+      // 900000  + (1300000-900000)*0.55  = 1120000
+      expect(line, [1110000, 1120000]);
+    });
+
+    test('소수는 round 로 다듬는다', () {
+      final line = simulationLine(
+        [_point(100, 101, 0)],
+        {RuleType.averagingDownLimit}, // 0.10 → 100.1
+      );
+      expect(line, [100]);
+    });
+  });
+
+  group('btcHoldProfitRate', () {
+    test('첫 값과 마지막 값으로 수익률을 계산한다', () {
+      final rate = btcHoldProfitRate([
+        _point(0, 0, 1000000),
+        _point(0, 0, 1250000),
+      ]);
+      expect(rate, closeTo(25, 1e-9));
+    });
+
+    test('스냅샷이 2개 미만이면 계산하지 않는다', () {
+      expect(btcHoldProfitRate([_point(0, 0, 1000)]), isNull);
+      expect(btcHoldProfitRate([]), isNull);
+    });
+
+    test('시작 평가액이 0 이면 계산하지 않는다', () {
+      expect(btcHoldProfitRate([_point(0, 0, 0), _point(0, 0, 100)]), isNull);
+    });
+  });
+
+  group('labelTickInterval', () {
+    test('기간 구간별 라벨 간격', () {
+      expect(labelTickInterval(14), 1);
+      expect(labelTickInterval(15), 7);
+      expect(labelTickInterval(60), 7);
+      expect(labelTickInterval(61), 14);
+      expect(labelTickInterval(180), 14);
+      expect(labelTickInterval(181), 30);
+    });
+  });
+
+  group('chartYRange', () {
+    test('표시 중인 모든 시리즈의 min/max 에 10% 패딩을 덧댄다', () {
+      final range = chartYRange([
+        [100, 200],
+        [50, 150],
+      ]);
+      // min 50, max 200 → 패딩 15
+      expect(range.min, closeTo(35, 1e-9));
+      expect(range.max, closeTo(215, 1e-9));
+    });
+
+    test('범위가 0 이면 패딩은 1 이다', () {
+      final range = chartYRange([
+        [100, 100],
+      ]);
+      expect(range.min, 99);
+      expect(range.max, 101);
+    });
+
+    test('데이터가 없으면 기본 범위를 준다', () {
+      final range = chartYRange([]);
+      expect(range.min, 0);
+      expect(range.max, 1);
+    });
+  });
+
+  group('filterViolations', () {
+    final violations = [_violation(-1000), _violation(0), _violation(2000)];
+
+    test('profitLoss == 0 은 수익으로 분류된다', () {
+      expect(filterViolations(violations, ViolationFilter.profit).length, 2);
+      expect(filterViolations(violations, ViolationFilter.loss).length, 1);
+      expect(filterViolations(violations, ViolationFilter.all).length, 3);
+    });
+
+    test('정렬하지 않고 서버 순서를 유지한다', () {
+      final all = filterViolations(violations, ViolationFilter.all);
+      expect(all.map((v) => v.profitLoss), [-1000, 0, 2000]);
+    });
+  });
+}

--- a/mobile/test/round_rules_test.dart
+++ b/mobile/test/round_rules_test.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/core/constants/exchanges.dart';
+import 'package:trypto/features/round/round_rules.dart';
+import 'package:trypto/models/enums.dart';
+
+/// 서버가 400 이 아니라 500 을 내는 입력(R8)과, 웹이 제출 시점까지 미루는 검증을
+/// 입력 단계에서 잡는지 고정한다.
+void main() {
+  RoundDraft draft({
+    int seed = 10000000,
+    int emergencyLimit = 500000,
+    Map<RuleType, int> rules = const {RuleType.chaseBuyBan: 15},
+  }) => RoundDraft(seed: seed, emergencyLimit: emergencyLimit, rules: rules);
+
+  group('시드머니 범위 (국내 100만 ~ 5,000만)', () {
+    test('0 은 배정 안 함이라 범위 검사를 건너뛴다', () {
+      expect(SeedPolicy.validate(ExchangeIds.upbit, 0), isNull);
+    });
+
+    test('경계값은 통과한다', () {
+      expect(SeedPolicy.validate(ExchangeIds.upbit, 1000000), isNull);
+      expect(SeedPolicy.validate(ExchangeIds.bithumb, 50000000), isNull);
+    });
+
+    test('경계 밖은 막는다', () {
+      expect(SeedPolicy.validate(ExchangeIds.upbit, 999999), isNotNull);
+      expect(SeedPolicy.validate(ExchangeIds.upbit, 50000001), isNotNull);
+    });
+  });
+
+  group('시드머니 범위 (해외 100 ~ 50,000)', () {
+    test('바이낸스는 USDT 기준 범위를 쓴다', () {
+      expect(SeedPolicy.validate(ExchangeIds.binance, 100), isNull);
+      expect(SeedPolicy.validate(ExchangeIds.binance, 50000), isNull);
+      expect(SeedPolicy.validate(ExchangeIds.binance, 99), isNotNull);
+      expect(SeedPolicy.validate(ExchangeIds.binance, 50001), isNotNull);
+    });
+
+    test('국내 판별은 기준통화로 한다', () {
+      expect(SeedPolicy.isDomestic(ExchangeIds.upbit), isTrue);
+      expect(SeedPolicy.isDomestic(ExchangeIds.bithumb), isTrue);
+      expect(SeedPolicy.isDomestic(ExchangeIds.binance), isFalse);
+    });
+  });
+
+  group('긴급 자금 상한 (0 초과 ~ 100만)', () {
+    test('100만원 초과는 입력 단계에서 막는다', () {
+      expect(EmergencyFundingPolicy.validate(1000001), '긴급 자금 상한은 100만원입니다.');
+    });
+
+    test('0 이하는 제출 조건을 채우지 못한다', () {
+      expect(EmergencyFundingPolicy.validate(0), isNotNull);
+    });
+
+    test('상한값 자체는 통과한다', () {
+      expect(EmergencyFundingPolicy.validate(1000000), isNull);
+    });
+  });
+
+  group('제출 조건 — seed > 0 && emergencyLimit > 0 && 활성 규칙 >= 1', () {
+    test('셋을 모두 채우면 제출할 수 있다', () {
+      expect(draft().canSubmit, isTrue);
+    });
+
+    test('시드머니가 없으면 막는다', () {
+      expect(draft(seed: 0).canSubmit, isFalse);
+      expect(draft(seed: 0).seedError, '시드머니를 입력해 주세요.');
+    });
+
+    test('시드머니가 범위 밖이면 막는다', () {
+      expect(draft(seed: 60000000).canSubmit, isFalse);
+    });
+
+    test('긴급 자금 상한이 100만원을 넘으면 막는다', () {
+      expect(draft(emergencyLimit: 2000000).canSubmit, isFalse);
+    });
+
+    test('활성 규칙이 하나도 없으면 막는다', () {
+      final empty = draft(rules: const {});
+      expect(empty.canSubmit, isFalse);
+      expect(empty.rulesError, isNotNull);
+    });
+  });
+
+  group('요청 조립', () {
+    /// 중첩 DTO 는 `toJson()` 이 인스턴스 그대로 담고 `jsonEncode` 가 펼친다. 실제 바디를
+    /// 검사해야 계약이 고정된다.
+    Map<String, dynamic> body(RoundDraft draft) =>
+        jsonDecode(jsonEncode(draft.toRequest().toJson()))
+            as Map<String, dynamic>;
+
+    test('시드는 거래소 3개로 펼치고 업비트에 전액을 싣는다', () {
+      final json = body(draft(seed: 10000000));
+      expect(json['seeds'], [
+        {'exchangeId': ExchangeIds.upbit, 'amount': 10000000.0},
+        {'exchangeId': ExchangeIds.bithumb, 'amount': 0.0},
+        {'exchangeId': ExchangeIds.binance, 'amount': 0.0},
+      ]);
+      expect(json['emergencyFundingLimit'], 500000.0);
+    });
+
+    test('userId 를 보내지 않는다', () {
+      expect(body(draft()).containsKey('userId'), isFalse);
+    });
+
+    test('같은 ruleType 은 두 번 실리지 않는다 (서버가 500 을 낸다)', () {
+      final rules = draft(
+        rules: const {
+          RuleType.chaseBuyBan: 15,
+          RuleType.averagingDownLimit: 3,
+          RuleType.overtradingLimit: 10,
+        },
+      ).toRequest().rules;
+
+      final types = rules.map((rule) => rule.ruleType).toList();
+      expect(types.toSet().length, types.length);
+      expect(types.length, 3);
+    });
+
+    test('임계값과 ruleType 와이어 값을 그대로 싣는다', () {
+      final json = body(draft(rules: const {RuleType.overtradingLimit: 7}));
+      expect(json['rules'], [
+        {'ruleType': 'OVERTRADING_LIMIT', 'thresholdValue': 7.0},
+      ]);
+    });
+  });
+
+  group('규칙 설정표 (사양서 §7.3.2)', () {
+    test('생성 화면이 제시하는 것은 판정 로직이 있는 3종뿐이다', () {
+      expect(
+        ruleConfigs.map((config) => config.ruleType).toList(),
+        RuleType.selectable,
+      );
+    });
+
+    test('기본값·범위·입력 방식이 규칙 표와 같다', () {
+      final byType = {
+        for (final config in ruleConfigs) config.ruleType: config,
+      };
+
+      final chase = byType[RuleType.chaseBuyBan]!;
+      expect([chase.defaultValue, chase.min, chase.max], [15, 1, 50]);
+      expect(chase.input, RuleInputKind.slider);
+      expect(chase.unit, '%');
+
+      final averaging = byType[RuleType.averagingDownLimit]!;
+      expect([averaging.defaultValue, averaging.min, averaging.max], [3, 1, 10]);
+      expect(averaging.input, RuleInputKind.stepper);
+
+      final overtrading = byType[RuleType.overtradingLimit]!;
+      expect([
+        overtrading.defaultValue,
+        overtrading.min,
+        overtrading.max,
+      ], [10, 1, 50]);
+      expect(overtrading.unit, '회/일');
+    });
+
+    test('입력값은 범위로 clamp 한다', () {
+      final averaging = ruleConfigs.firstWhere(
+        (config) => config.ruleType == RuleType.averagingDownLimit,
+      );
+      expect(averaging.clamp(0), 1);
+      expect(averaging.clamp(99), 10);
+      expect(averaging.clamp(5), 5);
+    });
+
+    test('표시 라벨은 손절·익절까지 5종을 모두 갖는다', () {
+      for (final type in RuleType.values) {
+        expect(ruleLabels[type], isNotNull, reason: type.wire);
+        expect(ruleUnits[type], isNotNull, reason: type.wire);
+      }
+    });
+  });
+}

--- a/mobile/test/round_rules_test.dart
+++ b/mobile/test/round_rules_test.dart
@@ -59,6 +59,34 @@ void main() {
     });
   });
 
+  group('긴급 자금 투입 금액 (0 < amount <= limit)', () {
+    test('상한을 넘으면 입력 단계에서 막는다', () {
+      expect(
+        EmergencyFundingPolicy.validateCharge(1000001, 1000000),
+        '상한을 초과했습니다. 1,000,000원 이하로 입력해주세요.',
+      );
+    });
+
+    test('상한값과 0 초과 경계는 통과한다', () {
+      expect(EmergencyFundingPolicy.validateCharge(1000000, 1000000), isNull);
+      expect(EmergencyFundingPolicy.validateCharge(1, 1000000), isNull);
+    });
+
+    test('0 이하는 막는다', () {
+      expect(EmergencyFundingPolicy.validateCharge(0, 1000000), isNotNull);
+      expect(EmergencyFundingPolicy.validateCharge(-1, 1000000), isNotNull);
+    });
+
+    test('상한이 0 인 라운드는 긴급 자금을 쓸 수 없다', () {
+      expect(EmergencyFundingPolicy.validateCharge(1000, 0), isNotNull);
+    });
+
+    test('프리셋은 상한의 25 / 50 / 100% 를 내림한 값이다', () {
+      expect(EmergencyFundingPolicy.presets(1000000), [250000, 500000, 1000000]);
+      expect(EmergencyFundingPolicy.presets(333333), [83333, 166666, 333333]);
+    });
+  });
+
   group('제출 조건 — seed > 0 && emergencyLimit > 0 && 활성 규칙 >= 1', () {
     test('셋을 모두 채우면 제출할 수 있다', () {
       expect(draft().canSubmit, isTrue);

--- a/mobile/test/router_boot_test.dart
+++ b/mobile/test/router_boot_test.dart
@@ -6,9 +6,12 @@ import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:trypto/app.dart';
 import 'package:trypto/core/api/api_client.dart';
 import 'package:trypto/core/auth/session_store.dart';
+import 'package:trypto/core/realtime/stomp_service.dart';
 import 'package:trypto/features/auth/login_page.dart';
 import 'package:trypto/features/market/market_page.dart';
 import 'package:trypto/features/round/round_create_page.dart';
+
+import 'support/fake_stomp.dart';
 
 /// 콜드 스타트 3경로. 가드 단위 테스트가 판별식을 고정한다면, 여기서는 **부팅 첫 프레임에
 /// redirect loop 가 나지 않는다**는 것을 실제 GoRouter 로 확인한다(6단위 완료 조건).
@@ -92,6 +95,7 @@ void main() {
           sessionStoreProvider.overrideWithValue(store),
           sessionExpiryProvider.overrideWithValue(expiry),
           dioProvider.overrideWithValue(dio),
+          stompServiceProvider.overrideWithValue(FakeStompService()),
         ],
         child: const TryptoApp(),
       ),

--- a/mobile/test/support/fake_stomp.dart
+++ b/mobile/test/support/fake_stomp.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+import 'package:trypto/core/realtime/stomp_service.dart';
+
+/// 실제 소켓을 열지 않는다. 구독 목적지를 노출하고 프레임을 손으로 밀어 넣는다.
+///
+/// 위젯 테스트에서 진짜 [StompService] 를 쓰면 WS 연결에 실패하고 백오프 타이머가 남아
+/// `A Timer is still pending` 으로 죽는다.
+class FakeStompService implements StompService {
+  final Map<String, StompFrameHandler> _handlers = {};
+
+  List<String> get destinations => _handlers.keys.toList();
+
+  void emit(String destination, String body) =>
+      _handlers[destination]?.call(body);
+
+  @override
+  bool get connected => true;
+
+  @override
+  void connect() {}
+
+  @override
+  VoidCallback subscribe(String destination, StompFrameHandler handler) {
+    _handlers[destination] = handler;
+    return () => _handlers.remove(destination);
+  }
+
+  @override
+  void forceReconnect() {}
+
+  @override
+  void dispose() => _handlers.clear();
+}

--- a/mobile/test/ticker_store_test.dart
+++ b/mobile/test/ticker_store_test.dart
@@ -1,0 +1,226 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/core/realtime/ticker_store.dart';
+import 'package:trypto/models/exchange_coin.dart';
+import 'package:trypto/models/ticker.dart';
+
+/// 성능 계약(계획서 §7-3). 프레임 드랍은 눈으로 회귀를 잡을 수 없다. 불변식을 고정한다.
+void main() {
+  ExchangeCoin coin(String symbol, {double price = 100}) => ExchangeCoin(
+    exchangeCoinId: 1,
+    coinId: 1,
+    coinSymbol: symbol,
+    coinName: symbol,
+    price: price,
+    changeRate: 0,
+    volume: 0,
+  );
+
+  Ticker tick(
+    String symbol, {
+    required double price,
+    required int timestamp,
+    double changeRate = 0,
+    double quoteTurnover = 0,
+  }) => Ticker(
+    coinId: 1,
+    symbol: symbol,
+    price: price,
+    changeRate: changeRate,
+    quoteTurnover: quoteTurnover,
+    timestamp: timestamp,
+  );
+
+  late TickerStore store;
+
+  setUp(() {
+    store = TickerStore()..switchExchange([coin('BTC'), coin('ETH')]);
+  });
+
+  tearDown(() => store.dispose());
+
+  testWidgets('1,000틱을 ingest 해도 flush 전에는 알림이 0회다', (tester) async {
+    var notifications = 0;
+    store.row('BTC')!.addListener(() => notifications++);
+
+    for (var i = 0; i < 1000; i++) {
+      store.ingest([tick('BTC', price: 100.0 + i, timestamp: i)]);
+    }
+    expect(notifications, 0);
+
+    await tester.pump();
+    expect(notifications, 1);
+  });
+
+  testWidgets('같은 프레임의 같은 심볼은 마지막 값만 남는다', (tester) async {
+    store.ingest([
+      tick('BTC', price: 100, timestamp: 1),
+      tick('BTC', price: 130, timestamp: 2),
+      tick('BTC', price: 110, timestamp: 3),
+    ]);
+    await tester.pump();
+
+    expect(store.row('BTC')!.value.price, 110);
+  });
+
+  testWidgets('목록 밖 심볼은 버린다', (tester) async {
+    var notifications = 0;
+    store.row('BTC')!.addListener(() => notifications++);
+
+    store.ingest([tick('DOGE', price: 1, timestamp: 1)]);
+    await tester.pump();
+
+    expect(store.row('DOGE'), isNull);
+    expect(notifications, 0);
+  });
+
+  testWidgets('값이 바뀌지 않은 심볼에는 알림이 가지 않는다', (tester) async {
+    store.ingest([tick('BTC', price: 100, timestamp: 1)]);
+    await tester.pump();
+
+    var notifications = 0;
+    store.row('BTC')!.addListener(() => notifications++);
+
+    // 같은 가격에 재체결 — tickedAt 은 바뀌지만 CoinRowState 는 같다.
+    store.ingest([tick('BTC', price: 100, timestamp: 2)]);
+    await tester.pump();
+
+    expect(notifications, 0);
+  });
+
+  testWidgets('리스너 없는 심볼은 플래시를 계산하지 않는다', (tester) async {
+    store.ingest([tick('BTC', price: 100, timestamp: 1)]);
+    await tester.pump();
+    store.ingest([tick('BTC', price: 120, timestamp: 2)]);
+    await tester.pump();
+
+    expect(store.flash('BTC')!.value, isNull);
+  });
+
+  testWidgets('플래시는 방향을 판정하고 100ms 뒤 스스로 꺼진다', (tester) async {
+    final flash = store.flash('BTC')!;
+    final seen = <FlashDir?>[];
+    flash.addListener(() => seen.add(flash.value));
+
+    store.ingest([tick('BTC', price: 100, timestamp: 1)]);
+    await tester.pump();
+    expect(flash.value, isNull, reason: '첫 틱은 직전 tickedAt 이 없어 깜빡이지 않는다');
+
+    store.ingest([tick('BTC', price: 120, timestamp: 2)]);
+    await tester.pump();
+    expect(flash.value, FlashDir.up);
+
+    store.ingest([tick('BTC', price: 90, timestamp: 3)]);
+    await tester.pump();
+    expect(flash.value, FlashDir.down);
+
+    // 같은 가격 재체결도 tickedAt 이 바뀌면 깜빡인다(사양서 §3.3.3).
+    store.ingest([tick('BTC', price: 90, timestamp: 4)]);
+    await tester.pump();
+    expect(flash.value, FlashDir.same);
+
+    // 틱이 끊겨도 잔여 플래시가 꺼진다 — 심볼별 Timer 없이 flush 루프가 쓸어 담는다.
+    await tester.pump(const Duration(milliseconds: 150));
+    expect(flash.value, isNull);
+    expect(seen.last, isNull);
+  });
+
+  testWidgets('거래소를 전환하면 버퍼와 notifier 가 비워진다', (tester) async {
+    store.ingest([tick('BTC', price: 100, timestamp: 1)]);
+    store.switchExchange([coin('XRP', price: 700)]);
+    await tester.pump();
+
+    expect(store.row('BTC'), isNull);
+    expect(store.row('XRP')!.value.price, 700);
+    expect(store.orderDirty, isFalse);
+  });
+
+  testWidgets('비활성 상태에서는 틱을 받지 않는다', (tester) async {
+    store.setActive(false);
+    var notifications = 0;
+    store.row('BTC')!.addListener(() => notifications++);
+
+    store.ingest([tick('BTC', price: 999, timestamp: 1)]);
+    await tester.pump();
+
+    expect(notifications, 0);
+    expect(store.row('BTC')!.value.price, 100);
+  });
+
+  testWidgets('관찰자는 매 틱 동기 호출되고 그리기 알림은 프레임당 1회다', (tester) async {
+    final observer = _RecordingObserver();
+    store.setRawObserver(observer);
+
+    store.ingest([
+      tick('BTC', price: 100, timestamp: 1),
+      tick('BTC', price: 130, timestamp: 2),
+    ]);
+    store.ingest([
+      tick('BTC', price: 90, timestamp: 3),
+      tick('BTC', price: 110, timestamp: 4),
+    ]);
+
+    // 접기는 프레임을 기다리지 않는다. 기다리면 한 프레임 안의 체결이 사라진다.
+    expect(observer.ticks.map((t) => t.price).toList(), [100, 130, 90, 110]);
+    expect(observer.frames, 0);
+
+    await tester.pump();
+    expect(observer.frames, 1);
+
+    store.clearRawObserver(observer);
+    store.ingest([tick('BTC', price: 500, timestamp: 5)]);
+    await tester.pump();
+    expect(observer.ticks.length, 4);
+    expect(observer.frames, 1);
+  });
+
+  testWidgets('관찰자를 등록하지 않으면 목록 경로는 그대로다', (tester) async {
+    var notifications = 0;
+    store.row('BTC')!.addListener(() => notifications++);
+
+    for (var i = 0; i < 500; i++) {
+      store.ingest([tick('BTC', price: 100.0 + i, timestamp: i)]);
+      store.ingest([tick('ETH', price: 50.0 + i, timestamp: i)]);
+    }
+    await tester.pump();
+
+    expect(notifications, 1);
+    expect(store.row('BTC')!.value.price, 599);
+    expect(store.row('ETH')!.value.price, 549);
+  });
+
+  test('decodeTickers 는 배열만 받아들이고 실패를 조용히 무시한다', () {
+    expect(decodeTickers('not json'), isEmpty);
+    expect(decodeTickers('{"symbol":"BTC"}'), isEmpty);
+    expect(decodeTickers('[]'), isEmpty);
+
+    final parsed = decodeTickers(
+      '[{"coinId":1,"symbol":"BTC","price":152340000,'
+      '"changeRate":0.0123,"quoteTurnover":8423199301.55,'
+      '"timestamp":1735689600123}]',
+    );
+    expect(parsed, hasLength(1));
+    expect(parsed.single.price, 152340000);
+    expect(parsed.single.timestamp, 1735689600123);
+  });
+
+  test('CoinRowState 의 ==/hashCode 는 성능 계약이다', () {
+    const a = CoinRowState(1, 2, 3);
+    const b = CoinRowState(1, 2, 3);
+    const c = CoinRowState(1, 2, 4);
+
+    expect(a, b);
+    expect(a.hashCode, b.hashCode);
+    expect(a, isNot(c));
+  });
+}
+
+class _RecordingObserver implements TickObserver {
+  final List<Ticker> ticks = [];
+  int frames = 0;
+
+  @override
+  void onTick(Ticker tick) => ticks.add(tick);
+
+  @override
+  void onFrame() => frames++;
+}

--- a/mobile/test/wallet_assets_test.dart
+++ b/mobile/test/wallet_assets_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/features/market/market_controller.dart';
+import 'package:trypto/features/wallet/transfer_wizard/transfer_draft.dart';
+import 'package:trypto/features/wallet/wallet_assets.dart';
+import 'package:trypto/models/exchange_coin.dart';
+import 'package:trypto/models/wallet.dart';
+
+CoinEntry _coin(int coinId, String symbol, String name, double price) =>
+    CoinEntry(
+      ExchangeCoin(
+        exchangeCoinId: coinId * 10,
+        coinId: coinId,
+        coinSymbol: symbol,
+        coinName: name,
+        price: price,
+        changeRate: 0,
+        volume: 0,
+      ),
+    );
+
+WalletBalances _balances(
+  List<CoinBalance> balances, {
+  double available = 0,
+  double locked = 0,
+  String base = 'KRW',
+}) => WalletBalances(
+  exchangeId: 1,
+  baseCurrencySymbol: base,
+  baseCurrencyAvailable: available,
+  baseCurrencyLocked: locked,
+  balances: balances,
+);
+
+final _coins = [
+  _coin(1, 'BTC', '비트코인', 50000000),
+  _coin(2, 'ETH', '이더리움', 3000000),
+  _coin(3, 'XRP', '리플', 700),
+];
+
+void main() {
+  group('buildWalletAssets', () {
+    test('코인 현재가는 상장 목록의 price 다 (웹은 0 고정 — R9-3)', () {
+      final assets = buildWalletAssets(
+        balances: _balances([
+          const CoinBalance(coinId: 1, available: 0.5, locked: 0),
+        ], available: 1000000),
+        coins: _coins,
+      );
+
+      final btc = assets.firstWhere((asset) => asset.symbol == 'BTC');
+      expect(btc.currentPrice, 50000000);
+      expect(btc.totalValue, 25000000);
+      // 총자산이 기준통화 잔고만 반영하는 웹의 결함(1,000,000)이 재현되지 않는다.
+      expect(totalAssetValue(assets), 26000000);
+    });
+
+    test('기준통화 행이 맨 앞이고 현재가는 1 이다', () {
+      final assets = buildWalletAssets(
+        balances: _balances(const [], available: 5000, locked: 1000),
+        coins: _coins,
+      );
+
+      final base = assets.first;
+      expect(base.isBase, isTrue);
+      expect(base.coinId, isNull);
+      expect(base.symbol, 'KRW');
+      expect(base.name, '원화');
+      expect(base.currentPrice, 1);
+      expect(base.total, 6000);
+      expect(base.totalValue, 6000);
+    });
+
+    test('잔고가 없는 상장 코인도 0 으로 포함한다', () {
+      final assets = buildWalletAssets(
+        balances: _balances(const []),
+        coins: _coins,
+      );
+
+      expect(assets, hasLength(4)); // 기준통화 + 코인 3
+      expect(assets.every((asset) => !asset.isBase ? !asset.hasBalance : true), isTrue);
+    });
+
+    test('코인은 평가액 내림차순이다', () {
+      final assets = buildWalletAssets(
+        balances: _balances(const [
+          CoinBalance(coinId: 1, available: 0.001, locked: 0), // 50,000
+          CoinBalance(coinId: 2, available: 1, locked: 0), // 3,000,000
+          CoinBalance(coinId: 3, available: 100, locked: 0), // 70,000
+        ]),
+        coins: _coins,
+      );
+
+      expect([for (final asset in assets) asset.symbol], [
+        'KRW',
+        'ETH',
+        'XRP',
+        'BTC',
+      ]);
+    });
+
+    test('잠금 잔고도 총 수량·평가액에 들어간다', () {
+      final assets = buildWalletAssets(
+        balances: _balances(const [
+          CoinBalance(coinId: 3, available: 100, locked: 50),
+        ]),
+        coins: _coins,
+      );
+
+      final xrp = assets.firstWhere((asset) => asset.symbol == 'XRP');
+      expect(xrp.total, 150);
+      expect(xrp.totalValue, 105000);
+    });
+  });
+
+  group('applyWalletFilter', () {
+    final assets = buildWalletAssets(
+      balances: _balances(const [
+        CoinBalance(coinId: 1, available: 0.5, locked: 0), // 25,000,000
+        CoinBalance(coinId: 3, available: 1, locked: 0), // 700 → 소액
+      ], available: 3000),
+      coins: _coins,
+    );
+
+    test('심볼·한글명·초성으로 찾는다', () {
+      expect(
+        [
+          for (final asset in applyWalletFilter(
+            assets,
+            query: 'btc',
+            baseCurrency: 'KRW',
+          ))
+            asset.symbol,
+        ],
+        ['BTC'],
+      );
+      expect(
+        [
+          for (final asset in applyWalletFilter(
+            assets,
+            query: '리플',
+            baseCurrency: 'KRW',
+          ))
+            asset.symbol,
+        ],
+        ['XRP'],
+      );
+      expect(
+        [
+          for (final asset in applyWalletFilter(
+            assets,
+            query: 'ㅂㅌ',
+            baseCurrency: 'KRW',
+          ))
+            asset.symbol,
+        ],
+        ['BTC'],
+      );
+    });
+
+    test('소액 제외는 평가액 1,000원 미만을 걷어낸다', () {
+      final filtered = applyWalletFilter(
+        assets,
+        hideSmall: true,
+        baseCurrency: 'KRW',
+      );
+
+      // XRP(700원)와 잔고 0 코인이 빠지고 기준통화·BTC 만 남는다.
+      expect([for (final asset in filtered) asset.symbol], ['KRW', 'BTC']);
+    });
+
+    test('검색어가 없으면 전량을 돌려준다', () {
+      expect(applyWalletFilter(assets, baseCurrency: 'KRW'), hasLength(4));
+    });
+  });
+
+  group('validateTransferAmount', () {
+    test('빈 입력·0·음수는 수량 오류다', () {
+      expect(validateTransferAmount('', 10), '수량을 입력해 주세요.');
+      expect(validateTransferAmount('0', 10), '수량을 입력해 주세요.');
+      expect(validateTransferAmount('abc', 10), '수량을 입력해 주세요.');
+    });
+
+    test('가용 잔고를 넘으면 막는다', () {
+      expect(validateTransferAmount('10.00000001', 10), '가용 잔고를 초과합니다.');
+      expect(validateTransferAmount('10', 10), isNull);
+      expect(validateTransferAmount('0.00000001', 10), isNull);
+    });
+
+    test('double 오차로 전액 출금이 막히지 않는다', () {
+      // 0.1 + 0.2 == 0.30000000000000004 이므로 double 비교였다면 통과하지 못한다.
+      expect(validateTransferAmount('0.3', 0.1 + 0.2), isNull);
+    });
+  });
+
+  group('transferAmountOfRatio', () {
+    test('최대는 잔고를 그대로 쓴다', () {
+      expect(transferAmountOfRatio(1.23456789, 1), '1.23456789');
+    });
+
+    test('비율은 8자리에서 내림한다 — 반올림하면 잔고를 넘을 수 있다', () {
+      expect(transferAmountOfRatio(1, 0.25), '0.25');
+      expect(transferAmountOfRatio(0.00000003, 0.5), '0.00000001');
+      expect(validateTransferAmount(transferAmountOfRatio(3.7, 0.5), 3.7), isNull);
+    });
+  });
+}

--- a/mobile/test/widget/candle_chart_test.dart
+++ b/mobile/test/widget/candle_chart_test.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/core/realtime/ticker_store.dart';
+import 'package:trypto/core/theme/theme.dart';
+import 'package:trypto/features/market/candle_chart.dart';
+import 'package:trypto/features/market/candle_painter.dart';
+import 'package:trypto/features/market/candle_repository.dart';
+import 'package:trypto/features/market/live_candles.dart';
+import 'package:trypto/models/candle.dart';
+import 'package:trypto/models/enums.dart';
+import 'package:trypto/models/exchange_coin.dart';
+import 'package:trypto/models/ticker.dart';
+
+/// 10단위 완료 조건 ⑤⑥: 과거로 패닝해 실시간 봉이 화면 밖이면 repaint 가 0이고, 새 봉이
+/// 열리고 15초 뒤 REST 재조회가 **정확히 1회** 나가며 보고 있던 구간이 그대로다.
+void main() {
+  const request = CandleRequest(
+    exchangeCode: 'UPBIT',
+    symbol: 'BTC',
+    interval: CandleInterval.minute1,
+  );
+
+  DateTime at(int minute, [int second = 0]) =>
+      DateTime(2026, 7, 15, 10, minute, second);
+
+  /// 10:00 ~ 11:29. 최초 표시 개수(1분봉 40개)보다 많아야 패닝할 여지가 생긴다.
+  List<Candle> server() => [
+    for (var minute = 0; minute < 90; minute++)
+      Candle(
+        time: at(minute),
+        open: 100 + minute.toDouble(),
+        high: 110 + minute.toDouble(),
+        low: 90 + minute.toDouble(),
+        close: 105 + minute.toDouble(),
+      ),
+  ];
+
+  Ticker tick(double price, DateTime time) => Ticker(
+    coinId: 1,
+    symbol: 'BTC',
+    price: price,
+    changeRate: 0,
+    quoteTurnover: 0,
+    timestamp: time.millisecondsSinceEpoch,
+  );
+
+  late _FakeCandleRepository repository;
+  late ProviderContainer container;
+  late TickerStore store;
+
+  setUp(() {
+    repository = _FakeCandleRepository(server());
+    container = ProviderContainer(
+      overrides: [candleRepositoryProvider.overrideWithValue(repository)],
+    );
+    store = container.read(tickerStoreProvider)
+      ..switchExchange([
+        const ExchangeCoin(
+          exchangeCoinId: 1,
+          coinId: 1,
+          coinSymbol: 'BTC',
+          coinName: '비트코인',
+          price: 100,
+          changeRate: 0,
+          volume: 0,
+        ),
+      ]);
+  });
+
+  tearDown(() => container.dispose());
+
+  CandlePainter painterOf(WidgetTester tester) => tester
+      .widgetList<CustomPaint>(find.byType(CustomPaint))
+      .map((paint) => paint.painter)
+      .whereType<CandlePainter>()
+      .first;
+
+  Future<void> pumpChart(WidgetTester tester) async {
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: buildTryptoTheme(),
+          home: const Scaffold(
+            body: CandleChart(request: request, baseCurrency: 'KRW'),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('진입 시 캔들을 한 번 조회하고 최신 봉을 추종한다', (tester) async {
+    await pumpChart(tester);
+
+    expect(repository.calls, 1);
+    final painter = painterOf(tester);
+    expect(painter.endIndex, 90);
+    expect(painter.startIndex, 50);
+    expect(painter.liveVisible, isFalse, reason: '실시간 봉이 아직 없다');
+  });
+
+  testWidgets('새 봉이 열리면 화면이 따라가고 실시간 봉이 보인다', (tester) async {
+    await pumpChart(tester);
+
+    store.ingest([tick(500, at(90, 5))]);
+    await tester.pump();
+
+    final painter = painterOf(tester);
+    expect(painter.endIndex, 91, reason: '추종 중이면 오른쪽 끝이 마지막 봉이다');
+    expect(painter.liveVisible, isTrue);
+    expect(painter.visible.last.close, 500);
+  });
+
+  testWidgets('과거로 패닝해 실시간 봉이 화면 밖이면 틱이 와도 repaint 가 0이다', (tester) async {
+    await pumpChart(tester);
+
+    await tester.drag(find.byType(CandleChart), const Offset(200, 0));
+    await tester.pump();
+
+    final panned = painterOf(tester);
+    expect(panned.endIndex, lessThan(90));
+
+    store.ingest([tick(500, at(90, 5))]);
+    await tester.pump();
+
+    final after = painterOf(tester);
+    expect(after.endIndex, panned.endIndex, reason: '보고 있는 구간은 흔들리지 않는다');
+    expect(after.liveVisible, isFalse);
+    expect(after.shouldRepaint(panned), isFalse);
+
+    // 같은 봉에 체결이 계속 쌓여도 마찬가지다.
+    final before = painterOf(tester);
+    for (var i = 0; i < 100; i++) {
+      store.ingest([tick(500.0 + i, at(90, 10 + i ~/ 10))]);
+    }
+    await tester.pump();
+    expect(painterOf(tester).shouldRepaint(before), isFalse);
+  });
+
+  testWidgets('새 봉이 열리고 15초 뒤 재조회가 정확히 1회 나가고 구간이 유지된다', (tester) async {
+    await pumpChart(tester);
+    await tester.drag(find.byType(CandleChart), const Offset(200, 0));
+    await tester.pump();
+    final panned = painterOf(tester);
+
+    store.ingest([tick(500, at(90, 5))]);
+    await tester.pump();
+
+    // 같은 봉 안의 체결은 타이머를 다시 걸지 않는다.
+    for (var i = 0; i < 50; i++) {
+      store.ingest([tick(500.0 + i, at(90, 10 + i ~/ 10))]);
+    }
+    await tester.pump(const Duration(seconds: 10));
+    expect(repository.calls, 1, reason: '아직 15초가 지나지 않았다');
+
+    await tester.pump(const Duration(seconds: 6));
+    await tester.pumpAndSettle();
+
+    expect(repository.calls, 2);
+    final reconciled = painterOf(tester);
+    expect(reconciled.endIndex, panned.endIndex);
+    expect(reconciled.startIndex, panned.startIndex);
+  });
+
+  testWidgets('재조회가 빈 배열을 주면 실시간 봉이 자리를 지킨다', (tester) async {
+    await pumpChart(tester);
+    store.ingest([tick(500, at(90, 5))]);
+    await tester.pump();
+
+    repository.candles = const [];
+    await tester.pump(const Duration(seconds: 16));
+    await tester.pumpAndSettle();
+
+    expect(repository.calls, 2);
+    final painter = painterOf(tester);
+    expect(painter.endIndex, 91);
+    expect(painter.visible.last.close, 500);
+  });
+}
+
+class _FakeCandleRepository implements CandleRepository {
+  _FakeCandleRepository(this.candles);
+
+  List<Candle> candles;
+  int calls = 0;
+
+  @override
+  Future<List<Candle>> getCandles({
+    required String exchange,
+    required String coin,
+    required CandleInterval interval,
+    int? limit,
+    DateTime? cursor,
+  }) async {
+    calls++;
+    return normalizeCandles(candles, interval);
+  }
+}

--- a/mobile/test/widget/coin_row_isolation_test.dart
+++ b/mobile/test/widget/coin_row_isolation_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/core/realtime/ticker_store.dart';
+import 'package:trypto/core/theme/theme.dart';
+import 'package:trypto/features/market/coin_row.dart';
+import 'package:trypto/models/exchange_coin.dart';
+import 'package:trypto/models/ticker.dart';
+
+/// 설계의 핵심 주장을 코드로 못 박는 유일한 장치(계획서 §7-7).
+///
+/// 한 심볼에만 틱이 오면 **그 행의 숫자 위젯만 다시 만들어진다.** 위젯 인스턴스는 빌드마다
+/// 새로 생성되므로, 인스턴스 동일성이 곧 "리빌드하지 않았다"는 증거다.
+void main() {
+  ExchangeCoin coin(String symbol, double price) => ExchangeCoin(
+    exchangeCoinId: 1,
+    coinId: 1,
+    coinSymbol: symbol,
+    coinName: symbol,
+    price: price,
+    changeRate: 0,
+    volume: 1000,
+  );
+
+  Ticker tick(String symbol, double price, int timestamp) => Ticker(
+    coinId: 1,
+    symbol: symbol,
+    price: price,
+    changeRate: 0.01,
+    quoteTurnover: 2000,
+    timestamp: timestamp,
+  );
+
+  late TickerStore store;
+
+  setUp(() {
+    store = TickerStore()
+      ..switchExchange([coin('BTC', 100000), coin('ETH', 5000)]);
+  });
+
+  tearDown(() => store.dispose());
+
+  CoinNumbers numbersOf(WidgetTester tester, String symbol) => tester.widget<CoinNumbers>(
+    find.descendant(
+      of: find.byWidgetPredicate(
+        (widget) => widget is CoinRow && widget.symbol == symbol,
+      ),
+      matching: find.byType(CoinNumbers),
+    ),
+  );
+
+  Future<void> pumpRows(WidgetTester tester) => tester.pumpWidget(
+    MaterialApp(
+      theme: buildTryptoTheme(),
+      home: Scaffold(
+        body: ListView(
+          itemExtent: kCoinRowHeight,
+          children: [
+            for (final symbol in ['BTC', 'ETH'])
+              CoinRow(
+                symbol: symbol,
+                name: symbol,
+                row: store.row(symbol)!,
+                flash: store.flash(symbol)!,
+                baseCurrency: 'KRW',
+              ),
+          ],
+        ),
+      ),
+    ),
+  );
+
+  testWidgets('틱이 온 행의 숫자만 다시 빌드되고 이웃 행은 그대로다', (tester) async {
+    await pumpRows(tester);
+
+    final btcBefore = numbersOf(tester, 'BTC');
+    final ethBefore = numbersOf(tester, 'ETH');
+
+    store.ingest([tick('BTC', 123456, 1)]);
+    await tester.pump();
+
+    final btcAfter = numbersOf(tester, 'BTC');
+    final ethAfter = numbersOf(tester, 'ETH');
+
+    expect(identical(btcBefore, btcAfter), isFalse);
+    expect(identical(ethBefore, ethAfter), isTrue);
+    expect(btcAfter.price, 123456);
+    expect(find.text('₩123,456'), findsOneWidget);
+  });
+
+  testWidgets('플래시 테두리는 숫자 위젯을 다시 만들지 않는다', (tester) async {
+    await pumpRows(tester);
+
+    store.ingest([tick('BTC', 123456, 1)]);
+    await tester.pump();
+
+    final numbers = numbersOf(tester, 'BTC');
+    expect(store.flash('BTC')!.value, isNull);
+
+    // 같은 가격에 재체결 — 숫자는 그대로이고 테두리만 깜빡인다.
+    store.ingest([tick('BTC', 123456, 2)]);
+    await tester.pump();
+
+    expect(store.flash('BTC')!.value, FlashDir.same);
+    expect(identical(numbers, numbersOf(tester, 'BTC')), isTrue);
+
+    await tester.pump(const Duration(milliseconds: 150));
+    expect(store.flash('BTC')!.value, isNull);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/mobile/test/widget/emergency_funding_test.dart
+++ b/mobile/test/widget/emergency_funding_test.dart
@@ -1,0 +1,224 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+import 'package:trypto/app.dart';
+import 'package:trypto/core/api/api_client.dart';
+import 'package:trypto/core/auth/session_store.dart';
+import 'package:trypto/core/realtime/stomp_service.dart';
+import 'package:trypto/features/round/emergency_funding_sheet.dart';
+
+import '../support/fake_stomp.dart';
+
+/// 12단위 완료 조건: 3회를 모두 쓰면 버튼이 비활성된다.
+/// 상한(100만원) 초과는 **입력 단계에서** 막는다 — 웹은 제출 시점에 실패하고도 아무 말이 없다.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SessionStore store;
+  late SessionExpiryNotifier expiry;
+  late Dio dio;
+  late DioAdapter adapter;
+  late FakeStompService stomp;
+  late List<RequestOptions> requests;
+
+  Map<String, dynamic> envelope(Object? data) => {
+    'status': 200,
+    'code': 'SUCCESS',
+    'message': '',
+    'data': data,
+  };
+
+  void stubRound({required int chargeCount}) {
+    adapter.onGet(
+      '/api/rounds/active',
+      (server) => server.reply(
+        200,
+        envelope({
+          'roundId': 10,
+          'userId': 1,
+          'roundNumber': 1,
+          'status': 'ACTIVE',
+          'initialSeed': 10000000.0,
+          'emergencyFundingLimit': 1000000.0,
+          'emergencyChargeCount': chargeCount,
+          'startedAt': '2026-07-01T09:00:00',
+          'endedAt': null,
+          'rules': <Object>[],
+          'wallets': [
+            {'walletId': 100, 'exchangeId': 1},
+          ],
+        }),
+      ),
+    );
+  }
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+    store = SessionStore();
+    expiry = SessionExpiryNotifier();
+    stomp = FakeStompService();
+    requests = [];
+    dio = buildDio(store: store, expiry: expiry, baseUrl: 'http://test.local');
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          requests.add(options);
+          handler.next(options);
+        },
+      ),
+    );
+    adapter = DioAdapter(dio: dio);
+
+    adapter
+      ..onGet(
+        '/api/users/me',
+        (server) => server.reply(
+          200,
+          envelope({
+            'userId': 1,
+            'nickname': '테스터',
+            'createdAt': '2026-07-01T09:00:00',
+          }),
+        ),
+      )
+      ..onGet(
+        '/api/rounds/summary',
+        (server) => server.reply(200, envelope({'totalRoundCount': 1})),
+      )
+      ..onGet(
+        '/api/exchanges/1/coins',
+        (server) => server.reply(
+          200,
+          envelope([
+            {
+              'exchangeCoinId': 1,
+              'coinId': 1,
+              'coinSymbol': 'BTC',
+              'coinName': '비트코인',
+              'price': 96000000.0,
+              'changeRate': 0.01,
+              'volume': 1e11,
+            },
+          ]),
+        ),
+      );
+  });
+
+  Finder inSheet(Finder matching) => find.descendant(
+    of: find.byType(EmergencyFundingSheet),
+    matching: matching,
+  );
+
+  Future<void> pumpMarket(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 3;
+    addTearDown(tester.view.reset);
+
+    await store.save('session-id');
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sessionStoreProvider.overrideWithValue(store),
+          sessionExpiryProvider.overrideWithValue(expiry),
+          dioProvider.overrideWithValue(dio),
+          stompServiceProvider.overrideWithValue(stomp),
+        ],
+        child: const TryptoApp(),
+      ),
+    );
+    for (var i = 0; i < 10; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('배너에 남은 횟수가 뜨고 상한 초과는 확정 버튼을 막는다', (tester) async {
+    stubRound(chargeCount: 3);
+    await pumpMarket(tester);
+
+    expect(find.text('긴급 자금 · 남은 횟수 3회'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(FilledButton, '투입'));
+    await tester.pumpAndSettle();
+    expect(find.byType(EmergencyFundingSheet), findsOneWidget);
+
+    final confirm = find.widgetWithText(FilledButton, '투입 확정');
+    // 아무것도 넣지 않으면 비활성이다.
+    expect(tester.widget<FilledButton>(confirm).onPressed, isNull);
+
+    await tester.enterText(inSheet(find.byType(TextField)), '1000001');
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('상한을 초과했습니다. 1,000,000원 이하로 입력해주세요.'),
+      findsOneWidget,
+    );
+    expect(tester.widget<FilledButton>(confirm).onPressed, isNull);
+    // 상한 초과는 네트워크 호출 없이 막는다.
+    expect(
+      requests.any((request) => request.path.contains('emergency-funding')),
+      isFalse,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('프리셋으로 투입하면 남은 횟수가 줄고 성공을 알린다', (tester) async {
+    stubRound(chargeCount: 3);
+    adapter.onPost(
+      '/api/rounds/10/emergency-funding',
+      (server) => server.reply(
+        200,
+        envelope({
+          'roundId': 10,
+          'exchangeId': 1,
+          'chargedAmount': 500000.0,
+          'remainingChargeCount': 2,
+        }),
+      ),
+      data: Matchers.any,
+    );
+
+    await pumpMarket(tester);
+    await tester.tap(find.widgetWithText(FilledButton, '투입'));
+    await tester.pumpAndSettle();
+
+    // 프리셋은 상한의 25% / 50% / 100%.
+    await tester.tap(find.widgetWithText(OutlinedButton, '50만'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, '투입 확정'));
+    await tester.pumpAndSettle();
+
+    final body = requests
+        .lastWhere((request) => request.path.contains('emergency-funding'))
+        .data as Map<String, dynamic>;
+    expect(body['exchangeId'], 1);
+    expect(body['amount'], 500000.0);
+    // 멱등키는 UUID v4 필수 — 형식이 틀리면 서버가 500 을 낸다.
+    expect(
+      body['idempotencyKey'],
+      matches(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+      ),
+    );
+
+    expect(find.byType(EmergencyFundingSheet), findsNothing);
+    expect(find.text('50만원을 투입했습니다.'), findsOneWidget);
+    expect(find.text('긴급 자금 · 남은 횟수 2회'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('3회를 모두 쓰면 배너 버튼이 비활성된다', (tester) async {
+    stubRound(chargeCount: 0);
+    await pumpMarket(tester);
+
+    expect(find.text('긴급 자금 · 3회를 모두 사용했습니다'), findsOneWidget);
+    expect(
+      tester.widget<FilledButton>(find.widgetWithText(FilledButton, '투입')).onPressed,
+      isNull,
+    );
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/mobile/test/widget/market_page_test.dart
+++ b/mobile/test/widget/market_page_test.dart
@@ -1,0 +1,224 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+import 'package:trypto/app.dart';
+import 'package:trypto/core/api/api_client.dart';
+import 'package:trypto/core/auth/session_store.dart';
+import 'package:trypto/features/market/coin_row.dart';
+import 'package:trypto/features/market/coin_search_field.dart';
+import 'package:trypto/features/market/market_controller.dart';
+import 'package:trypto/features/market/market_page.dart';
+
+/// 8단위 완료 조건: WS 없이 REST 스냅샷만으로 600행 목록이 뜨고 검색·필터·정렬이 동작한다.
+/// 레이아웃 오버플로도 여기서 잡힌다(`takeException`).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SessionStore store;
+  late SessionExpiryNotifier expiry;
+  late Dio dio;
+  late DioAdapter adapter;
+
+  Map<String, dynamic> envelope(Object? data) => {
+    'status': 200,
+    'code': 'SUCCESS',
+    'message': '',
+    'data': data,
+  };
+
+  Map<String, dynamic> coin(
+    int id,
+    String symbol,
+    String name, {
+    required double price,
+    required double changeRate,
+    required double volume,
+  }) => {
+    'exchangeCoinId': id,
+    'coinId': id,
+    'coinSymbol': symbol,
+    'coinName': name,
+    'price': price,
+    'changeRate': changeRate,
+    'volume': volume,
+  };
+
+  /// 이름 있는 4개 + 이름 없는 596개 = 600행.
+  List<Map<String, dynamic>> coins() => [
+    coin(1, 'BTC', '비트코인', price: 96000000, changeRate: 0.012, volume: 9e11),
+    coin(2, 'ETH', '이더리움', price: 5300000, changeRate: -0.004, volume: 5e11),
+    coin(3, 'SOL', '솔라나', price: 280000, changeRate: 0.031, volume: 3e11),
+    coin(4, 'XRP', '리플', price: 0, changeRate: 0, volume: 0),
+    for (var i = 5; i <= 600; i++)
+      coin(
+        i,
+        'C$i',
+        '코인$i',
+        price: i.toDouble(),
+        changeRate: i.isEven ? 0.01 : -0.01,
+        volume: i.toDouble(),
+      ),
+  ];
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+    store = SessionStore();
+    expiry = SessionExpiryNotifier();
+    dio = buildDio(store: store, expiry: expiry, baseUrl: 'http://test.local');
+    adapter = DioAdapter(dio: dio);
+
+    adapter
+      ..onGet(
+        '/api/users/me',
+        (server) => server.reply(
+          200,
+          envelope({
+            'userId': 1,
+            'nickname': '테스터',
+            'createdAt': '2026-07-01T09:00:00',
+          }),
+        ),
+      )
+      ..onGet(
+        '/api/rounds/active',
+        (server) => server.reply(
+          200,
+          envelope({
+            'roundId': 10,
+            'userId': 1,
+            'roundNumber': 1,
+            'status': 'ACTIVE',
+            'initialSeed': 10000000.0,
+            'emergencyFundingLimit': 1000000.0,
+            'emergencyChargeCount': 3,
+            'startedAt': '2026-07-01T09:00:00',
+            'endedAt': null,
+            'rules': <Object>[],
+            'wallets': [
+              {'walletId': 100, 'exchangeId': 1},
+            ],
+          }),
+        ),
+      )
+      ..onGet(
+        '/api/rounds/summary',
+        (server) => server.reply(200, envelope({'totalRoundCount': 1})),
+      )
+      ..onGet(
+        '/api/exchanges/1/coins',
+        (server) => server.reply(200, envelope(coins())),
+      );
+  });
+
+  Future<void> pumpMarket(WidgetTester tester) async {
+    await store.save('session-id');
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sessionStoreProvider.overrideWithValue(store),
+          sessionExpiryProvider.overrideWithValue(expiry),
+          dioProvider.overrideWithValue(dio),
+        ],
+        child: const TryptoApp(),
+      ),
+    );
+
+    // 부팅(인증 복구 → 라운드 조회 → /market).
+    for (var i = 0; i < 10; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    // 600행 응답은 50KB 를 넘어 dio 가 **백그라운드 아이솔레이트**에서 디코딩한다. fake async
+    // 로는 완료되지 않으므로 실제 비동기 구간을 열어 준다. (프로덕션에서는 이 오프로딩 덕에
+    // 목록 디코딩이 UI 스레드를 멈추지 않는다.)
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 300)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MarketPage), findsOneWidget);
+  }
+
+  /// 화면에 실제로 만들어진 행의 심볼. `itemExtent` 덕에 보이는 만큼만 빌드된다.
+  List<String> renderedSymbols(WidgetTester tester) => tester
+      .widgetList<CoinRow>(find.byType(CoinRow))
+      .map((row) => row.symbol)
+      .toList();
+
+  testWidgets('스냅샷 600행이 거래대금 내림차순으로 뜬다', (tester) async {
+    await pumpMarket(tester);
+
+    final symbols = renderedSymbols(tester);
+    expect(symbols, isNotEmpty);
+    expect(symbols.take(3).toList(), ['BTC', 'ETH', 'SOL']);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('시세가 없는 코인은 현재가·거래대금을 - 로 표시한다', (tester) async {
+    await pumpMarket(tester);
+
+    await tester.enterText(find.byType(CoinSearchField), 'XRP');
+    await tester.pumpAndSettle();
+
+    // 현재가·전일대비(가격 0) + 거래대금(0) = 3칸.
+    expect(renderedSymbols(tester), ['XRP']);
+    expect(find.text('-'), findsNWidgets(3));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('초성으로 검색한다', (tester) async {
+    await pumpMarket(tester);
+
+    await tester.enterText(find.byType(CoinSearchField), 'ㅂㅌ');
+    await tester.pumpAndSettle();
+
+    expect(renderedSymbols(tester), ['BTC']);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('검색 결과가 없으면 빈 상태를 보여준다', (tester) async {
+    await pumpMarket(tester);
+
+    await tester.enterText(find.byType(CoinSearchField), '없는코인');
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CoinRow), findsNothing);
+    expect(find.text('검색 결과가 없습니다.'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('하락 필터는 내린 코인만 남긴다', (tester) async {
+    await pumpMarket(tester);
+
+    await tester.tap(find.widgetWithText(ChoiceChip, '하락'));
+    await tester.pumpAndSettle();
+
+    final symbols = renderedSymbols(tester);
+    expect(symbols, isNotEmpty);
+    expect(symbols, isNot(contains('BTC')));
+    expect(symbols.first, 'ETH');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('정렬 키를 바꾸면 목록 순서가 바뀐다', (tester) async {
+    await pumpMarket(tester);
+
+    await tester.tap(find.byType(PopupMenuButton<MarketSortKey>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('현재가').last);
+    await tester.pumpAndSettle();
+
+    expect(renderedSymbols(tester).first, 'BTC');
+
+    // 같은 키를 다시 누르면 방향만 뒤집는다 → 최저가가 맨 위로 온다.
+    await tester.tap(find.byType(PopupMenuButton<MarketSortKey>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('현재가').last);
+    await tester.pumpAndSettle();
+
+    expect(renderedSymbols(tester).first, 'XRP');
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/mobile/test/widget/market_page_test.dart
+++ b/mobile/test/widget/market_page_test.dart
@@ -7,13 +7,18 @@ import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:trypto/app.dart';
 import 'package:trypto/core/api/api_client.dart';
 import 'package:trypto/core/auth/session_store.dart';
+import 'package:trypto/core/realtime/stomp_service.dart';
 import 'package:trypto/features/market/coin_row.dart';
 import 'package:trypto/features/market/coin_search_field.dart';
 import 'package:trypto/features/market/market_controller.dart';
 import 'package:trypto/features/market/market_page.dart';
 
+import '../support/fake_stomp.dart';
+
 /// 8단위 완료 조건: WS 없이 REST 스냅샷만으로 600행 목록이 뜨고 검색·필터·정렬이 동작한다.
 /// 레이아웃 오버플로도 여기서 잡힌다(`takeException`).
+///
+/// 9단위: 토픽 구독이 거래소당 하나이고, 틱이 목록의 숫자와(1초 스로틀 뒤) 정렬을 바꾼다.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -21,6 +26,7 @@ void main() {
   late SessionExpiryNotifier expiry;
   late Dio dio;
   late DioAdapter adapter;
+  late FakeStompService stomp;
 
   Map<String, dynamic> envelope(Object? data) => {
     'status': 200,
@@ -67,6 +73,7 @@ void main() {
     FlutterSecureStorage.setMockInitialValues({});
     store = SessionStore();
     expiry = SessionExpiryNotifier();
+    stomp = FakeStompService();
     dio = buildDio(store: store, expiry: expiry, baseUrl: 'http://test.local');
     adapter = DioAdapter(dio: dio);
 
@@ -121,6 +128,7 @@ void main() {
           sessionStoreProvider.overrideWithValue(store),
           sessionExpiryProvider.overrideWithValue(expiry),
           dioProvider.overrideWithValue(dio),
+          stompServiceProvider.overrideWithValue(stomp),
         ],
         child: const TryptoApp(),
       ),
@@ -221,4 +229,43 @@ void main() {
     expect(renderedSymbols(tester).first, 'XRP');
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('티커 토픽은 거래소당 하나만 구독한다', (tester) async {
+    await pumpMarket(tester);
+
+    expect(stomp.destinations, ['/topic/tickers.1']);
+  });
+
+  testWidgets('틱은 숫자를 즉시 바꾸고 정렬은 1초 스로틀 뒤에 따라온다', (tester) async {
+    await pumpMarket(tester);
+    expect(renderedSymbols(tester).take(2).toList(), ['BTC', 'ETH']);
+
+    // ETH 의 거래대금이 BTC 를 앞지른다.
+    stomp.emit(
+      '/topic/tickers.1',
+      '[{"coinId":2,"symbol":"ETH","price":5555555,"changeRate":0.02,'
+          '"quoteTurnover":9.9e11,"timestamp":1735689600123}]',
+    );
+    await tester.pump();
+
+    // 숫자는 그 프레임에 바뀐다. 목록 행과 주요 코인 카드가 같은 notifier 를 구독한다.
+    expect(find.text('₩5,555,555'), findsNWidgets(2));
+    // 자리는 아직 바뀌지 않는다 — 초당 60번 자리를 바꾸는 목록은 읽을 수 없다.
+    expect(renderedSymbols(tester).take(2).toList(), ['BTC', 'ETH']);
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(renderedSymbols(tester).take(2).toList(), ['ETH', 'BTC']);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('다른 탭으로 나가면 구독을 해제한다', (tester) async {
+    await pumpMarket(tester);
+    expect(stomp.destinations, isNotEmpty);
+
+    await tester.tap(find.text('랭킹'));
+    await tester.pumpAndSettle();
+
+    expect(stomp.destinations, isEmpty);
+  });
 }
+

--- a/mobile/test/widget/order_sheet_test.dart
+++ b/mobile/test/widget/order_sheet_test.dart
@@ -1,0 +1,336 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+import 'package:trypto/app.dart';
+import 'package:trypto/core/api/api_client.dart';
+import 'package:trypto/core/auth/session_store.dart';
+import 'package:trypto/core/realtime/stomp_service.dart';
+import 'package:trypto/features/market/coin_row.dart';
+import 'package:trypto/features/market/order_history_tab.dart';
+import 'package:trypto/features/market/order_sheet.dart';
+
+import '../support/fake_stomp.dart';
+
+/// 계획서 §7-⑧ — 시장가 매수를 고르면 수량 칸이 사라지고, 전송 바디에 `volume` 이 없고
+/// `price` 에 총액이 실린다. 이 규칙을 어기면 서버가 400 이다.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SessionStore store;
+  late SessionExpiryNotifier expiry;
+  late Dio dio;
+  late DioAdapter adapter;
+  late FakeStompService stomp;
+  late List<RequestOptions> requests;
+
+  Map<String, dynamic> envelope(Object? data, {String code = 'SUCCESS'}) => {
+    'status': 200,
+    'code': code,
+    'message': '',
+    'data': data,
+  };
+
+  Map<String, dynamic> coin(int id, String symbol, String name, double price) =>
+      {
+        'exchangeCoinId': id,
+        'coinId': id,
+        'coinSymbol': symbol,
+        'coinName': name,
+        'price': price,
+        'changeRate': 0.01,
+        'volume': 1e11,
+      };
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+    store = SessionStore();
+    expiry = SessionExpiryNotifier();
+    stomp = FakeStompService();
+    requests = [];
+    dio = buildDio(store: store, expiry: expiry, baseUrl: 'http://test.local');
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          requests.add(options);
+          handler.next(options);
+        },
+      ),
+    );
+    adapter = DioAdapter(dio: dio);
+
+    adapter
+      ..onGet(
+        '/api/users/me',
+        (server) => server.reply(
+          200,
+          envelope({
+            'userId': 1,
+            'nickname': '테스터',
+            'createdAt': '2026-07-01T09:00:00',
+          }),
+        ),
+      )
+      ..onGet(
+        '/api/rounds/active',
+        (server) => server.reply(
+          200,
+          envelope({
+            'roundId': 10,
+            'userId': 1,
+            'roundNumber': 1,
+            'status': 'ACTIVE',
+            'initialSeed': 10000000.0,
+            'emergencyFundingLimit': 1000000.0,
+            'emergencyChargeCount': 3,
+            'startedAt': '2026-07-01T09:00:00',
+            'endedAt': null,
+            'rules': <Object>[],
+            'wallets': [
+              {'walletId': 100, 'exchangeId': 1},
+            ],
+          }),
+        ),
+      )
+      ..onGet(
+        '/api/rounds/summary',
+        (server) => server.reply(200, envelope({'totalRoundCount': 1})),
+      )
+      ..onGet(
+        '/api/exchanges/1/coins',
+        (server) => server.reply(
+          200,
+          envelope([
+            coin(1, 'BTC', '비트코인', 96000000),
+            coin(2, 'ETH', '이더리움', 5300000),
+          ]),
+        ),
+      )
+      ..onGet(
+        '/api/candles',
+        (server) => server.reply(200, envelope(<Object>[])),
+        queryParameters: {
+          'exchange': 'UPBIT',
+          'coin': 'BTC',
+          'interval': '1d',
+          'limit': 90,
+        },
+      )
+      ..onGet(
+        '/api/orders/available',
+        (server) => server.reply(
+          200,
+          envelope({'available': 10000000.0, 'currentPrice': 96000000.0}),
+        ),
+        queryParameters: {
+          'walletId': 100,
+          'exchangeCoinId': 1,
+          'side': 'BUY',
+        },
+      )
+      ..onGet(
+        '/api/orders/available',
+        (server) => server.reply(
+          200,
+          envelope({'available': 0.5, 'currentPrice': 96000000.0}),
+        ),
+        queryParameters: {
+          'walletId': 100,
+          'exchangeCoinId': 1,
+          'side': 'SELL',
+        },
+      )
+      ..onPost(
+        '/api/orders',
+        (server) => server.reply(
+          201,
+          envelope({
+            'orderId': 55,
+            'side': 'BUY',
+            'orderType': 'MARKET',
+            'quantity': 0.00052,
+            'orderAmount': 50000.0,
+            'fee': 25.0,
+            'filledPrice': 96000000.0,
+            'price': null,
+            'status': 'FILLED',
+            'createdAt': '2026-07-15T10:00:00',
+            'filledAt': '2026-07-15T10:00:00',
+          }, code: 'CREATED'),
+        ),
+        data: Matchers.any,
+      );
+  });
+
+  void stubHistory(String status, List<Map<String, dynamic>> content) {
+    adapter.onGet(
+      '/api/orders',
+      (server) => server.reply(
+        200,
+        envelope({'content': content, 'nextCursor': null, 'hasNext': false}),
+      ),
+      queryParameters: {
+        'walletId': 100,
+        'exchangeCoinId': 1,
+        'status': status,
+        'size': 20,
+      },
+    );
+  }
+
+  Future<void> openDetail(WidgetTester tester) async {
+    // 기본 800×600 은 가로 화면이라 시트 안의 입력 칸이 뷰포트 밖으로 밀려 빌드되지 않는다.
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 3;
+    addTearDown(tester.view.reset);
+
+    await store.save('session-id');
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sessionStoreProvider.overrideWithValue(store),
+          sessionExpiryProvider.overrideWithValue(expiry),
+          dioProvider.overrideWithValue(dio),
+          stompServiceProvider.overrideWithValue(stomp),
+        ],
+        child: const TryptoApp(),
+      ),
+    );
+    for (var i = 0; i < 10; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(CoinRow).first);
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> openSheet(WidgetTester tester, String side) async {
+    await tester.tap(find.widgetWithText(FilledButton, side));
+    await tester.pumpAndSettle();
+    expect(find.byType(OrderSheet), findsOneWidget);
+  }
+
+  Finder inSheet(Finder matching) =>
+      find.descendant(of: find.byType(OrderSheet), matching: matching);
+
+  Map<String, dynamic> placedOrder() => requests
+      .lastWhere((request) => request.path == '/api/orders' && request.method == 'POST')
+      .data as Map<String, dynamic>;
+
+  testWidgets('시장가 매수 — 수량 칸이 사라지고 바디에 volume 이 없다', (tester) async {
+    stubHistory('FILLED', []);
+    await openDetail(tester);
+    await openSheet(tester, '매수');
+
+    // 지정가(기본)에서는 가격·수량·총액 3칸이다.
+    expect(inSheet(find.text('주문 수량')), findsOneWidget);
+    expect(inSheet(find.text('주문 총액')), findsOneWidget);
+
+    await tester.tap(inSheet(find.text('시장가')));
+    await tester.pumpAndSettle();
+
+    expect(inSheet(find.text('주문 수량')), findsNothing);
+    expect(inSheet(find.text('주문 총액')), findsOneWidget);
+    expect(inSheet(find.byType(TextField)), findsOneWidget);
+
+    await tester.enterText(inSheet(find.byType(TextField)), '50000');
+    await tester.pumpAndSettle();
+    await tester.tap(inSheet(find.widgetWithText(FilledButton, '매수')));
+    await tester.pumpAndSettle();
+
+    final body = placedOrder();
+    expect(body.containsKey('volume'), isFalse);
+    expect(body['price'], 50000.0);
+    expect(body['orderType'], 'MARKET');
+    expect(body['side'], 'BUY');
+    expect(body['walletId'], 100);
+    expect(body['exchangeCoinId'], 1);
+    // 멱등키는 UUID v4 다. 형식이 틀리면 서버가 500 을 낸다.
+    expect(
+      body['clientOrderId'],
+      matches(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+      ),
+    );
+
+    expect(find.text('주문이 체결되었습니다.'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('지정가 매도 — 수량을 넣으면 총액이 따라오고 둘 다 전송된다', (tester) async {
+    stubHistory('FILLED', []);
+    await openDetail(tester);
+    await openSheet(tester, '매도');
+
+    final fields = inSheet(find.byType(TextField));
+    await tester.enterText(fields.at(0), '96000000');
+    await tester.pumpAndSettle();
+    await tester.enterText(fields.at(1), '0.001');
+    await tester.pumpAndSettle();
+
+    // 총액 = 0.001 × 96,000,000 (지정가에서만 연동한다)
+    expect(
+      tester.widget<TextField>(fields.at(2)).controller?.text,
+      '96,000',
+    );
+
+    await tester.tap(inSheet(find.widgetWithText(FilledButton, '매도')));
+    await tester.pumpAndSettle();
+
+    final body = placedOrder();
+    expect(body['volume'], 0.001);
+    expect(body['price'], 96000000.0);
+    expect(body['orderType'], 'LIMIT');
+    expect(body['side'], 'SELL');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('거래내역 — 미체결 주문을 취소하면 목록에서 사라진다', (tester) async {
+    stubHistory('FILLED', []);
+    stubHistory('PENDING', [
+      {
+        'orderId': 77,
+        'exchangeCoinId': 1,
+        'side': 'BUY',
+        'orderType': 'LIMIT',
+        'quantity': 0.001,
+        'filledPrice': null,
+        'price': 90000000.0,
+        'orderAmount': null,
+        'fee': null,
+        'createdAt': '2026-07-15T10:00:00',
+        'filledAt': null,
+      },
+    ]);
+    adapter.onPost(
+      '/api/orders/77/cancel',
+      (server) =>
+          server.reply(200, envelope({'orderId': 77, 'status': 'CANCELED'})),
+      data: Matchers.any,
+    );
+
+    await openDetail(tester);
+    await tester.tap(find.text('거래내역'));
+    await tester.pumpAndSettle();
+    expect(find.byType(OrderHistoryTab), findsOneWidget);
+    expect(find.text('체결 내역이 없습니다.'), findsOneWidget);
+
+    await tester.tap(find.text('미체결'));
+    await tester.pumpAndSettle();
+    expect(find.text('대기'), findsOneWidget);
+
+    await tester.tap(find.text('취소'));
+    await tester.pumpAndSettle();
+
+    final cancel = requests.lastWhere(
+      (request) => request.path == '/api/orders/77/cancel',
+    );
+    expect((cancel.data as Map<String, dynamic>)['walletId'], 100);
+    expect(find.text('미체결 주문이 없습니다.'), findsOneWidget);
+    expect(find.text('주문을 취소했습니다.'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/mobile/test/widget/regret_chart_test.dart
+++ b/mobile/test/widget/regret_chart_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trypto/core/theme/theme.dart';
+import 'package:trypto/features/regret/regret_chart.dart';
+import 'package:trypto/models/enums.dart';
+import 'package:trypto/models/regret.dart';
+
+RegretChart _chart(int days) => RegretChart(
+  roundId: 1,
+  exchangeId: 1,
+  exchangeName: '업비트',
+  currency: 'KRW',
+  totalDays: days,
+  assetHistory: [
+    for (var i = 0; i < days; i++)
+      AssetHistoryPoint(
+        snapshotDate: DateTime(2026, 7, 1).add(Duration(days: i)),
+        actualAsset: 1000000 + i * 1000,
+        ruleFollowedAsset: 1100000 + i * 1200,
+        btcHoldAsset: 900000 + i * 800,
+      ),
+  ],
+  violationMarkers: [
+    if (days > 2)
+      ViolationMarker(
+        snapshotDate: DateTime(2026, 7, 2),
+        assetValue: 1001000,
+      ),
+  ],
+);
+
+void main() {
+  testWidgets('차트가 그려진다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildTryptoTheme(),
+        home: Scaffold(
+          body: RegretAssetChart(
+            chart: _chart(30),
+            enabledRules: const {RuleType.chaseBuyBan, RuleType.lossCut},
+            btcEnabled: true,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(RegretAssetChart), findsOneWidget);
+  });
+
+  testWidgets('스냅샷이 2개 미만이면 집계 전 안내를 그린다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildTryptoTheme(),
+        home: Scaffold(
+          body: RegretAssetChart(
+            chart: _chart(1),
+            enabledRules: const {},
+            btcEnabled: false,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.textContaining('매일 밤 집계'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

웹과 동등한 9개 화면을 구현한다.

- **라운드 생성** — 시드머니·투자 원칙 설정
- **마켓** — 코인 목록(REST)·실시간 티커·코인 상세·실시간 캔들·주문·거래내역
- **긴급 자금** — 배너·투입 바텀시트
- **포트폴리오** — 자산 구성 도넛
- **입출금** — 보유 자산·송금 마법사
- **랭킹** — 시상대·랭커 포트폴리오
- **투자 복기** — 자산 추이·규칙 위반
- **마이페이지** — 닉네임 변경·피드백·회원 탈퇴

Closes #279