### PR TITLE
[#285] 모바일 QA 수정 (칩 대비·실시간 갱신·연타·플래시)

### DIFF
--- a/mobile/lib/core/realtime/ticker_store.dart
+++ b/mobile/lib/core/realtime/ticker_store.dart
@@ -81,6 +81,7 @@ class TickerStore {
   bool _scheduled = false;
   int _frameId = 0;
   bool _active = true;
+  int _holdCount = 0;
   bool _orderDirty = false;
   bool _disposed = false;
 
@@ -103,10 +104,21 @@ class TickerStore {
     if (identical(_observer, observer)) _observer = null;
   }
 
+  /// 상세·전체화면 차트가 마켓을 덮는 동안 잡아 둔다. 마켓 페이지는 자기가 가려지면
+  /// `setActive(false)` 를 부르지만, 그 화면들도 같은 스토어에서 티커를 받으므로 멈추면 안 된다.
+  void hold() => _holdCount++;
+
+  void release() {
+    if (_holdCount > 0) _holdCount--;
+  }
+
   /// 마켓 탭이 비활성이면 flush 를 멈춘다. `indexedStack` 은 숨은 탭의 build 비용을 그대로
   /// 청구하므로 구독 해제만으로는 부족하다(계획서 §4.2.3).
+  /// 단, 잡고 있는 화면(상세·전체화면 차트)이 있으면 마켓이 가려져도 멈추지 않는다.
   void setActive(bool active) {
-    if (_active == active || _disposed) return;
+    if (_disposed) return;
+    if (!active && _holdCount > 0) return;
+    if (_active == active) return;
     _active = active;
     if (active) return;
     _pending.clear();

--- a/mobile/lib/core/theme/theme.dart
+++ b/mobile/lib/core/theme/theme.dart
@@ -492,7 +492,7 @@ ThemeData buildTryptoTheme() {
     ),
     chipTheme: ChipThemeData(
       backgroundColor: TryptoPalette.secondary,
-      selectedColor: TryptoPalette.primary.withValues(alpha: 0.12),
+      selectedColor: TryptoPalette.primary.withValues(alpha: 0.18),
       side: const BorderSide(color: TryptoPalette.border),
       labelStyle: _sans(12, 1.3333, FontWeight.w500),
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),

--- a/mobile/lib/features/market/coin_detail_page.dart
+++ b/mobile/lib/features/market/coin_detail_page.dart
@@ -5,6 +5,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../../core/constants/exchanges.dart';
 import '../../core/format/formatters.dart';
+import '../../core/realtime/stomp_service.dart';
 import '../../core/realtime/ticker_store.dart';
 import '../../core/router/guard.dart';
 import '../../core/theme/theme.dart';
@@ -39,6 +40,37 @@ class _CoinDetailPageState extends ConsumerState<CoinDetailPage> {
   /// 주문이 나갈 때마다 올린다. 거래내역 탭이 이 값을 보고 다시 읽는다 — 체결 이벤트 큐는
   /// 서버에서 동작하지 않으므로(사양서 R3) 반영은 전부 REST 재조회다.
   int _revision = 0;
+
+  /// 이 화면은 마켓을 루트 네비게이터 위로 덮는다. 가려진 마켓 페이지는 자기 티커 구독을
+  /// 끊고 스토어를 멈추려 하므로, 상세가 직접 스토어를 잡고(hold) 같은 토픽을 구독해 현재가·
+  /// 캔들 실시간 갱신을 잇는다. 거래소는 진입 시점에 고정된다(쿼리 파라미터).
+  void Function()? _cancelTickers;
+  bool _bound = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_bound) return;
+    _bound = true;
+    final store = ref.read(tickerStoreProvider);
+    store.hold();
+    final exchange = ExchangeIds.byKey(
+      GoRouterState.of(context).uri.queryParameters['exchange'],
+    );
+    _cancelTickers = ref
+        .read(stompServiceProvider)
+        .subscribe(
+          '/topic/tickers.${exchange.id}',
+          (body) => store.ingest(decodeTickers(body)),
+        );
+  }
+
+  @override
+  void dispose() {
+    _cancelTickers?.call();
+    ref.read(tickerStoreProvider).release();
+    super.dispose();
+  }
 
   void _refresh() => setState(() => _revision++);
 

--- a/mobile/lib/features/market/coin_detail_page.dart
+++ b/mobile/lib/features/market/coin_detail_page.dart
@@ -398,6 +398,14 @@ class IntervalChips extends StatelessWidget {
             ChoiceChip(
               label: Text(entry.value.label),
               selected: entry.key == interval,
+              labelStyle: TextStyle(
+                fontSize: 12,
+                fontWeight:
+                    entry.key == interval ? FontWeight.w700 : FontWeight.w600,
+                color: entry.key == interval
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.onSurface,
+              ),
               onSelected: (_) => onChanged(entry.key),
             ),
             const SizedBox(width: TryptoSpacing.xs),

--- a/mobile/lib/features/market/coin_row.dart
+++ b/mobile/lib/features/market/coin_row.dart
@@ -82,29 +82,17 @@ class CoinRow extends StatelessWidget {
             const SizedBox(width: TryptoSpacing.sm),
             SizedBox(
               width: _kNumericWidth,
-              child: Stack(
-                // 테두리가 숫자 바깥(오른쪽 8 · 위아래 10)으로 확장된다. 자르면 안 된다.
-                clipBehavior: Clip.none,
-                children: [
-                  RepaintBoundary(
-                    child: ValueListenableBuilder<CoinRowState>(
-                      valueListenable: row,
-                      builder: (context, state, child) => CoinNumbers(
-                        price: state.price,
-                        changeRate: state.changeRate,
-                        volume: state.volume,
-                        baseCurrency: baseCurrency,
-                      ),
-                    ),
+              child: RepaintBoundary(
+                child: ValueListenableBuilder<CoinRowState>(
+                  valueListenable: row,
+                  builder: (context, state, child) => CoinNumbers(
+                    price: state.price,
+                    changeRate: state.changeRate,
+                    volume: state.volume,
+                    baseCurrency: baseCurrency,
+                    flash: flash,
                   ),
-                  Positioned(
-                    left: 0,
-                    right: -8,
-                    top: -10,
-                    bottom: -10,
-                    child: RepaintBoundary(child: _FlashBorder(flash: flash)),
-                  ),
-                ],
+                ),
               ),
             ),
           ],
@@ -114,13 +102,14 @@ class CoinRow extends StatelessWidget {
   }
 }
 
-/// 숫자의 글자색·배경을 바꾸지 않고 **테두리만 잠깐 두른다**. 읽어야 할 숫자가 흔들리지 않게
-/// 하려는 의도적 선택이다(사양서 §3.3.3). 페이드하지 않으므로 `AnimatedContainer` 를 쓰지
-/// 않는다.
-class _FlashBorder extends StatelessWidget {
-  const _FlashBorder({required this.flash});
+/// 시세가 바뀐 **현재가 숫자에만** 잠깐 얇은 테두리를 두른다(업비트 방식). 테두리 두께·여백은
+/// 플래시 유무와 무관하게 항상 차지하므로(색만 바뀐다) 깜빡여도 레이아웃이 흔들리지 않는다.
+/// 페이드하지 않으므로 `AnimatedContainer` 를 쓰지 않는다(사양서 §3.3.3).
+class _PriceFlash extends StatelessWidget {
+  const _PriceFlash({required this.flash, required this.child});
 
   final FlashNotifier flash;
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
@@ -129,21 +118,22 @@ class _FlashBorder extends StatelessWidget {
     return ValueListenableBuilder<FlashDir?>(
       valueListenable: flash,
       builder: (context, dir, child) {
-        if (dir == null) return const SizedBox.shrink();
         final color = switch (dir) {
+          null => Colors.transparent,
           FlashDir.up => colors.positive,
           FlashDir.down => colors.negative,
           FlashDir.same => colors.flashNeutral,
         };
-        return IgnorePointer(
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              border: Border.all(color: color),
-              borderRadius: BorderRadius.circular(TryptoRadius.md),
-            ),
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+          decoration: BoxDecoration(
+            border: Border.all(color: color),
+            borderRadius: BorderRadius.circular(TryptoRadius.sm),
           ),
+          child: child,
         );
       },
+      child: child,
     );
   }
 }
@@ -156,12 +146,14 @@ class CoinNumbers extends StatelessWidget {
     required this.changeRate,
     required this.volume,
     required this.baseCurrency,
+    required this.flash,
   });
 
   final double price;
   final double changeRate;
   final double volume;
   final String baseCurrency;
+  final FlashNotifier flash;
 
   @override
   Widget build(BuildContext context) {
@@ -174,14 +166,17 @@ class CoinNumbers extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        NumericText(
-          unpriced
-              ? '-'
-              : '${getCurrencySymbol(baseCurrency)}'
-                    '${formatPrice(price, baseCurrency)}',
-          color: unpriced
-              ? theme.colorScheme.onSurfaceVariant
-              : context.profitColor(changeRate),
+        _PriceFlash(
+          flash: flash,
+          child: NumericText(
+            unpriced
+                ? '-'
+                : '${getCurrencySymbol(baseCurrency)}'
+                      '${formatPrice(price, baseCurrency)}',
+            color: unpriced
+                ? theme.colorScheme.onSurfaceVariant
+                : context.profitColor(changeRate),
+          ),
         ),
         const SizedBox(height: 4),
         Row(

--- a/mobile/lib/features/market/market_page.dart
+++ b/mobile/lib/features/market/market_page.dart
@@ -233,6 +233,10 @@ class _CoinListState extends ConsumerState<_CoinList> {
   late List<CoinEntry> _rows;
   Timer? _resort;
 
+  /// 따닥 연타 방지. `isCurrent` 는 같은 프레임 안의 두 번째 탭에서는 아직 바뀌지 않아
+  /// 둘 다 통과한다. 첫 탭에서 동기적으로 세워 두고 상세가 닫힐 때(push 의 Future 완료) 푼다.
+  bool _opening = false;
+
   @override
   void initState() {
     super.initState();
@@ -315,9 +319,17 @@ class _CoinListState extends ConsumerState<_CoinList> {
                         row: _store.row(entry.symbol)!,
                         flash: _store.flash(entry.symbol)!,
                         baseCurrency: widget.exchange.baseCurrency,
-                        onTap: () => context.push(
-                          Routes.coinDetail(entry.symbol, widget.exchange.key),
-                        ),
+                        onTap: () async {
+                          if (_opening) return;
+                          _opening = true;
+                          await context.push(
+                            Routes.coinDetail(
+                              entry.symbol,
+                              widget.exchange.key,
+                            ),
+                          );
+                          if (mounted) _opening = false;
+                        },
                       );
                     },
                   ),

--- a/mobile/lib/features/market/market_page.dart
+++ b/mobile/lib/features/market/market_page.dart
@@ -356,6 +356,14 @@ class _ListControls extends StatelessWidget {
             ChoiceChip(
               label: Text(filter.label),
               selected: view.filter == filter,
+              labelStyle: TextStyle(
+                fontSize: 12,
+                fontWeight:
+                    view.filter == filter ? FontWeight.w700 : FontWeight.w600,
+                color: view.filter == filter
+                    ? theme.colorScheme.primary
+                    : theme.colorScheme.onSurface,
+              ),
               onSelected: (_) => onFilter(filter),
             ),
             const SizedBox(width: TryptoSpacing.xs),

--- a/mobile/lib/features/regret/rule_chips.dart
+++ b/mobile/lib/features/regret/rule_chips.dart
@@ -106,6 +106,11 @@ class RuleChips extends StatelessWidget {
                   ? 'BTC만 홀드한 나'
                   : 'BTC만 홀드한 나 ${formatProfitPercent(btcProfitRate!)}',
             ),
+            labelStyle: TextStyle(
+              fontSize: 12,
+              fontWeight: btcEnabled ? FontWeight.w700 : FontWeight.w600,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
             side: BorderSide(
               color: btcEnabled ? btcHoldColor : TryptoPalette.border,
             ),


### PR DESCRIPTION
## Summary

클릭 검증으로 발견한 UI 문제 5건을 수정한다.

- 마켓 필터·차트 간격 칩 대비 개선
- 코인 상세 현재가·캔들 실시간 갱신 수정
- 코인 행 연타 이중 열림 수정
- 복기 BTC 홀드 칩 흰 글씨 가독성 개선
- 시세 변동 플래시를 현재가 숫자에만 얇은 테두리로 표시

Closes #285