### PR TITLE
[#289] 구글 로그인 (앱 SDK + 백엔드 ID 토큰 검증)

### DIFF
--- a/api/src/main/java/ksh/tryptobackend/user/adapter/out/oauth/GoogleOAuthClient.java
+++ b/api/src/main/java/ksh/tryptobackend/user/adapter/out/oauth/GoogleOAuthClient.java
@@ -1,5 +1,6 @@
 package ksh.tryptobackend.user.adapter.out.oauth;
 
+import java.net.URI;
 import ksh.tryptobackend.common.exception.CustomException;
 import ksh.tryptobackend.common.exception.ErrorCode;
 import ksh.tryptobackend.user.domain.vo.ClientType;
@@ -33,6 +34,37 @@ public class GoogleOAuthClient implements OAuthClient {
         String accessToken = exchangeAccessToken(authorizationCode, codeVerifier, clientType);
         String memberId = fetchMemberId(accessToken);
         return SocialIdentity.of(Provider.GOOGLE, memberId);
+    }
+
+    /**
+     * 앱(google_sign_in)이 네이티브로 받은 ID 토큰으로 신원을 확인한다. 안드로이드·iOS 는 커스텀 스킴
+     * 리다이렉트가 막혀 인가 코드 흐름을 쓸 수 없으므로 SDK 가 준 ID 토큰을 tokeninfo 로 검증한다.
+     * 발급자(iss)와 발급 대상(aud)을 대조해 다른 앱의 토큰을 걸러 낸 뒤 sub 를 식별자로 쓴다.
+     */
+    @Override
+    public SocialIdentity getIdentityByAccessToken(String idToken) {
+        GoogleTokenInfoResponse info = requestTokenInfo(idToken);
+        if (info == null || info.sub() == null) {
+            throw new CustomException(ErrorCode.SOCIAL_SERVER_ERROR);
+        }
+        if (!properties.isTrustedIssuer(info.iss()) || !properties.isOwnAudience(info.aud())) {
+            throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
+        }
+        return SocialIdentity.of(Provider.GOOGLE, info.sub());
+    }
+
+    private GoogleTokenInfoResponse requestTokenInfo(String idToken) {
+        try {
+            return restClient
+                    .get()
+                    .uri(URI.create(properties.getTokenInfoUri() + "?id_token=" + idToken))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, OAuthHttp::failAuthentication)
+                    .onStatus(HttpStatusCode::is5xxServerError, OAuthHttp::failProviderServer)
+                    .body(GoogleTokenInfoResponse.class);
+        } catch (RestClientException e) {
+            throw new CustomException(ErrorCode.SOCIAL_SERVER_ERROR);
+        }
     }
 
     private String exchangeAccessToken(String authorizationCode, String codeVerifier, ClientType clientType) {

--- a/api/src/main/java/ksh/tryptobackend/user/adapter/out/oauth/GoogleOAuthProperties.java
+++ b/api/src/main/java/ksh/tryptobackend/user/adapter/out/oauth/GoogleOAuthProperties.java
@@ -1,8 +1,43 @@
 package ksh.tryptobackend.user.adapter.out.oauth;
 
+import java.util.Objects;
+import java.util.Set;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConfigurationProperties(prefix = "app.oauth.google")
-public class GoogleOAuthProperties extends OAuthProviderProperties {}
+public class GoogleOAuthProperties extends OAuthProviderProperties {
+
+    /** 구글이 발급자를 표기하는 두 형태를 모두 허용한다. */
+    private static final Set<String> TRUSTED_ISSUERS = Set.of("accounts.google.com", "https://accounts.google.com");
+
+    /** ID 토큰 검증 엔드포인트. 앱(google_sign_in)이 네이티브로 받은 ID 토큰의 서명·만료를 구글이 확인해 준다. */
+    private String tokenInfoUri = "https://oauth2.googleapis.com/tokeninfo";
+
+    public String getTokenInfoUri() {
+        return tokenInfoUri;
+    }
+
+    public void setTokenInfoUri(String tokenInfoUri) {
+        this.tokenInfoUri = tokenInfoUri;
+    }
+
+    public boolean isTrustedIssuer(String iss) {
+        return TRUSTED_ISSUERS.contains(iss);
+    }
+
+    /**
+     * ID 토큰의 aud 가 이 프로젝트에 발급된 클라이언트 ID 중 하나인지 확인한다. 앱은 웹 클라이언트 ID 를
+     * serverClientId 로 넘기므로 그 값이 aud 로 온다 — 다른 앱이 발급받은 토큰을 이 검사에서 걸러 낸다.
+     */
+    public boolean isOwnAudience(String aud) {
+        if (aud == null || aud.isBlank()) {
+            return false;
+        }
+        return getCredentials().values().stream()
+                .map(OAuthCredentials::clientId)
+                .filter(Objects::nonNull)
+                .anyMatch(aud::equals);
+    }
+}

--- a/api/src/main/java/ksh/tryptobackend/user/adapter/out/oauth/GoogleTokenInfoResponse.java
+++ b/api/src/main/java/ksh/tryptobackend/user/adapter/out/oauth/GoogleTokenInfoResponse.java
@@ -1,0 +1,7 @@
+package ksh.tryptobackend.user.adapter.out.oauth;
+
+/**
+ * 구글 tokeninfo 응답(ID 토큰 검증용). 서명·만료는 구글이 확인해 주고, 우리는 발급자(iss)와 발급 대상(aud)을
+ * 대조한 뒤 사용자 식별자(sub)를 쓴다.
+ */
+public record GoogleTokenInfoResponse(String sub, String aud, String iss) {}

--- a/mobile/lib/core/auth/auth_config.dart
+++ b/mobile/lib/core/auth/auth_config.dart
@@ -42,12 +42,11 @@ abstract final class AuthConfig {
         : Env.googleIosClientId,
   };
 
-  /// 버튼을 살리는 조건은 제공자별로 다르다(사양서 §2.4). 카카오는 SDK 로 동작하므로 네이티브 앱
-  /// 키만 있으면 되고(기본값이 있어 항상 채워진다), 구글은 `clientId` 와 콜백 스킴이 모두 있어야 한다.
+  /// 버튼을 살리는 조건은 제공자별로 다르다(사양서 §2.4). 둘 다 SDK 로 동작한다 — 카카오는 네이티브
+  /// 앱 키, 구글은 serverClientId(웹 클라이언트 ID)만 있으면 된다. 둘 다 기본값이 있어 항상 채워진다.
   static bool isConfigured(SocialProvider provider) => switch (provider) {
     SocialProvider.kakao => Env.kakaoNativeAppKey.isNotEmpty,
-    SocialProvider.google =>
-      clientId(provider).isNotEmpty && callbackScheme(provider).isNotEmpty,
+    SocialProvider.google => Env.googleServerClientId.isNotEmpty,
   };
 
   /// 비어 있는 `--dart-define` 키 목록. 디버그 빌드에서만 노출한다.
@@ -57,8 +56,7 @@ abstract final class AuthConfig {
           if (Env.kakaoNativeAppKey.isEmpty) 'KAKAO_NATIVE_APP_KEY',
         ],
         SocialProvider.google => [
-          if (clientId(provider).isEmpty) _clientIdKey(provider),
-          if (callbackScheme(provider).isEmpty) _callbackSchemeKey(provider),
+          if (Env.googleServerClientId.isEmpty) 'GOOGLE_SERVER_CLIENT_ID',
         ],
       };
 
