### PR TITLE
[#281] 카카오 로그인 공식 SDK 전환 (앱)

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -21,9 +21,9 @@ android {
         versionCode = flutter.versionCode
         versionName = flutter.versionName
 
-        // OAuth 콜백 스킴의 안드로이드 단일 출처. lib/core/env.dart 의 기본값과 같아야 한다.
-        // 제공자 콘솔이 커스텀 스킴을 거부하면 이 값을 바꾸고, 제공자별로 갈리면
-        // AndroidManifest 의 CallbackActivity 에 <data> 한 줄을 더한다.
+        // 구글 브라우저 인가 코드 흐름의 콜백 스킴(단일 출처). lib/core/env.dart 의 기본값과 같아야 한다.
+        // 아직 콘솔 미설정이라 자리만 잡아 둔 값이다(역방향 클라이언트 ID 스킴으로 바뀔 수 있다).
+        // 카카오는 SDK 로 전환해 커스텀 스킴 placeholder 가 필요 없다(AndroidManifest 의 AuthCodeHandlerActivity 참조).
         manifestPlaceholders["authCallbackScheme"] = "trypto"
     }
 

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -47,10 +47,11 @@
             </intent-filter>
         </activity>
 
-        <!-- 카카오 로그인 SDK 가 카카오톡 앱 로그인의 결과를 되받는 리다이렉트 처리기.
-             스킴은 `kakao{네이티브앱키}`, host 는 `oauth` 로 SDK 가 고정한다(공식 문서). -->
+        <!-- 카카오 로그인 SDK 가 카카오 인가 결과를 되받는 리다이렉트 처리기.
+             Flutter SDK(kakao_flutter_sdk)는 네이티브 SDK 의 AuthCodeHandlerActivity 가 아니라
+             AuthCodeCustomTabsActivity 를 제공한다. 스킴은 `kakao{네이티브앱키}`, host 는 `oauth`. -->
         <activity
-            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:name="com.kakao.sdk.flutter.AuthCodeCustomTabsActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -33,8 +33,9 @@
             </intent-filter>
         </activity>
 
-        <!-- 커스텀 스킴은 flutter_web_auth_2 의 CallbackActivity 에만 선언한다.
-             스킴 값의 출처는 build.gradle.kts 의 authCallbackScheme placeholder 다. -->
+        <!-- 구글의 커스텀 스킴(trypto) 콜백은 flutter_web_auth_2 의 CallbackActivity 가 받는다.
+             스킴 값의 출처는 build.gradle.kts 의 authCallbackScheme placeholder 다.
+             카카오는 SDK 로 전환해 이 콜백을 쓰지 않는다(아래 AuthCodeHandlerActivity 가 받는다). -->
         <activity
             android:name="com.linusu.flutter_web_auth_2.CallbackActivity"
             android:exported="true">
@@ -43,6 +44,21 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="${authCallbackScheme}"/>
+            </intent-filter>
+        </activity>
+
+        <!-- 카카오 로그인 SDK 가 카카오톡 앱 로그인의 결과를 되받는 리다이렉트 처리기.
+             스킴은 `kakao{네이티브앱키}`, host 는 `oauth` 로 SDK 가 고정한다(공식 문서). -->
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:host="oauth"
+                    android:scheme="kakaodf7305f4a85506b955eafc916218ca7b"/>
             </intent-filter>
         </activity>
 

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -34,6 +34,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>trypto</string>
+				<string>kakaodf7305f4a85506b955eafc916218ca7b</string>
 			</array>
 		</dict>
 	</array>

--- a/mobile/lib/core/auth/auth_config.dart
+++ b/mobile/lib/core/auth/auth_config.dart
@@ -30,6 +30,8 @@ abstract final class AuthConfig {
     SocialProvider.google => Env.googleCallbackScheme,
   };
 
+  /// 브라우저 인가 코드 흐름(구글)의 콜백 URI. 서버 설정값(`GOOGLE_{ANDROID|IOS}_REDIRECT_URI`)과
+  /// 문자 단위로 같아야 토큰 교환이 성립한다. 카카오는 SDK 로 전환해 이 경로를 쓰지 않는다.
   static String redirectUri(SocialProvider provider) =>
       '${callbackScheme(provider)}://auth/${provider.wire}/callback';
 
@@ -40,15 +42,25 @@ abstract final class AuthConfig {
         : Env.googleIosClientId,
   };
 
-  /// 웹과 같은 규칙(사양서 §2.4): `clientId` 와 콜백 스킴이 모두 채워졌을 때만 버튼을 살린다.
-  static bool isConfigured(SocialProvider provider) =>
-      clientId(provider).isNotEmpty && callbackScheme(provider).isNotEmpty;
+  /// 버튼을 살리는 조건은 제공자별로 다르다(사양서 §2.4). 카카오는 SDK 로 동작하므로 네이티브 앱
+  /// 키만 있으면 되고(기본값이 있어 항상 채워진다), 구글은 `clientId` 와 콜백 스킴이 모두 있어야 한다.
+  static bool isConfigured(SocialProvider provider) => switch (provider) {
+    SocialProvider.kakao => Env.kakaoNativeAppKey.isNotEmpty,
+    SocialProvider.google =>
+      clientId(provider).isNotEmpty && callbackScheme(provider).isNotEmpty,
+  };
 
   /// 비어 있는 `--dart-define` 키 목록. 디버그 빌드에서만 노출한다.
-  static List<String> missingDefines(SocialProvider provider) => [
-    if (clientId(provider).isEmpty) _clientIdKey(provider),
-    if (callbackScheme(provider).isEmpty) _callbackSchemeKey(provider),
-  ];
+  static List<String> missingDefines(SocialProvider provider) =>
+      switch (provider) {
+        SocialProvider.kakao => [
+          if (Env.kakaoNativeAppKey.isEmpty) 'KAKAO_NATIVE_APP_KEY',
+        ],
+        SocialProvider.google => [
+          if (clientId(provider).isEmpty) _clientIdKey(provider),
+          if (callbackScheme(provider).isEmpty) _callbackSchemeKey(provider),
+        ],
+      };
 
   static Uri authorizeUrl(
     SocialProvider provider, {

--- a/mobile/lib/core/env.dart
+++ b/mobile/lib/core/env.dart
@@ -22,20 +22,29 @@ class Env {
     'GOOGLE_IOS_CLIENT_ID',
   );
 
-  /// OAuth 콜백 스킴의 Dart 단일 출처. 제공자 콘솔이 커스텀 스킴을 거부하면
-  /// 제공자별로 값이 갈릴 수 있으므로 키를 둘로 나눠 둔다.
-  ///
-  /// 값을 바꾸면 네이티브 등록처 두 곳도 같이 바꾼다.
+  /// 구글 브라우저 인가 코드 흐름의 콜백 스킴(Dart 단일 출처). 값을 바꾸면 네이티브 등록처도 같이 바꾼다.
   /// - android/app/build.gradle.kts : manifestPlaceholders["authCallbackScheme"]
   /// - ios/Runner/Info.plist        : CFBundleURLSchemes
-  static const kakaoCallbackScheme = String.fromEnvironment(
-    'KAKAO_CALLBACK_SCHEME',
-    defaultValue: _defaultCallbackScheme,
-  );
   static const googleCallbackScheme = String.fromEnvironment(
     'GOOGLE_CALLBACK_SCHEME',
     defaultValue: _defaultCallbackScheme,
   );
 
+  /// 카카오는 SDK 로 전환해 브라우저 콜백 스킴을 쓰지 않는다. 이 값은 SDK 의 카카오톡 로그인
+  /// 리다이렉트 처리기(`AuthCodeHandlerActivity`)가 쓰는 `kakao{네이티브앱키}://oauth` 스킴을
+  /// 문서화할 뿐이며, 실제 등록은 AndroidManifest 에 직접 박아 둔다.
+  static const kakaoCallbackScheme = String.fromEnvironment(
+    'KAKAO_CALLBACK_SCHEME',
+    defaultValue: 'kakao$_kakaoNativeAppKey',
+  );
+
+  /// 카카오 공식 SDK 초기화용 네이티브 앱 키. 카카오는 브라우저 리다이렉트가 불가해 SDK 로
+  /// 앱에서 액세스 토큰을 받는다(커스텀 스킴 콜백을 쓰지 않는다).
+  static const kakaoNativeAppKey = String.fromEnvironment(
+    'KAKAO_NATIVE_APP_KEY',
+    defaultValue: _kakaoNativeAppKey,
+  );
+
+  static const _kakaoNativeAppKey = 'df7305f4a85506b955eafc916218ca7b';
   static const _defaultCallbackScheme = 'trypto';
 }

--- a/mobile/lib/features/auth/auth_controller.dart
+++ b/mobile/lib/features/auth/auth_controller.dart
@@ -3,10 +3,8 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/api/api_exception.dart';
-import '../../core/auth/auth_config.dart';
 import '../../core/auth/session_store.dart';
 import '../../models/enums.dart';
-import '../../models/user.dart';
 import '../mypage/user_repository.dart';
 import 'auth_repository.dart';
 import 'social_login.dart';
@@ -96,21 +94,14 @@ class AuthController extends Notifier<AuthState> {
     state = AuthState(status: AuthStatus.authorizing, provider: provider);
 
     try {
-      final authorization = await ref
-          .read(socialLoginProvider)
-          .authorize(provider);
+      // 인가 흐름은 제공자별로 다르다(카카오 SDK 토큰 / 구글 인가 코드). 서버 교환에 넣을
+      // LoginRequest 를 통째로 돌려받으므로 여기서는 제공자를 구분하지 않는다.
+      final request = await ref.read(socialLoginProvider).authorize(provider);
 
       state = AuthState(status: AuthStatus.exchanging, provider: provider);
       final response = await ref
           .read(authRepositoryProvider)
-          .login(
-            provider,
-            LoginRequest(
-              code: authorization.code,
-              codeVerifier: authorization.codeVerifier,
-              clientType: AuthConfig.clientType,
-            ),
-          );
+          .login(provider, request);
 
       // 세션은 SessionInterceptor 가 Set-Cookie 에서 회수해 저장했다. 화면 이동은 하지 않는다 —
       // 인증 상태가 바뀌면 라우터의 redirect 가 /market 으로 보낸다.

--- a/mobile/lib/features/auth/social_login.dart
+++ b/mobile/lib/features/auth/social_login.dart
@@ -2,10 +2,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
+import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
 import '../../core/auth/auth_config.dart';
 import '../../core/auth/pkce.dart';
 import '../../models/enums.dart';
+import '../../models/user.dart';
 
 /// 인가 단계의 실패. [message] 는 그대로 사용자에게 보여준다(사양서 §2.2.4 의 6종 문구).
 class SocialLoginException implements Exception {
@@ -15,14 +17,6 @@ class SocialLoginException implements Exception {
 
   @override
   String toString() => 'SocialLoginException($message)';
-}
-
-/// 인가 화면을 통과해 받아 온 값. 곧바로 서버 교환에 쓰고 버린다.
-class SocialAuthorization {
-  const SocialAuthorization({required this.code, required this.codeVerifier});
-
-  final String code;
-  final String codeVerifier;
 }
 
 /// 콜백 URL 검증(사양서 §2.2.4). 인가 코드를 돌려주고, 실패는 사용자 문구를 담아 던진다.
@@ -99,7 +93,7 @@ class OAuthSecrets {
   }
 }
 
-/// 인가 화면 호출부. 테스트에서 플러그인을 대체할 수 있도록 함수로 받는다.
+/// 구글 인가 화면 호출부. 테스트에서 플러그인을 대체할 수 있도록 함수로 받는다.
 typedef WebAuthenticator =
     Future<String> Function({
       required String url,
@@ -114,20 +108,62 @@ Future<String> _authenticateWithWebAuth({
   callbackUrlScheme: callbackUrlScheme,
 );
 
-/// 소셜 인가(계획서 §4.3.2). Android 는 Chrome Custom Tabs, iOS 는 `ASWebAuthenticationSession`.
-///
-/// 콜백 URL 은 `authenticate()` 의 반환값으로 온다. 딥링크 라우팅·팝업 중계가 통째로 불필요하다.
+/// 카카오 SDK 토큰 획득부. 테스트에서 SDK 를 대체할 수 있도록 함수로 받는다.
+typedef KakaoTokenProvider = Future<String> Function();
+
+/// 카카오톡이 깔려 있으면 앱 대 앱으로, 없으면 카카오 계정 웹 로그인으로 토큰을 받는다
+/// (에뮬레이터엔 카카오톡이 없어 실제로는 account 경로가 쓰인다).
+Future<String> _authenticateWithKakao() async {
+  final installed = await isKakaoTalkInstalled();
+  final token = installed
+      ? await UserApi.instance.loginWithKakaoTalk()
+      : await UserApi.instance.loginWithKakaoAccount();
+  return token.accessToken;
+}
+
+/// 소셜 인가. 제공자로 분기한다 — 카카오는 공식 SDK 로 액세스 토큰을, 구글은 기존
+/// flutter_web_auth_2 인가 코드 흐름(Android 는 Chrome Custom Tabs, iOS 는
+/// `ASWebAuthenticationSession`)을 쓴다. 반환값은 곧바로 서버 교환에 넣는 [LoginRequest] 다.
 class SocialLoginService {
   SocialLoginService({
     required OAuthSecrets secrets,
     WebAuthenticator authenticator = _authenticateWithWebAuth,
+    KakaoTokenProvider kakaoTokenProvider = _authenticateWithKakao,
   }) : _secrets = secrets,
-       _authenticate = authenticator;
+       _authenticate = authenticator,
+       _kakaoToken = kakaoTokenProvider;
 
   final OAuthSecrets _secrets;
   final WebAuthenticator _authenticate;
+  final KakaoTokenProvider _kakaoToken;
 
-  Future<SocialAuthorization> authorize(SocialProvider provider) async {
+  Future<LoginRequest> authorize(SocialProvider provider) => switch (provider) {
+    SocialProvider.kakao => _authorizeKakao(),
+    SocialProvider.google => _authorizeGoogle(),
+  };
+
+  /// 카카오: SDK 가 앱에서 직접 액세스 토큰을 돌려준다. 취소·실패는 SDK 예외로 오므로
+  /// 크래시 대신 다시 시도할 수 있는 사용자 문구로 감싼다.
+  Future<LoginRequest> _authorizeKakao() async {
+    const provider = SocialProvider.kakao;
+    try {
+      final accessToken = await _kakaoToken();
+      return LoginRequest.kakao(
+        accessToken: accessToken,
+        clientType: AuthConfig.clientType,
+      );
+    } on SocialLoginException {
+      rethrow;
+    } catch (_) {
+      throw SocialLoginException(
+        '${AuthConfig.label(provider)} 로그인이 취소되었거나 실패했습니다.',
+      );
+    }
+  }
+
+  /// 구글: 브라우저 인가 코드 흐름. 콜백 URL 은 `authenticate()` 의 반환값으로 온다.
+  Future<LoginRequest> _authorizeGoogle() async {
+    const provider = SocialProvider.google;
     if (!AuthConfig.isConfigured(provider)) {
       throw SocialLoginException(
         '${AuthConfig.label(provider)} 로그인 설정이 완료되지 않았습니다.',
@@ -153,7 +189,11 @@ class SocialLoginService {
         expectedState: state,
         codeVerifier: verifier,
       );
-      return SocialAuthorization(code: code, codeVerifier: verifier);
+      return LoginRequest.google(
+        code: code,
+        codeVerifier: verifier,
+        clientType: AuthConfig.clientType,
+      );
     } on PlatformException {
       // 사용자가 인가 화면을 닫으면 CANCELED 가 온다. 콜백 스킴이 OS 에 등록되지 않은 경우도
       // 여기로 떨어지므로, 크래시 대신 다시 시도할 수 있는 문구를 남긴다.

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
 import 'app.dart';
 import 'core/auth/session_store.dart';
+import 'core/env.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // 카카오 로그인은 공식 SDK 로 앱에서 액세스 토큰을 받는다. 네이티브 앱 키의 단일 출처는 Env 다.
+  KakaoSdk.init(nativeAppKey: Env.kakaoNativeAppKey);
 
   // 세션을 먼저 읽어 들인다. 인터셉터의 onRequest 는 보안 저장소를 await 하지 않으므로
   // (요청마다 플랫폼 채널을 왕복하면 프레임에 얹힌다) 첫 요청 전에 동기 캐시가 채워져 있어야

--- a/mobile/lib/models/user.dart
+++ b/mobile/lib/models/user.dart
@@ -7,20 +7,29 @@ part 'user.g.dart';
 
 /// `POST /api/auth/{provider}/login`
 ///
-/// [clientType] 은 백엔드가 받기로 한 필드다(계획서 §9-2 — 구글의 Android·iOS 클라이언트 ID 가
-/// 별개라 서버가 플랫폼을 알아야 토큰 교환의 client_id 를 맞출 수 있다).
-/// **현행 서버 `LoginRequest` 에는 아직 이 필드가 없으므로** null 이면 바디에서 통째로 뺀다.
-/// 값을 채우는 플랫폼 판별은 인증 단위에서 붙인다.
+/// 제공자별로 바디가 갈린다(확정 와이어 계약). 카카오는 앱이 공식 SDK 로 받은 액세스 토큰을
+/// 보내고(`{accessToken, clientType}`), 구글/웹은 기존 인가 코드 흐름을 그대로 쓴다
+/// (`{code, codeVerifier, clientType}`). 두 흐름은 상호배타이므로 named 생성자로 나눈다.
+///
+/// [clientType] 은 서버가 플랫폼별 제공자 자격증명을 고르는 값이다(구글의 Android·iOS 클라이언트
+/// ID 가 별개다). `includeIfNull: false` 라 해당 흐름에 없는 필드는 바디에서 통째로 빠진다.
 @JsonSerializable(createFactory: false, includeIfNull: false)
 class LoginRequest {
-  const LoginRequest({
+  /// 구글/웹: 인가 코드 + PKCE 검증값.
+  const LoginRequest.google({
     required this.code,
     required this.codeVerifier,
     this.clientType,
-  });
+  }) : accessToken = null;
 
-  final String code;
-  final String codeVerifier;
+  /// 카카오: 공식 SDK 가 앱에서 받은 액세스 토큰.
+  const LoginRequest.kakao({required this.accessToken, this.clientType})
+    : code = null,
+      codeVerifier = null;
+
+  final String? code;
+  final String? codeVerifier;
+  final String? accessToken;
   final ClientType? clientType;
 
   Map<String, dynamic> toJson() => _$LoginRequestToJson(this);

--- a/mobile/lib/models/user.g.dart
+++ b/mobile/lib/models/user.g.dart
@@ -8,8 +8,9 @@ part of 'user.dart';
 
 Map<String, dynamic> _$LoginRequestToJson(LoginRequest instance) =>
     <String, dynamic>{
-      'code': instance.code,
-      'codeVerifier': instance.codeVerifier,
+      'code': ?instance.code,
+      'codeVerifier': ?instance.codeVerifier,
+      'accessToken': ?instance.accessToken,
       'clientType': ?_$ClientTypeEnumMap[instance.clientType],
     };
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -25,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
+  asn1lib:
+    dependency: transitive
+    description:
+      name: asn1lib
+      sha256: "9a8f69025044eb466b9b60ef3bc3ac99b4dc6c158ae9c56d25eeccf5bc56d024"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.5"
   async:
     dependency: transitive
     description:
@@ -209,6 +217,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  encrypt:
+    dependency: transitive
+    description:
+      name: encrypt
+      sha256: "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.3"
   equatable:
     dependency: transitive
     description:
@@ -326,6 +342,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  flutter_svg:
+    dependency: transitive
+    description:
+      name: flutter_svg
+      sha256: "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -384,6 +408,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_mock_adapter:
     dependency: "direct dev"
     description:
@@ -464,6 +496,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.14.0"
+  kakao_flutter_sdk_auth:
+    dependency: transitive
+    description:
+      name: kakao_flutter_sdk_auth
+      sha256: b610ebf2a74aafc543141f1edf7d3ed82fcabcc1317181895151b1fe8f9d62d9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.10.0"
+  kakao_flutter_sdk_common:
+    dependency: transitive
+    description:
+      name: kakao_flutter_sdk_common
+      sha256: e00122b2a6158853adfbb8d51f71f11f7c2cbbbe21f29b0d7494b0de5ec5e4fd
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.10.0"
+  kakao_flutter_sdk_user:
+    dependency: "direct main"
+    description:
+      name: kakao_flutter_sdk_user
+      sha256: "33d44bd2c25ea922078c6ab3eb33d978745d8f9c1920927f4745141e08ea5e57"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.10.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -584,6 +640,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: transitive
     description:
@@ -656,6 +720,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.9.1"
   pool:
     dependency: transitive
     description:
@@ -704,6 +776,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  shared_preferences:
+    dependency: transitive
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.27"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -893,6 +1021,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.3"
+  vector_graphics:
+    dependency: transitive
+    description:
+      name: vector_graphics
+      sha256: "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  vector_graphics_codec:
+    dependency: transitive
+    description:
+      name: vector_graphics_codec
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.13"
+  vector_graphics_compiler:
+    dependency: transitive
+    description:
+      name: vector_graphics_compiler
+      sha256: "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.6"
   vector_math:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -30,6 +30,9 @@ dependencies:
   flutter_web_auth_2: ^4.1.0
   flutter_secure_storage: ^9.2.2
   crypto: ^3.0.6
+  # 카카오는 브라우저 리다이렉트가 불가(커스텀 스킴을 REST 리다이렉트로 등록 불가)해 공식 SDK 로
+  # 앱에서 액세스 토큰을 받고, 백엔드가 그 토큰으로 신원을 확인한다. 구글은 flutter_web_auth_2 유지.
+  kakao_flutter_sdk_user: ^1.9.0
 
   # 값·포맷
   decimal: ^3.2.1

--- a/mobile/test/pkce_test.dart
+++ b/mobile/test/pkce_test.dart
@@ -34,55 +34,46 @@ void main() {
   });
 
   group('AuthConfig', () {
-    test('redirect URI 는 서버 설정값과 같은 문자열을 만든다', () {
-      expect(
-        AuthConfig.redirectUri(SocialProvider.kakao),
-        'trypto://auth/kakao/callback',
-      );
+    // 카카오는 SDK 로 전환해 브라우저 인가 코드 흐름을 쓰지 않는다. redirectUri·authorizeUrl 은
+    // 구글 전용이다.
+    test('구글 redirect URI 는 서버 설정값과 같은 문자열을 만든다', () {
       expect(
         AuthConfig.redirectUri(SocialProvider.google),
         'trypto://auth/google/callback',
       );
     });
 
-    test('인가 URL 은 PKCE 규격대로 조립된다', () {
+    test('구글 인가 URL 은 PKCE 규격대로 조립된다', () {
       final url = AuthConfig.authorizeUrl(
-        SocialProvider.kakao,
+        SocialProvider.google,
         challenge: 'challenge-value',
         state: 'state-value',
       );
 
-      expect(url.origin, 'https://kauth.kakao.com');
-      expect(url.path, '/oauth/authorize');
+      expect(url.origin, 'https://accounts.google.com');
+      expect(url.path, '/o/oauth2/v2/auth');
       expect(url.queryParameters['response_type'], 'code');
       expect(url.queryParameters['code_challenge'], 'challenge-value');
       expect(url.queryParameters['code_challenge_method'], 'S256');
       expect(url.queryParameters['state'], 'state-value');
       expect(
         url.queryParameters['redirect_uri'],
-        'trypto://auth/kakao/callback',
+        'trypto://auth/google/callback',
       );
-      expect(url.queryParameters.containsKey('scope'), isFalse);
-    });
-
-    test('구글만 openid scope 를 붙인다', () {
-      final url = AuthConfig.authorizeUrl(
-        SocialProvider.google,
-        challenge: 'c',
-        state: 's',
-      );
-
-      expect(url.origin, 'https://accounts.google.com');
+      // 구글만 openid scope 를 붙인다.
       expect(url.queryParameters['scope'], 'openid');
     });
 
-    test('clientId 가 비면 버튼을 살리지 않는다', () {
-      // --dart-define 이 없는 테스트 환경에서는 두 제공자 모두 미설정이다.
-      expect(AuthConfig.isConfigured(SocialProvider.kakao), isFalse);
-      expect(
-        AuthConfig.missingDefines(SocialProvider.kakao),
-        contains('KAKAO_CLIENT_ID'),
-      );
+    test('카카오는 네이티브 앱 키 기본값만으로 버튼이 살아 있다', () {
+      // --dart-define 이 없어도 카카오는 SDK 로 동작하므로 네이티브 앱 키 기본값으로 설정 완료다.
+      expect(AuthConfig.isConfigured(SocialProvider.kakao), isTrue);
+      expect(AuthConfig.missingDefines(SocialProvider.kakao), isEmpty);
+    });
+
+    test('구글은 clientId 가 비면 버튼을 살리지 않는다', () {
+      // --dart-define 이 없는 테스트 환경에서 구글은 미설정이다.
+      expect(AuthConfig.isConfigured(SocialProvider.google), isFalse);
+      expect(AuthConfig.missingDefines(SocialProvider.google), isNotEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary

카카오 로그인을 공식 SDK 액세스 토큰 방식으로 전환한다.

- **SDK 의존성** — kakao_flutter_sdk_user 추가
- **인가 흐름** — 앱에서 액세스 토큰을 받아 서버 교환
- **안드로이드 설정** — SDK 콜백 액티비티(AuthCodeCustomTabsActivity)
- **테스트** — AuthConfig 갱신

Closes #281