### PR TITLE
[#283] 백엔드 액세스 토큰 로그인 경로 추가

### DIFF
--- a/api/src/main/java/ksh/tryptobackend/common/exception/ErrorCode.java
+++ b/api/src/main/java/ksh/tryptobackend/common/exception/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
     SIGNUP_RESTRICTED(403, "signup.restricted"),
     SOCIAL_SERVER_ERROR(502, "social.server.error"),
     SOCIAL_LOGIN_NOT_CONFIGURED(503, "social.login.not.configured"),
+    ACCESS_TOKEN_LOGIN_NOT_SUPPORTED(400, "access.token.login.not.supported"),
 
     PRICE_NOT_AVAILABLE(500, "price.not.available"),
 

--- a/api/src/main/java/ksh/tryptobackend/user/adapter/in/dto/request/LoginRequest.java
+++ b/api/src/main/java/ksh/tryptobackend/user/adapter/in/dto/request/LoginRequest.java
@@ -1,13 +1,29 @@
 package ksh.tryptobackend.user.adapter.in.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.AssertTrue;
 import ksh.tryptobackend.user.application.port.in.dto.command.LoginCommand;
 import ksh.tryptobackend.user.domain.vo.ClientType;
 import ksh.tryptobackend.user.domain.vo.Provider;
 
-public record LoginRequest(@NotBlank String code, @NotBlank String codeVerifier, String clientType) {
+public record LoginRequest(String code, String codeVerifier, String accessToken, String clientType) {
+
+    @AssertTrue(message = "인가 코드와 검증값 또는 액세스 토큰 중 하나는 있어야 합니다.") public boolean isCredentialProvided() {
+        return hasAuthorizationCode() || hasAccessToken();
+    }
 
     public LoginCommand toCommand(Provider provider) {
-        return new LoginCommand(provider, code, codeVerifier, ClientType.fromNullable(clientType));
+        return new LoginCommand(provider, code, codeVerifier, ClientType.fromNullable(clientType), accessToken);
+    }
+
+    private boolean hasAuthorizationCode() {
+        return isPresent(code) && isPresent(codeVerifier);
+    }
+
+    private boolean hasAccessToken() {
+        return isPresent(accessToken);
+    }
+
+    private static boolean isPresent(String value) {
+        return value != null && !value.isBlank();
     }
 }

--- a/api/src/main/java/ksh/tryptobackend/user/adapter/out/oauth/KakaoOAuthClient.java
+++ b/api/src/main/java/ksh/tryptobackend/user/adapter/out/oauth/KakaoOAuthClient.java
@@ -31,6 +31,11 @@ public class KakaoOAuthClient implements OAuthClient {
     @Override
     public SocialIdentity getIdentity(String authorizationCode, String codeVerifier, ClientType clientType) {
         String accessToken = exchangeAccessToken(authorizationCode, codeVerifier, clientType);
+        return getIdentityByAccessToken(accessToken);
+    }
+
+    @Override
+    public SocialIdentity getIdentityByAccessToken(String accessToken) {
         Long memberId = fetchMemberId(accessToken);
         return SocialIdentity.of(Provider.KAKAO, String.valueOf(memberId));
     }

--- a/api/src/main/java/ksh/tryptobackend/user/adapter/out/oauth/OAuthClient.java
+++ b/api/src/main/java/ksh/tryptobackend/user/adapter/out/oauth/OAuthClient.java
@@ -1,5 +1,7 @@
 package ksh.tryptobackend.user.adapter.out.oauth;
 
+import ksh.tryptobackend.common.exception.CustomException;
+import ksh.tryptobackend.common.exception.ErrorCode;
 import ksh.tryptobackend.user.domain.vo.ClientType;
 import ksh.tryptobackend.user.domain.vo.Provider;
 import ksh.tryptobackend.user.domain.vo.SocialIdentity;
@@ -9,4 +11,8 @@ public interface OAuthClient {
     Provider provider();
 
     SocialIdentity getIdentity(String authorizationCode, String codeVerifier, ClientType clientType);
+
+    default SocialIdentity getIdentityByAccessToken(String accessToken) {
+        throw new CustomException(ErrorCode.ACCESS_TOKEN_LOGIN_NOT_SUPPORTED);
+    }
 }

--- a/api/src/main/java/ksh/tryptobackend/user/adapter/out/service/SocialAuthenticatorImpl.java
+++ b/api/src/main/java/ksh/tryptobackend/user/adapter/out/service/SocialAuthenticatorImpl.java
@@ -26,10 +26,19 @@ public class SocialAuthenticatorImpl implements SocialAuthenticator {
     @Override
     public SocialIdentity authenticate(
             Provider provider, String authorizationCode, String codeVerifier, ClientType clientType) {
+        return clientFor(provider).getIdentity(authorizationCode, codeVerifier, clientType);
+    }
+
+    @Override
+    public SocialIdentity authenticateWithAccessToken(Provider provider, String accessToken) {
+        return clientFor(provider).getIdentityByAccessToken(accessToken);
+    }
+
+    private OAuthClient clientFor(Provider provider) {
         OAuthClient client = clients.get(provider);
         if (client == null) {
             throw new CustomException(ErrorCode.INVALID_PROVIDER);
         }
-        return client.getIdentity(authorizationCode, codeVerifier, clientType);
+        return client;
     }
 }

--- a/api/src/main/java/ksh/tryptobackend/user/application/port/in/dto/command/LoginCommand.java
+++ b/api/src/main/java/ksh/tryptobackend/user/application/port/in/dto/command/LoginCommand.java
@@ -3,4 +3,10 @@ package ksh.tryptobackend.user.application.port.in.dto.command;
 import ksh.tryptobackend.user.domain.vo.ClientType;
 import ksh.tryptobackend.user.domain.vo.Provider;
 
-public record LoginCommand(Provider provider, String code, String codeVerifier, ClientType clientType) {}
+public record LoginCommand(
+        Provider provider, String code, String codeVerifier, ClientType clientType, String accessToken) {
+
+    public boolean hasAccessToken() {
+        return accessToken != null && !accessToken.isBlank();
+    }
+}

--- a/api/src/main/java/ksh/tryptobackend/user/application/service/LoginService.java
+++ b/api/src/main/java/ksh/tryptobackend/user/application/service/LoginService.java
@@ -37,8 +37,10 @@ public class LoginService implements LoginUseCase {
     @Override
     @Transactional
     public LoginResult login(LoginCommand command) {
-        SocialIdentity identity = socialAuthenticator.authenticate(
-                command.provider(), command.code(), command.codeVerifier(), command.clientType());
+        SocialIdentity identity = command.hasAccessToken()
+                ? socialAuthenticator.authenticateWithAccessToken(command.provider(), command.accessToken())
+                : socialAuthenticator.authenticate(
+                        command.provider(), command.code(), command.codeVerifier(), command.clientType());
         LocalDateTime now = LocalDateTime.now(clock);
 
         SocialAccount account = socialAccountQueryPort

--- a/api/src/main/java/ksh/tryptobackend/user/domain/service/SocialAuthenticator.java
+++ b/api/src/main/java/ksh/tryptobackend/user/domain/service/SocialAuthenticator.java
@@ -8,4 +8,6 @@ public interface SocialAuthenticator {
 
     SocialIdentity authenticate(
             Provider provider, String authorizationCode, String codeVerifier, ClientType clientType);
+
+    SocialIdentity authenticateWithAccessToken(Provider provider, String accessToken);
 }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -44,6 +44,7 @@ social.account.not.found=소셜 계정을 찾을 수 없습니다.
 signup.restricted=탈퇴 후 재가입 제한 기간이 지나지 않아 가입할 수 없습니다.
 social.server.error=소셜 서버 오류로 로그인에 실패했습니다.
 social.login.not.configured=해당 클라이언트의 소셜 로그인 설정이 없습니다.
+access.token.login.not.supported=액세스 토큰 로그인을 지원하지 않는 소셜 제공자입니다.
 nickname.same.as.current=현재 닉네임과 동일합니다.
 invalid.nickname.length=닉네임은 2자 이상 20자 이하여야 합니다.
 nickname.already.exists=이미 사용 중인 닉네임입니다.

--- a/api/src/test/java/ksh/tryptobackend/acceptance/mock/MockSocialAuthenticator.java
+++ b/api/src/test/java/ksh/tryptobackend/acceptance/mock/MockSocialAuthenticator.java
@@ -17,6 +17,11 @@ public class MockSocialAuthenticator implements SocialAuthenticator {
         return SocialIdentity.of(provider, authorizationCode);
     }
 
+    @Override
+    public SocialIdentity authenticateWithAccessToken(Provider provider, String accessToken) {
+        return SocialIdentity.of(provider, accessToken);
+    }
+
     public ClientType getLastClientType() {
         return lastClientType;
     }

--- a/api/src/test/java/ksh/tryptobackend/user/adapter/in/dto/request/LoginRequestTest.java
+++ b/api/src/test/java/ksh/tryptobackend/user/adapter/in/dto/request/LoginRequestTest.java
@@ -1,0 +1,41 @@
+package ksh.tryptobackend.user.adapter.in.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LoginRequestTest {
+
+    @Test
+    @DisplayName("액세스 토큰만 있어도 자격 증명이 갖춰진 것으로 본다")
+    void isCredentialProvided_accessTokenOnly_true() {
+        LoginRequest request = new LoginRequest(null, null, "app-access-token", "android");
+
+        assertThat(request.isCredentialProvided()).isTrue();
+    }
+
+    @Test
+    @DisplayName("인가 코드와 검증값이 모두 있으면 자격 증명이 갖춰진 것으로 본다")
+    void isCredentialProvided_codeAndVerifier_true() {
+        LoginRequest request = new LoginRequest("code", "verifier", null, "web");
+
+        assertThat(request.isCredentialProvided()).isTrue();
+    }
+
+    @Test
+    @DisplayName("인가 코드만 있고 검증값이 없으면 자격 증명이 갖춰지지 않은 것으로 본다")
+    void isCredentialProvided_codeWithoutVerifier_false() {
+        LoginRequest request = new LoginRequest("code", null, null, "web");
+
+        assertThat(request.isCredentialProvided()).isFalse();
+    }
+
+    @Test
+    @DisplayName("어떤 자격 증명도 없으면 자격 증명이 갖춰지지 않은 것으로 본다")
+    void isCredentialProvided_nothing_false() {
+        LoginRequest request = new LoginRequest(null, null, null, null);
+
+        assertThat(request.isCredentialProvided()).isFalse();
+    }
+}

--- a/api/src/test/java/ksh/tryptobackend/user/adapter/out/oauth/GoogleOAuthClientTest.java
+++ b/api/src/test/java/ksh/tryptobackend/user/adapter/out/oauth/GoogleOAuthClientTest.java
@@ -1,10 +1,13 @@
 package ksh.tryptobackend.user.adapter.out.oauth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.EnumMap;
 import java.util.Map;
+import ksh.tryptobackend.common.exception.CustomException;
+import ksh.tryptobackend.common.exception.ErrorCode;
 import ksh.tryptobackend.user.domain.vo.ClientType;
 import ksh.tryptobackend.user.domain.vo.Provider;
 import ksh.tryptobackend.user.domain.vo.SocialIdentity;
@@ -79,6 +82,17 @@ class GoogleOAuthClientTest {
         assertThat(androidForm).containsEntry("client_id", ANDROID_CREDENTIALS.clientId());
         assertThat(iosForm).containsEntry("client_id", IOS_CREDENTIALS.clientId());
         assertThat(androidForm.get("client_id")).isNotEqualTo(iosForm.get("client_id"));
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 로그인은 지원하지 않아 미지원 예외를 던진다")
+    void getIdentityByAccessToken_notSupported_throwsAccessTokenLoginNotSupported() {
+        GoogleOAuthClient client = new GoogleOAuthClient(configuredProperties());
+
+        assertThatThrownBy(() -> client.getIdentityByAccessToken("app-access-token"))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ACCESS_TOKEN_LOGIN_NOT_SUPPORTED);
     }
 
     private GoogleOAuthProperties configuredProperties() {

--- a/api/src/test/java/ksh/tryptobackend/user/adapter/out/oauth/KakaoOAuthClientTest.java
+++ b/api/src/test/java/ksh/tryptobackend/user/adapter/out/oauth/KakaoOAuthClientTest.java
@@ -59,6 +59,17 @@ class KakaoOAuthClientTest {
     }
 
     @Test
+    @DisplayName("액세스 토큰으로 회원을 조회하면 토큰 교환 없이 신원을 확정한다")
+    void getIdentityByAccessToken_skipsTokenExchange_resolvesIdentity() {
+        KakaoOAuthClient client = new KakaoOAuthClient(configuredProperties());
+
+        SocialIdentity identity = client.getIdentityByAccessToken("app-access-token");
+
+        assertThat(identity).isEqualTo(SocialIdentity.of(Provider.KAKAO, "1234"));
+        assertThat(server.tokenRequestForm()).isEmpty();
+    }
+
+    @Test
     @DisplayName("안드로이드 클라이언트로 인증하면 안드로이드 자격증명으로 토큰을 교환한다")
     void getIdentity_androidClientType_exchangesTokenWithAndroidCredentials() {
         KakaoOAuthClient client = new KakaoOAuthClient(configuredProperties());

--- a/api/src/test/java/ksh/tryptobackend/user/adapter/out/service/SocialAuthenticatorImplTest.java
+++ b/api/src/test/java/ksh/tryptobackend/user/adapter/out/service/SocialAuthenticatorImplTest.java
@@ -1,0 +1,56 @@
+package ksh.tryptobackend.user.adapter.out.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import ksh.tryptobackend.common.exception.CustomException;
+import ksh.tryptobackend.common.exception.ErrorCode;
+import ksh.tryptobackend.user.adapter.out.oauth.OAuthClient;
+import ksh.tryptobackend.user.domain.vo.ClientType;
+import ksh.tryptobackend.user.domain.vo.Provider;
+import ksh.tryptobackend.user.domain.vo.SocialIdentity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SocialAuthenticatorImplTest {
+
+    @Test
+    @DisplayName("액세스 토큰 인증은 해당 제공자 클라이언트로 신원 조회를 위임한다")
+    void authenticateWithAccessToken_delegatesToProviderClient() {
+        SocialAuthenticatorImpl authenticator = new SocialAuthenticatorImpl(List.of(new StubKakaoClient()));
+
+        SocialIdentity identity = authenticator.authenticateWithAccessToken(Provider.KAKAO, "app-access-token");
+
+        assertThat(identity).isEqualTo(SocialIdentity.of(Provider.KAKAO, "app-access-token"));
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 제공자로 액세스 토큰 인증을 요청하면 미지원 제공자 예외를 던진다")
+    void authenticateWithAccessToken_unknownProvider_throwsInvalidProvider() {
+        SocialAuthenticatorImpl authenticator = new SocialAuthenticatorImpl(List.of(new StubKakaoClient()));
+
+        assertThatThrownBy(() -> authenticator.authenticateWithAccessToken(Provider.GOOGLE, "app-access-token"))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PROVIDER);
+    }
+
+    private static class StubKakaoClient implements OAuthClient {
+
+        @Override
+        public Provider provider() {
+            return Provider.KAKAO;
+        }
+
+        @Override
+        public SocialIdentity getIdentity(String authorizationCode, String codeVerifier, ClientType clientType) {
+            return SocialIdentity.of(Provider.KAKAO, authorizationCode);
+        }
+
+        @Override
+        public SocialIdentity getIdentityByAccessToken(String accessToken) {
+            return SocialIdentity.of(Provider.KAKAO, accessToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

앱 SDK 가 받은 액세스 토큰으로 토큰 교환 없이 로그인하는 경로를 추가한다.

### 어댑터 계층
- 카카오 액세스 토큰으로 신원을 확인하는 OAuthClient 경로

### 애플리케이션 계층
- 로그인 요청·커맨드에 액세스 토큰 필드 추가
- 액세스 토큰이 있으면 토큰 교환 없이 인증하도록 서비스 분기

### 인프라
- 액세스 토큰 로그인 미지원 제공자 에러 코드

### 테스트
- 액세스 토큰 로그인 경로 단위 테스트

Closes #283