@@ -83,17 +81,4 @@ abstract final class AuthConfig {
       },
     );
   }
-
-  static String _clientIdKey(SocialProvider provider) => switch (provider) {
-    SocialProvider.kakao => 'KAKAO_CLIENT_ID',
-    SocialProvider.google => clientType == ClientType.android
-        ? 'GOOGLE_ANDROID_CLIENT_ID'
-        : 'GOOGLE_IOS_CLIENT_ID',
-  };
-
-  static String _callbackSchemeKey(SocialProvider provider) =>
-      switch (provider) {
-        SocialProvider.kakao => 'KAKAO_CALLBACK_SCHEME',
-        SocialProvider.google => 'GOOGLE_CALLBACK_SCHEME',
-      };
 }

--- a/mobile/lib/core/env.dart
+++ b/mobile/lib/core/env.dart
@@ -22,6 +22,17 @@ class Env {
     'GOOGLE_IOS_CLIENT_ID',
   );
 
+  /// 구글은 안드로이드에서 커스텀 스킴 리다이렉트가 폐지돼(앱 사칭 위험) 공식 SDK(google_sign_in)로
+  /// 네이티브 로그인한다. SDK 에 넘기는 serverClientId(= 웹 클라이언트 ID)가 ID 토큰의 대상(aud)이
+  /// 되고, 백엔드가 같은 값으로 검증한다. 클라이언트 ID 는 비밀이 아니므로 기본값을 둔다.
+  static const googleServerClientId = String.fromEnvironment(
+    'GOOGLE_SERVER_CLIENT_ID',
+    defaultValue: _googleServerClientId,
+  );
+
+  static const _googleServerClientId =
+      '218669927577-c4kei34t4og2ddh9jq8a3i46fsr61rrp.apps.googleusercontent.com';
+
   /// 구글 브라우저 인가 코드 흐름의 콜백 스킴(Dart 단일 출처). 값을 바꾸면 네이티브 등록처도 같이 바꾼다.
   /// - android/app/build.gradle.kts : manifestPlaceholders["authCallbackScheme"]
   /// - ios/Runner/Info.plist        : CFBundleURLSchemes

