### PR TITLE
[#296] 소셜 로그인·로그아웃 흐름 버그 수정

### DIFF
--- a/api/src/main/java/ksh/tryptobackend/user/adapter/out/oauth/OAuthHttp.java
+++ b/api/src/main/java/ksh/tryptobackend/user/adapter/out/oauth/OAuthHttp.java
@@ -1,18 +1,23 @@
 package ksh.tryptobackend.user.adapter.out.oauth;
 
 import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import ksh.tryptobackend.common.exception.CustomException;
 import ksh.tryptobackend.common.exception.ErrorCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StreamUtils;
 import org.springframework.web.client.RestClient;
 
 final class OAuthHttp {
 
+    private static final Logger log = LoggerFactory.getLogger(OAuthHttp.class);
     private static final String GRANT_TYPE = "authorization_code";
 
     private OAuthHttp() {}
@@ -40,10 +45,28 @@ final class OAuthHttp {
     }
 
     static void failAuthentication(HttpRequest request, ClientHttpResponse response) {
+        logProviderFailure(request, response);
         throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
     }
 
     static void failProviderServer(HttpRequest request, ClientHttpResponse response) {
+        logProviderFailure(request, response);
         throw new CustomException(ErrorCode.SOCIAL_SERVER_ERROR);
+    }
+
+    // 제공자(카카오/구글)가 돌려준 실패 응답을 남긴다. 이 로그가 없으면 SOCIAL_LOGIN_FAILED 의
+    // 실제 원인(redirect_uri 불일치·client_secret 오류·인가 코드 만료 등)을 운영에서 알 수 없다.
+    // 실패 응답 본문에는 에러 코드만 담기며 액세스 토큰은 들어 있지 않다.
+    private static void logProviderFailure(HttpRequest request, ClientHttpResponse response) {
+        try {
+            log.warn(
+                    "소셜 로그인 제공자 요청 실패: {} {} -> status={} body={}",
+                    request.getMethod(),
+                    request.getURI(),
+                    response.getStatusCode(),
+                    StreamUtils.copyToString(response.getBody(), StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            log.warn("소셜 로그인 제공자 요청 실패, 응답 본문을 읽지 못했습니다", e);
+        }
     }
 }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Menu, X, LogOut } from "lucide-react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRound } from "@/contexts/RoundContext";
@@ -15,10 +15,18 @@ const navItems = [
 
 export function Header() {
   const location = useLocation();
+  const navigate = useNavigate();
   const { user, logout } = useAuth();
   const { hasActiveRound, isRoundLoading } = useRound();
   const [mobileOpen, setMobileOpen] = useState(false);
   const showRoundStart = !isRoundLoading && !hasActiveRound;
+
+  // 로그아웃 후에는 랜딩으로 보낸다. 순서가 중요하다 — 먼저 공개 라우트(/)로 옮긴 뒤 세션을 비운다.
+  // 반대로 하면 user 가 비는 순간 보호 라우트가 /login 으로 리다이렉트해 이 이동을 덮어쓴다.
+  const handleLogout = async () => {
+    navigate("/", { replace: true });
+    await logout();
+  };
 
   return (
     <header className="sticky top-0 z-50 border-b border-border/60 bg-background/95 backdrop-blur-md">
@@ -68,7 +76,7 @@ export function Header() {
             </Link>
           )}
           <button
-            onClick={logout}
+            onClick={() => void handleLogout()}
             className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
           >
             <LogOut className="h-3.5 w-3.5" />
@@ -131,7 +139,7 @@ export function Header() {
             <button
               onClick={() => {
                 setMobileOpen(false);
-                logout();
+                void handleLogout();
               }}
               className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
             >

--- a/frontend/src/components/round/RoundCreateHeader.tsx
+++ b/frontend/src/components/round/RoundCreateHeader.tsx
@@ -1,9 +1,17 @@
 import { LogOut } from "lucide-react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 
 export function RoundCreateHeader() {
   const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  // 로그아웃 후에는 랜딩으로 보낸다. 먼저 공개 라우트(/)로 옮긴 뒤 세션을 비운다 — 순서를 바꾸면
+  // user 가 비는 순간 보호 라우트가 /login 으로 리다이렉트해 이 이동을 덮어쓴다.
+  const handleLogout = async () => {
+    navigate("/", { replace: true });
+    await logout();
+  };
 
   return (
     <header className="sticky top-0 z-50 bg-white/90 shadow-sm backdrop-blur-xl">
@@ -18,7 +26,7 @@ export function RoundCreateHeader() {
             <span className="text-sm font-medium text-muted-foreground">{user.nickname}</span>
           )}
           <button
-            onClick={logout}
+            onClick={() => void handleLogout()}
             className="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground"
           >
             <LogOut className="h-4 w-4" />

--- a/frontend/src/hooks/useSocialLogin.ts
+++ b/frontend/src/hooks/useSocialLogin.ts
@@ -41,6 +41,10 @@ export function useSocialLogin(): SocialLogin {
 
   const finish = useCallback(
     async (message: SocialCallbackMessage) => {
+      // 콜백은 한 번만 처리한다. 팝업이 StrictMode 로 결과를 두 번 발행하거나 다른 탭이
+      // 같은 메시지를 중복 전달하면, 두 번째부터는 이미 state·verifier 를 지운 뒤라
+      // 검증이 실패해 "보안 검증 실패" 가 순간 뜬다. 먼저 온 것만 받고 나머지는 버린다.
+      if (answeredRef.current) return;
       answeredRef.current = true;
       popupRef.current?.close();
       popupRef.current = null;

--- a/mobile/lib/features/mypage/mypage_page.dart
+++ b/mobile/lib/features/mypage/mypage_page.dart
@@ -356,8 +356,12 @@ class _AccountActions extends ConsumerWidget {
         SizedBox(
           width: double.infinity,
           child: OutlinedButton.icon(
-            // 서버 호출이 실패해도 로컬 상태를 비운다. 인증이 비면 redirect 가 /login 으로 보낸다.
-            onPressed: () => ref.read(authControllerProvider.notifier).logout(),
+            // 서버 호출이 실패해도 로컬 상태를 비운다. 로그아웃 뒤에는 /login 으로 스택을 리셋한다 —
+            // redirect 에만 맡기면 뒤로가기가 이전 보호 화면으로 돌아가려다 다시 /login 으로 튕긴다.
+            onPressed: () async {
+              await ref.read(authControllerProvider.notifier).logout();
+              if (context.mounted) context.go(Routes.login);
+            },
             icon: const Icon(LucideIcons.logOut, size: 16),
             label: const Text('로그아웃'),
           ),


### PR DESCRIPTION
## Summary

소셜 로그인·로그아웃 흐름의 버그 4건을 수정한다.

- **제공자 실패 로깅** — 카카오·구글이 돌려준 실패 응답을 남겨 원인을 진단 가능하게 한다.
- **콜백 중복 처리** — 이미 처리한 콜백은 무시해 "보안 검증에 실패했습니다" 순간 노출을 막는다.
- **로그아웃 내비게이션** — 웹은 랜딩으로, 모바일은 스택 리셋으로 로그인 화면에 갇히지 않게 한다.

---

## 주요 변경 사항

### api
- `OAuthHttp` — 제공자 4xx/5xx 실패 시 상태코드와 응답 본문을 WARN 으로 남긴다. 실패 응답 본문에는 에러 코드만 담기며 액세스 토큰은 없다.

### 웹 (frontend)
- `useSocialLogin` — 콜백 멱등 가드를 추가한다. StrictMode·다중 탭의 중복 발행에도 먼저 온 것만 처리한다.
- `Header`·`RoundCreateHeader` — 로그아웃 시 먼저 랜딩(`/`)으로 이동한 뒤 세션을 비운다. 순서를 바꾸면 보호 라우트가 /login 으로 리다이렉트해 이동을 덮어쓴다.

### 모바일 (mobile)
- `mypage_page` — 로그아웃 후 `context.go(Routes.login)` 으로 내비게이션 스택을 리셋해, 로그인 화면에서 뒤로가기가 앱을 깔끔히 종료하게 한다.

---

## Test Plan

- [x] 웹: 로그아웃 → 랜딩(`/`) 도착 확인
- [x] 모바일: 로그아웃 → 로그인 화면 → 뒤로가기 시 앱 종료(런처) 확인
- [x] 제공자 실패 응답이 WARN 로그로 남는지 확인

Closes #296