--- a/mobile/lib/features/auth/auth_controller.dart
+++ b/mobile/lib/features/auth/auth_controller.dart
@@ -94,7 +94,7 @@ class AuthController extends Notifier<AuthState> {
     state = AuthState(status: AuthStatus.authorizing, provider: provider);
 
     try {
-      // 인가 흐름은 제공자별로 다르다(카카오 SDK 토큰 / 구글 인가 코드). 서버 교환에 넣을
+      // 인가 흐름은 제공자별 공식 SDK 로 다르다(카카오 액세스 토큰 / 구글 ID 토큰). 서버 교환에 넣을
       // LoginRequest 를 통째로 돌려받으므로 여기서는 제공자를 구분하지 않는다.
       final request = await ref.read(socialLoginProvider).authorize(provider);
 

--- a/mobile/lib/features/auth/social_login.dart
+++ b/mobile/lib/features/auth/social_login.dart
@@ -1,11 +1,10 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
 import '../../core/auth/auth_config.dart';
-import '../../core/auth/pkce.dart';
+import '../../core/env.dart';
 import '../../models/enums.dart';
 import '../../models/user.dart';
 
@@ -93,20 +92,23 @@ class OAuthSecrets {
   }
 }
 
-/// 구글 인가 화면 호출부. 테스트에서 플러그인을 대체할 수 있도록 함수로 받는다.
-typedef WebAuthenticator =
-    Future<String> Function({
-      required String url,
-      required String callbackUrlScheme,
-    });
+/// 구글 SDK 토큰 획득부. 테스트에서 SDK 를 대체할 수 있도록 함수로 받는다. null 을 돌려주면 SDK 가
+/// 토큰 없이 반환한 것으로, 취소·실패와 같게 다룬다.
+typedef GoogleTokenProvider = Future<String?> Function();
 
-Future<String> _authenticateWithWebAuth({
-  required String url,
-  required String callbackUrlScheme,
-}) => FlutterWebAuth2.authenticate(
-  url: url,
-  callbackUrlScheme: callbackUrlScheme,
-);
+/// `initialize` 는 앱 수명 동안 한 번이면 된다. 첫 구글 로그인에서 만들어 두고 재사용한다.
+Future<void>? _googleInitialized;
+
+/// 구글 공식 SDK 로 네이티브 로그인해 ID 토큰을 받는다. `serverClientId`(웹 클라이언트 ID)가 ID
+/// 토큰의 대상(aud)이 되며, 백엔드가 같은 값으로 검증한다.
+Future<String?> _authenticateWithGoogle() async {
+  _googleInitialized ??= GoogleSignIn.instance.initialize(
+    serverClientId: Env.googleServerClientId,
+  );
+  await _googleInitialized;
+  final account = await GoogleSignIn.instance.authenticate();
+  return account.authentication.idToken;
+}
 
 /// 카카오 SDK 토큰 획득부. 테스트에서 SDK 를 대체할 수 있도록 함수로 받는다.
 typedef KakaoTokenProvider = Future<String> Function();
@@ -121,21 +123,19 @@ Future<String> _authenticateWithKakao() async {
   return token.accessToken;
 }
 
-/// 소셜 인가. 제공자로 분기한다 — 카카오는 공식 SDK 로 액세스 토큰을, 구글은 기존
-/// flutter_web_auth_2 인가 코드 흐름(Android 는 Chrome Custom Tabs, iOS 는
-/// `ASWebAuthenticationSession`)을 쓴다. 반환값은 곧바로 서버 교환에 넣는 [LoginRequest] 다.
+/// 소셜 인가. 제공자로 분기한다 — 둘 다 공식 SDK 로 앱에서 직접 토큰을 받는다. 카카오는 액세스
+/// 토큰을, 구글은 ID 토큰을 돌려준다. 구글도 SDK 인 이유는 안드로이드에서 커스텀 스킴 리다이렉트가
+/// 폐지돼(앱 사칭 위험) 브라우저 인가 코드 흐름을 못 쓰기 때문이다. 반환값은 곧바로 서버 교환에
+/// 넣는 [LoginRequest] 다.
 class SocialLoginService {
   SocialLoginService({
-    required OAuthSecrets secrets,
-    WebAuthenticator authenticator = _authenticateWithWebAuth,
     KakaoTokenProvider kakaoTokenProvider = _authenticateWithKakao,
-  }) : _secrets = secrets,
-       _authenticate = authenticator,
-       _kakaoToken = kakaoTokenProvider;
+    GoogleTokenProvider googleTokenProvider = _authenticateWithGoogle,
+  }) : _kakaoToken = kakaoTokenProvider,
+       _googleToken = googleTokenProvider;
 
-  final OAuthSecrets _secrets;
-  final WebAuthenticator _authenticate;
   final KakaoTokenProvider _kakaoToken;
+  final GoogleTokenProvider _googleToken;
 
   Future<LoginRequest> authorize(SocialProvider provider) => switch (provider) {
     SocialProvider.kakao => _authorizeKakao(),
@@ -161,7 +161,8 @@ class SocialLoginService {
     }
   }
 
-  /// 구글: 브라우저 인가 코드 흐름. 콜백 URL 은 `authenticate()` 의 반환값으로 온다.
+  /// 구글: 공식 SDK 가 앱에서 직접 ID 토큰을 돌려준다. 취소·중단·실패는 SDK 예외
+  /// (`GoogleSignInException`)로 오므로 크래시 대신 다시 시도할 수 있는 사용자 문구로 감싼다.
   Future<LoginRequest> _authorizeGoogle() async {
     const provider = SocialProvider.google;
     if (!AuthConfig.isConfigured(provider)) {
@@ -169,39 +170,23 @@ class SocialLoginService {
         '${AuthConfig.label(provider)} 로그인 설정이 완료되지 않았습니다.',
       );
     }
-
-    final verifier = Pkce.verifier();
-    final state = Pkce.state();
-    await _secrets.put(provider: provider, verifier: verifier, state: state);
-
     try {
-      final callback = await _authenticate(
-        url: AuthConfig.authorizeUrl(
-          provider,
-          challenge: Pkce.challenge(verifier),
-          state: state,
-        ).toString(),
-        callbackUrlScheme: AuthConfig.callbackScheme(provider),
-      );
-      final code = verifySocialCallback(
-        Uri.parse(callback),
-        provider: provider,
-        expectedState: state,
-        codeVerifier: verifier,
-      );
-      return LoginRequest.google(
-        code: code,
-        codeVerifier: verifier,
+      final idToken = await _googleToken();
+      if (idToken == null || idToken.isEmpty) {
+        throw SocialLoginException(
+          '${AuthConfig.label(provider)} 로그인이 취소되었거나 실패했습니다.',
+        );
+      }
+      return LoginRequest.googleToken(
+        idToken: idToken,
         clientType: AuthConfig.clientType,
       );
-    } on PlatformException {
-      // 사용자가 인가 화면을 닫으면 CANCELED 가 온다. 콜백 스킴이 OS 에 등록되지 않은 경우도
-      // 여기로 떨어지므로, 크래시 대신 다시 시도할 수 있는 문구를 남긴다.
+    } on SocialLoginException {
+      rethrow;
+    } catch (_) {
       throw SocialLoginException(
         '${AuthConfig.label(provider)} 로그인이 취소되었거나 실패했습니다.',
       );
-    } finally {
-      await _secrets.clear();
     }
   }
 }
@@ -209,5 +194,5 @@ class SocialLoginService {
 final oauthSecretsProvider = Provider<OAuthSecrets>((ref) => OAuthSecrets());
 
 final socialLoginProvider = Provider<SocialLoginService>(
-  (ref) => SocialLoginService(secrets: ref.watch(oauthSecretsProvider)),
+  (ref) => SocialLoginService(),
 );

--- a/mobile/lib/models/user.dart
+++ b/mobile/lib/models/user.dart
@@ -15,7 +15,7 @@ part 'user.g.dart';
 /// ID 가 별개다). `includeIfNull: false` 라 해당 흐름에 없는 필드는 바디에서 통째로 빠진다.
 @JsonSerializable(createFactory: false, includeIfNull: false)
 class LoginRequest {
-  /// 구글/웹: 인가 코드 + PKCE 검증값.
+  /// 웹: 인가 코드 + PKCE 검증값. 앱은 안드로이드에서 커스텀 스킴이 막혀 이 흐름을 쓰지 않는다.
   const LoginRequest.google({
     required this.code,
     required this.codeVerifier,
@@ -25,6 +25,13 @@ class LoginRequest {
   /// 카카오: 공식 SDK 가 앱에서 받은 액세스 토큰.
   const LoginRequest.kakao({required this.accessToken, this.clientType})
     : code = null,
+      codeVerifier = null;
+
+  /// 구글(앱): 공식 SDK(google_sign_in)가 받은 ID 토큰. 카카오와 같은 토큰 채널(`accessToken`)로
+  /// 보낸다 — 서버는 이 값을 tokeninfo 로 검증해 신원을 확인한다.
+  const LoginRequest.googleToken({required String idToken, this.clientType})
+    : accessToken = idToken,
+      code = null,
       codeVerifier = null;
 
   final String? code;

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -392,6 +392,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.8.1"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+1"
+  google_sign_in:
+    dependency: "direct main"
+    description:
+      name: google_sign_in
+      sha256: "521031b65853b4409b8213c0387d57edaad7e2a949ce6dea0d8b2afc9cb29763"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
+  google_sign_in_android:
+    dependency: transitive
+    description:
+      name: google_sign_in_android
+      sha256: a01d4fd5a0e4eb0c1961434a0289a436abf9225b0933963c8e4e5ed88c26e40b
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.15"
+  google_sign_in_ios:
+    dependency: transitive
+    description:
+      name: google_sign_in_ios
+      sha256: ac1e4c1205267cb7999d1d81333fccffdfda29e853f434bbaf71525498bb6950
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  google_sign_in_platform_interface:
+    dependency: transitive
+    description:
+      name: google_sign_in_platform_interface
+      sha256: "7f59208c42b415a3cca203571128d6f84f885fead2d5b53eb65a9e27f2965bb5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  google_sign_in_web:
+    dependency: transitive
+    description:
+      name: google_sign_in_web
+      sha256: d473003eeca892f96a01a64fc803378be765071cb0c265ee872c7f8683245d14
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   graphs:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   # UI
   fl_chart: ^1.0.0
   lucide_icons_flutter: ^3.1.0
+  google_sign_in: ^7.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

안드로이드에서 커스텀 스킴이 폐지돼 구글 로그인을 공식 SDK 방식으로 구현한다.

### 앱
- google_sign_in SDK 로 ID 토큰 획득 후 서버 전송
- serverClientId(웹 클라이언트 ID)를 ID 토큰 대상으로 사용

### 백엔드 (어댑터)
- ID 토큰을 tokeninfo 로 검증해 iss·aud 대조 후 sub 로 신원 확인

Closes #289