### PR TITLE
[#300] 오라클 클라우드 프로덕션 배포 인프라 및 배포 자동화 구축

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,62 @@
+# 프로덕션 서버용 환경변수 템플릿.
+# 복사해서 실제 값을 채운 파일(.env.prod / 서버의 .env)은 절대 커밋하지 않는다.
+#
+#   (PC)   cp .env.prod.example .env.prod  →  값 채움  →  deploy 스크립트가 사용
+#   (서버) 같은 내용이 서버의 .env 로 올라간다
+#
+# 검증: docker compose -f docker-compose.prod.yml --env-file .env.prod config --quiet
+
+# ---------- 이미지 태그 ----------
+# deploy 스크립트가 콘텐츠 해시 태그(arm64)로 채운다. 손으로 만지지 않는다.
+COLLECTOR_IMAGE=kimsehee98/trypto-collector:prod-CHANGEME
+API_IMAGE=kimsehee98/trypto-api:prod-CHANGEME
+ENGINE_IMAGE=kimsehee98/trypto-engine:prod-CHANGEME
+FRONTEND_IMAGE=kimsehee98/trypto-frontend:prod-CHANGEME
+
+# ---------- MySQL (오라클 관리형 HeatWave Always Free) ----------
+# MYSQL_HOST 는 HeatWave DB 시스템의 프라이빗 IP (VCN 안에서만 통한다).
+# 관리형 쪽 구성에서 time_zone=+09:00, utf8mb4_unicode_ci 를 맞춰야 한다.
+MYSQL_HOST=10.0.0.CHANGEME
+MYSQL_PORT=3306
+MYSQL_DATABASE=trypto
+MYSQL_USERNAME=trypto
+MYSQL_PASSWORD=CHANGEME
+
+# 평소 none. 테이블이 하나도 없는 최초 1회만 create 로 띄우고 곧바로 none 으로 되돌린다.
+HIBERNATE_DDL_AUTO=none
+SQL_INIT_MODE=always
+
+# ---------- RabbitMQ / InfluxDB / Grafana ----------
+RABBITMQ_USERNAME=trypto
+RABBITMQ_PASSWORD=CHANGEME
+INFLUXDB_USERNAME=admin
+INFLUXDB_PASSWORD=CHANGEME
+INFLUXDB_ORG=trypto
+INFLUXDB_BUCKET=ticker
+INFLUXDB_TOKEN=CHANGEME-긴-랜덤-문자열
+GRAFANA_PASSWORD=CHANGEME
+
+# ---------- 소셜 로그인 (백엔드 토큰 교환용) ----------
+# 카카오/구글 콘솔에 https://trypto.dev 콜백을 "추가" 등록한 뒤 쓴다.
+# localhost 콜백은 지우지 말 것 — 로컬 개발이 계속 써야 한다.
+KAKAO_CLIENT_ID=CHANGEME
+KAKAO_CLIENT_SECRET=CHANGEME
+KAKAO_REDIRECT_URI=https://trypto.dev/auth/kakao/callback
+GOOGLE_CLIENT_ID=CHANGEME.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=CHANGEME
+GOOGLE_REDIRECT_URI=https://trypto.dev/auth/google/callback
+
+# ---------- 소셜 로그인 (프론트, 빌드 시점에 번들에 박힘) ----------
+# 이 값들을 바꾸면 frontend 이미지를 반드시 다시 굽는다 (런타임 반영 안 됨).
+VITE_KAKAO_CLIENT_ID=CHANGEME
+VITE_KAKAO_REDIRECT_URI=https://trypto.dev/auth/kakao/callback
+VITE_GOOGLE_CLIENT_ID=CHANGEME.apps.googleusercontent.com
+VITE_GOOGLE_REDIRECT_URI=https://trypto.dev/auth/google/callback
+
+# 모바일용(KAKAO_ANDROID_* 등)은 아직 앱이 없으므로 생략한다. compose 기본값이 빈 값이다.
+
+# ---------- 기타 ----------
+# 프론트 컨테이너는 127.0.0.1:8081 로만 열리고 호스트 nginx 가 프록시한다.
+FRONTEND_PORT=8081
+LOG_LEVEL_APP=INFO
+LOG_LEVEL_WEBSOCKET=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ loadtest/tuning/
 
 # Env
 .env
+.env.prod

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.7
-FROM eclipse-temurin:21-jdk AS build
+# 빌드 스테이지는 빌드 머신 아키텍처로 돈다 (jar 는 아키텍처 무관). arm64 크로스 빌드 시 에뮬레이션을 피한다.
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk AS build
 WORKDIR /app
 COPY gradle/ gradle/
 COPY gradlew build.gradle settings.gradle ./

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.7
-FROM eclipse-temurin:21-jdk AS build
+# 빌드 스테이지는 빌드 머신 아키텍처로 돈다 (jar 는 아키텍처 무관). arm64 크로스 빌드 시 에뮬레이션을 피한다.
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk AS build
 WORKDIR /app
 COPY gradle/ gradle/
 COPY gradlew build.gradle settings.gradle ./

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,117 @@
+# 프로덕션 배포 (Oracle Cloud)
+
+배포는 두 가지로 나뉜다. **최초 1회 부트스트랩**과 **반복 배포**를 혼동하지 않는다.
+
+| 구분 | 무엇 | 언제 |
+|------|------|------|
+| 부트스트랩 | 인플럭스 시드, DNS, 인증서, DB 생성, 최초 스키마 | 서버를 처음 세울 때 딱 한 번 |
+| 반복 배포 | `bash deploy/deploy.sh` | 코드가 바뀔 때마다 |
+
+인프라 생성(terraform)은 [terraform/prod/README.md](../terraform/prod/README.md) 를 따른다.
+
+---
+
+## 반복 배포
+
+```
+bash deploy/deploy.sh                # 빌드/푸시 + 서버 반영
+bash deploy/deploy.sh --build-only   # 서버가 아직 없을 때 이미지만 준비
+```
+
+모듈별 소스 해시로 태그를 만들므로, 코드가 같으면 빌드·푸시·재기동이 전부 스킵된다.
+`VITE_` 값(소셜 로그인 주소 등)을 바꾸면 frontend 태그가 바뀌어 자동으로 다시 빌드된다.
+데이터 볼륨은 절대 건드리지 않는다.
+
+---
+
+## 최초 1회 부트스트랩
+
+전제: terraform apply 완료, `app_public_ip` 확보. 아래에서 `<IP>` 는 그 값이다.
+
+### 1. DNS
+
+Cloudflare → trypto.dev → DNS → A 레코드 생성: 이름 `@`, 값 `<IP>`, **프록시 꺼짐(회색 구름)**.
+
+### 2. 시계열 DB 시드 (D 드라이브 → 서버 볼륨)
+
+컨테이너를 처음 띄우기 **전에** 한다. 볼륨이 비어 있지 않으면 인플럭스 초기 셋업이 자동으로 생략되고, 시드에 들어 있는 조직/버킷/토큰/집계 태스크가 그대로 산다.
+
+```bash
+# PC (레포 루트)
+tar -C /d/trypto-influx-data -czf influx-seed.tar.gz .
+scp -i ~/.ssh/trypto_oracle influx-seed.tar.gz ubuntu@<IP>:/opt/trypto/
+
+# 서버
+docker volume create trypto_influxdb-data
+docker run --rm -v trypto_influxdb-data:/target -v /opt/trypto:/src alpine \
+  sh -c "tar -xzf /src/influx-seed.tar.gz -C /target && chown -R 1000:1000 /target"
+rm /opt/trypto/influx-seed.tar.gz
+```
+
+### 3. 데이터베이스 생성 (관리형 MySQL)
+
+기존 MySQL 컨테이너와 콜레이션을 맞춰서 만든다.
+
+```bash
+# 서버 (비밀번호는 .env 의 MYSQL_PASSWORD)
+mysql -h mysql.db.trypto.oraclevcn.com -u trypto -p \
+  -e "CREATE DATABASE trypto CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+```
+
+### 4. 첫 배포 + 최초 스키마
+
+```bash
+# PC
+bash deploy/deploy.sh
+```
+
+테이블이 하나도 없는 최초 1회만: 서버의 `/opt/trypto/.env` 에서 `HIBERNATE_DDL_AUTO=create` 로 바꿔
+`docker compose -f docker-compose.prod.yml up -d backend` 로 한 번 띄우고, 헬시 확인 후 **곧바로 `none` 으로 되돌려** 다시 `up -d backend` 한다.
+
+### 5. 인증서 + 호스트 nginx
+
+DNS 전파 후(1 단계로부터 수 분) 서버에서:
+
+```bash
+sudo certbot certonly --nginx -d trypto.dev
+sudo cp /opt/trypto/deploy/nginx-trypto.conf /etc/nginx/conf.d/trypto.conf   # deploy.sh 가 올려둔 파일
+sudo rm -f /etc/nginx/sites-enabled/default
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+갱신은 certbot 이 systemd 타이머로 자동 수행한다. `sudo certbot renew --dry-run` 으로 확인한다.
+
+### 6. 인플럭스 토큰 교체 (보안 위생)
+
+시드에 들어 있는 토큰은 개발용 약한 값이므로 부팅 후 교체한다.
+
+```bash
+# 서버
+cd /opt/trypto
+docker compose -f docker-compose.prod.yml exec influxdb \
+  influx auth create --org trypto --all-access
+# 출력된 토큰을 .env 의 INFLUXDB_TOKEN 에 반영 후
+docker compose -f docker-compose.prod.yml up -d backend collector
+```
+
+### 7. 소셜 로그인 콘솔 등록 (아직 안 했다면)
+
+- 카카오: Web 플랫폼 도메인 `https://trypto.dev` + Redirect URI `https://trypto.dev/auth/kakao/callback` 추가
+- 구글: 승인된 리디렉션 URI `https://trypto.dev/auth/google/callback` + JS 원본 `https://trypto.dev` 추가, 동의 화면 게시 상태 "프로덕션"
+
+### 8. 확인
+
+- `https://trypto.dev` 접속 → 시세 표시·소셜 로그인·주문까지 눈으로 확인
+- 그라파나: `ssh -i ~/.ssh/trypto_oracle -L 3000:localhost:3000 ubuntu@<IP>` 후 `http://localhost:3000`
+
+---
+
+## 트러블슈팅
+
+| 증상 | 확인 |
+|------|------|
+| 접속 자체가 안 됨 | 서버 iptables (`sudo iptables -L INPUT -n \| head`) — cloud-init 이 80/443 을 열었는지 |
+| 502 | 프론트 컨테이너 상태 (`docker compose ps`), 8081 바인딩 |
+| 로그인 무한 루프/쿠키 문제 | https 로 접속했는지 (SESSION_COOKIE_SECURE=true 는 http 에서 동작 안 함) |
+| buildx 가 --push 를 거부 | `docker buildx create --use` 로 빌더 생성 후 재시도 |
+| compose pull 실패 | 서버에서 `docker login` (프라이빗 이미지가 아니면 불필요) |

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# 프로덕션 배포 (반복 실행용).
+#
+#   bash deploy/deploy.sh                # 빌드/푸시 + 서버 반영
+#   bash deploy/deploy.sh --build-only   # 이미지 빌드/푸시까지만 (서버 없이도 가능)
+#
+# 동작: 모듈별 소스 콘텐츠 해시로 태그를 만들고(코드 같으면 태그 같음),
+# Docker Hub 에 그 태그가 이미 있으면 빌드/푸시를 통째로 스킵한다.
+# 이미지는 linux/arm64 로 굽는다 (오라클 A1). 빌드 스테이지는 Dockerfile 의
+# --platform=$BUILDPLATFORM 덕에 네이티브로 돌아서 에뮬레이션 비용이 없다.
+#
+# 최초 1회 부트스트랩(인플럭스 시드, 인증서, DB 생성 등)은 deploy/README.md 참고.
+# 그 절차는 이 스크립트가 하지 않는다.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ENV_FILE=.env.prod
+SSH_KEY="$HOME/.ssh/trypto_oracle"
+REMOTE=/opt/trypto
+HUB=kimsehee98
+MODE="${1:-}"
+
+log() { echo "[deploy] $*"; }
+die() { echo "[deploy][ERROR] $*" >&2; exit 1; }
+
+[ -f "$ENV_FILE" ] || die "$ENV_FILE 없음 (.env.prod.example 을 복사해 채운다)"
+docker info >/dev/null 2>&1 || die "docker 데몬이 안 떠 있다"
+# Windows 자격증명 저장소를 쓰면 docker info 에 Username 이 안 나오므로 config.json 의 로그인 흔적으로 확인한다
+grep -q 'index.docker.io' "$HOME/.docker/config.json" 2>/dev/null \
+  || docker info 2>/dev/null | grep -q "Username: $HUB" \
+  || die "docker login 필요 (Hub 계정: $HUB)"
+
+# ---------- 콘텐츠 해시 태그 ----------
+java_hash() {
+  local m=$1
+  {
+    find "$m/src" -type f -print0 | sort -z | xargs -0 sha256sum
+    sha256sum "$m/Dockerfile" "$m/build.gradle" "$m/settings.gradle"
+  } | sha256sum | cut -c1-12
+}
+
+front_hash() {
+  {
+    find frontend/src frontend/public -type f -print0 2>/dev/null | sort -z | xargs -0 sha256sum
+    sha256sum frontend/Dockerfile frontend/nginx.conf frontend/package.json \
+      frontend/package-lock.json frontend/index.html frontend/vite.config.ts
+    # VITE_ 값은 번들에 박히므로 값이 바뀌면 태그도 바뀌어야 한다
+    grep '^VITE_' "$ENV_FILE"
+  } | sha256sum | cut -c1-12
+}
+
+API_TAG="prod-$(java_hash api)"
+COL_TAG="prod-$(java_hash collector)"
+ENG_TAG="prod-$(java_hash engine)"
+FRT_TAG="prod-$(front_hash)"
+
+# ---------- Hub 존재 체크 → 없는 것만 arm64 빌드/푸시 ----------
+need() { ! docker manifest inspect "$1" >/dev/null 2>&1; }
+
+VITE_ARGS=$(grep '^VITE_' "$ENV_FILE" | sed 's/^/--build-arg /' | tr '\n' ' ')
+
+build_push() { # $1=이미지:태그 $2=컨텍스트 $3=추가인자
+  log "빌드/푸시: $1"
+  # shellcheck disable=SC2086
+  docker buildx build --platform linux/arm64 --push -t "$1" $3 "$2"
+}
+
+if need "$HUB/trypto-api:$API_TAG";       then build_push "$HUB/trypto-api:$API_TAG" ./api ""; else log "api 변경 없음 → 스킵"; fi
+if need "$HUB/trypto-collector:$COL_TAG"; then build_push "$HUB/trypto-collector:$COL_TAG" ./collector ""; else log "collector 변경 없음 → 스킵"; fi
+if need "$HUB/trypto-engine:$ENG_TAG";    then build_push "$HUB/trypto-engine:$ENG_TAG" ./engine ""; else log "engine 변경 없음 → 스킵"; fi
+if need "$HUB/trypto-frontend:$FRT_TAG";  then build_push "$HUB/trypto-frontend:$FRT_TAG" ./frontend "$VITE_ARGS"; else log "frontend 변경 없음 → 스킵"; fi
+
+# ---------- .env.prod 의 이미지 태그 갱신 ----------
+sed -i "s|^API_IMAGE=.*|API_IMAGE=$HUB/trypto-api:$API_TAG|" "$ENV_FILE"
+sed -i "s|^COLLECTOR_IMAGE=.*|COLLECTOR_IMAGE=$HUB/trypto-collector:$COL_TAG|" "$ENV_FILE"
+sed -i "s|^ENGINE_IMAGE=.*|ENGINE_IMAGE=$HUB/trypto-engine:$ENG_TAG|" "$ENV_FILE"
+sed -i "s|^FRONTEND_IMAGE=.*|FRONTEND_IMAGE=$HUB/trypto-frontend:$FRT_TAG|" "$ENV_FILE"
+log "태그: api=$API_TAG collector=$COL_TAG engine=$ENG_TAG frontend=$FRT_TAG"
+
+if [ "$MODE" = "--build-only" ]; then
+  log "빌드만 완료 (--build-only)"
+  exit 0
+fi
+
+# ---------- 서버 반영 ----------
+SERVER_IP="${SERVER_IP:-$(terraform -chdir=terraform/prod output -raw app_public_ip 2>/dev/null || true)}"
+[ -n "$SERVER_IP" ] || die "서버 IP 를 알 수 없다. 인스턴스 생성 전이면 --build-only 로 실행한다"
+
+SSH="ssh -i $SSH_KEY -o StrictHostKeyChecking=accept-new ubuntu@$SERVER_IP"
+log "파일 동기화 → $SERVER_IP:$REMOTE"
+$SSH "mkdir -p $REMOTE"
+scp -i "$SSH_KEY" -o StrictHostKeyChecking=accept-new docker-compose.prod.yml "ubuntu@$SERVER_IP:$REMOTE/"
+scp -i "$SSH_KEY" -o StrictHostKeyChecking=accept-new "$ENV_FILE" "ubuntu@$SERVER_IP:$REMOTE/.env"
+scp -r -i "$SSH_KEY" -o StrictHostKeyChecking=accept-new docker "ubuntu@$SERVER_IP:$REMOTE/"
+scp -r -i "$SSH_KEY" -o StrictHostKeyChecking=accept-new deploy "ubuntu@$SERVER_IP:$REMOTE/"
+
+log "이미지 pull + 컨테이너 교체"
+$SSH "cd $REMOTE && docker compose -f docker-compose.prod.yml pull -q && docker compose -f docker-compose.prod.yml up -d --no-build"
+
+log "컨테이너 상태:"
+$SSH "cd $REMOTE && docker compose -f docker-compose.prod.yml ps"
+log "완료. backend 는 헬시까지 최대 4분 걸린다. 로그 보기:"
+log "  ssh -i $SSH_KEY ubuntu@$SERVER_IP 'cd $REMOTE && docker compose -f docker-compose.prod.yml logs -f backend'"

--- a/deploy/nginx-trypto.conf
+++ b/deploy/nginx-trypto.conf
@@ -1,0 +1,44 @@
+# 호스트 nginx 설정 — TLS 종단 후 프론트 컨테이너(127.0.0.1:8081)로 넘긴다.
+# 서버의 /etc/nginx/conf.d/trypto.conf 로 배치한다. (부트스트랩 절차는 deploy/README.md)
+# 인증서 발급(certbot) 전에는 443 블록이 로드에 실패하므로, 발급 후에 배치한다.
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ""      close;
+}
+
+server {
+    listen 80;
+    server_name trypto.dev;
+
+    # certbot 갱신 검증 경로만 http 로 열어둔다
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name trypto.dev;
+
+    ssl_certificate     /etc/letsencrypt/live/trypto.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/trypto.dev/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # 웹소켓(/ws) 업그레이드. 시세 스트림이 오래 붙어 있으므로 타임아웃을 길게 준다
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,16 +1,20 @@
 # 배포용 구성. 이 파일 하나로 완결된다.
 #
-#   docker compose -f docker-compose.prod.yml up -d --build
+#   (PC)   deploy 스크립트가 arm64 이미지를 빌드해 Hub 에 올리고 .env 의 *_IMAGE 태그를 채운다
+#   (서버) docker compose -f docker-compose.prod.yml pull
+#          docker compose -f docker-compose.prod.yml up -d --no-build
 #
 # 개발용은 docker-compose.yml 이고 서로 겹쳐 쓰지 않는다.
 # 비밀번호·토큰·소셜 로그인 주소는 전부 .env 에서 읽는다. 값이 없으면 기동에 실패한다.
 #
 # 개발용과 다른 점
 #   - 비밀번호와 토큰이 파일에 박혀 있지 않다
-#   - HIBERNATE_DDL_AUTO 가 validate 다 (재시작해도 테이블이 지워지지 않는다)
-#   - 로그인 쿠키가 HTTPS 로만 오간다
+#   - HIBERNATE_DDL_AUTO 가 none 이다 (재시작해도 테이블이 지워지지 않는다)
+#   - MySQL 컨테이너가 없다. 오라클 관리형 MySQL(HeatWave)을 MYSQL_HOST 로 가리킨다
+#   - 로그인 쿠키가 HTTPS 로만 오간다 (TLS 는 호스트 nginx 가 종단한다)
 #   - 로그가 INFO 다
-#   - 바깥에 열리는 포트는 화면(80) 하나뿐이다. DB·Redis·RabbitMQ 는 컨테이너끼리만 통한다
+#   - 바깥에 직접 열리는 포트가 없다. 화면은 127.0.0.1:8081 이라 호스트 nginx 만 접근하고,
+#     Redis·RabbitMQ·InfluxDB 는 컨테이너끼리만 통한다
 #   - 화면이 Vite 개발 서버가 아니라 미리 빌드한 파일을 nginx 가 서빙한다
 #   - prometheus·grafana 는 서버 안(127.0.0.1)에만 열린다. SSH 로 연결해서 본다
 name: trypto
@@ -21,26 +25,10 @@ networks:
 
 services:
   # ---------- infra ----------
-  mysql:
-    image: mysql:8.0.30
-    restart: unless-stopped
-    networks:
-      - trypto-net
-    environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD:?MYSQL_PASSWORD 를 .env 에 넣어야 한다}
-      MYSQL_DATABASE: ${MYSQL_DATABASE:-trypto}
-    volumes:
-      - mysql-data:/var/lib/mysql
-    command:
-      - --character-set-server=utf8mb4
-      - --collation-server=utf8mb4_unicode_ci
-      - --default-time-zone=+09:00
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-p${MYSQL_PASSWORD}"]
-      interval: 5s
-      timeout: 3s
-      retries: 20
-
+  # MySQL 컨테이너는 없다. 오라클 관리형 MySQL(HeatWave Always Free)을 쓰고,
+  # 접속 정보는 .env 의 MYSQL_HOST/PORT/DATABASE/USERNAME/PASSWORD 로 받는다.
+  # 관리형 쪽 파라미터는 time_zone=+09:00, utf8mb4_unicode_ci 로 맞춘다
+  # (컨테이너 시절 command 로 강제하던 값과 동일해야 동작이 같다).
   redis:
     image: redis:7-alpine
     restart: unless-stopped
@@ -111,14 +99,12 @@ services:
       SPRING_RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD}
       INFLUXDB_URL: http://influxdb:8086
       INFLUXDB_TOKEN: ${INFLUXDB_TOKEN}
-      DB_HOST: mysql
-      DB_USERNAME: ${MYSQL_USERNAME:-root}
+      DB_HOST: ${MYSQL_HOST:?MYSQL_HOST 를 .env 에 넣어야 한다}
+      DB_USERNAME: ${MYSQL_USERNAME:?MYSQL_USERNAME 를 .env 에 넣어야 한다}
       DB_PASSWORD: ${MYSQL_PASSWORD}
       MANAGEMENT_PORT: "9090"
       LOG_LEVEL_APP: ${LOG_LEVEL_APP:-INFO}
     depends_on:
-      mysql:
-        condition: service_healthy
       rabbitmq:
         condition: service_healthy
       influxdb:
@@ -139,10 +125,10 @@ services:
     networks:
       - trypto-net
     environment:
-      MYSQL_HOST: mysql
-      MYSQL_PORT: "3306"
+      MYSQL_HOST: ${MYSQL_HOST:?MYSQL_HOST 를 .env 에 넣어야 한다}
+      MYSQL_PORT: "${MYSQL_PORT:-3306}"
       MYSQL_DATABASE: ${MYSQL_DATABASE:-trypto}
-      MYSQL_USERNAME: ${MYSQL_USERNAME:-root}
+      MYSQL_USERNAME: ${MYSQL_USERNAME:?MYSQL_USERNAME 를 .env 에 넣어야 한다}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       REDIS_HOST: redis
       REDIS_PORT: "6379"
@@ -202,10 +188,10 @@ services:
     volumes:
       - engine-wal:/wal
     environment:
-      MYSQL_HOST: mysql
-      MYSQL_PORT: "3306"
+      MYSQL_HOST: ${MYSQL_HOST:?MYSQL_HOST 를 .env 에 넣어야 한다}
+      MYSQL_PORT: "${MYSQL_PORT:-3306}"
       MYSQL_DATABASE: ${MYSQL_DATABASE:-trypto}
-      MYSQL_USERNAME: ${MYSQL_USERNAME:-root}
+      MYSQL_USERNAME: ${MYSQL_USERNAME:?MYSQL_USERNAME 를 .env 에 넣어야 한다}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       RABBITMQ_HOST: rabbitmq
       RABBITMQ_PORT: "5672"
@@ -214,8 +200,6 @@ services:
       ENGINE_WAL_DIR: /wal
       MANAGEMENT_PORT: "8082"
     depends_on:
-      mysql:
-        condition: service_healthy
       rabbitmq:
         condition: service_healthy
       backend:
@@ -242,8 +226,9 @@ services:
     restart: unless-stopped
     networks:
       - trypto-net
+    # 바깥에 직접 열지 않는다. 호스트 nginx(80/443)가 TLS 종단 후 여기로 프록시한다.
     ports:
-      - "${FRONTEND_PORT:-80}:80"
+      - "127.0.0.1:${FRONTEND_PORT:-8081}:80"
     depends_on:
       backend:
         condition: service_healthy
@@ -298,7 +283,6 @@ services:
       - prometheus
 
 volumes:
-  mysql-data:
   redis-data:
   rabbitmq-data:
   influxdb-data:

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.7
-FROM eclipse-temurin:21-jdk AS build
+# 빌드 스테이지는 빌드 머신 아키텍처로 돈다 (jar 는 아키텍처 무관). arm64 크로스 빌드 시 에뮬레이션을 피한다.
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk AS build
 WORKDIR /app
 COPY gradle/ gradle/
 COPY gradlew build.gradle settings.gradle ./

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,6 @@
 # 1단계: 프로덕션 번들 빌드
-FROM node:20-alpine AS build
+# 빌드 스테이지는 빌드 머신 아키텍처로 돈다 (번들은 아키텍처 무관). arm64 크로스 빌드 시 에뮬레이션을 피한다.
+FROM --platform=$BUILDPLATFORM node:20-alpine AS build
 
 WORKDIR /app
 

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -3,6 +3,7 @@
 *.tfstate
 *.tfstate.*
 *.tfvars
+apply-retry.log
 crash.log
 crash.*.log
 override.tf

--- a/terraform/prod/README.md
+++ b/terraform/prod/README.md
@@ -1,0 +1,48 @@
+# 프로덕션 인프라 (Oracle Cloud, Always Free)
+
+trypto 서비스 운영 인프라를 정의한다. 부하테스트 스택(`terraform/`)과는 상태 파일이 분리된 별개 스택이다.
+
+## 구성 요소
+
+| 리소스 | 내용 | 비용 |
+|--------|------|------|
+| VCN + 서브넷 2개 | 퍼블릭(VM) / 프라이빗(DB) 분리 | 무료 |
+| A1 인스턴스 | 2 OCPU / 12GB / 부트 100GB, Ubuntu 24.04 ARM | 무료 (Always Free) |
+| 고정 공인 IP | 인스턴스 재생성에도 유지 | 무료 |
+| 관리형 MySQL | HeatWave Always Free, 50GB, 일일 자동 백업 | 무료 (계정당 1개) |
+
+모든 리소스는 홈 리전(오사카)에만 생성할 수 있다.
+
+## 사전 준비
+
+1. **API 키** — 콘솔 우상단 프로필 → 내 프로파일 → API 키 → "API 키 추가" → 키 쌍 생성 후 개인 키를 `C:/Users/saree98/.oci/` 에 저장한다. 생성 직후 표시되는 "구성 파일 미리보기"에서 `tenancy` `user` `fingerprint` 값을 옮겨 적는다.
+2. **SSH 키** — `ssh-keygen -t ed25519 -f C:/Users/saree98/.ssh/trypto_oracle`
+3. **변수 파일** — `terraform.tfvars.example` 을 `terraform.tfvars` 로 복사해 값을 채운다.
+
+## 실행
+
+```
+terraform -chdir=terraform/prod init
+terraform -chdir=terraform/prod plan
+terraform -chdir=terraform/prod apply
+```
+
+### A1 용량 부족이 발생하는 경우
+
+`Out of host capacity` 오류는 계정 문제가 아니라 해당 가용 영역의 무료 ARM 재고 소진이다. 시간을 두고 apply 를 재시도한다. 수일간 계속되면 종량제(PAYG) 전환으로 우선순위를 높이는 방법이 있다 — Always Free 한도 내 사용은 전환 후에도 무료다.
+
+## apply 이후 절차
+
+1. 출력된 `app_public_ip` 를 Cloudflare 의 `trypto.dev` A 레코드로 등록한다 (프록시 꺼짐).
+2. VM 에 접속해 데이터베이스를 만든다 (기존 컨테이너 MySQL 과 콜레이션을 맞춘다):
+   ```
+   mysql -h mysql.db.trypto.oraclevcn.com -u trypto -p
+   CREATE DATABASE trypto CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+   ```
+3. 인증서 발급, `.env` 업로드, compose 기동은 배포 스크립트 문서를 따른다.
+
+## 주의 사항
+
+- `MySQL.Free` shape 는 Always Free 전용이며 스토리지 50GB 로 고정된다. 서버 시간대는 구성 리소스(`trypto-kst`)가 `+09:00` 으로 지정한다 — 기존 MySQL 컨테이너가 강제하던 값과 동일해야 시간 데이터가 일관된다.
+- 인스턴스 shape 를 2 OCPU / 12GB 초과로 바꾸면 Always Free 한도를 벗어난다 (2026-06 축소 이후 기준).
+- 체험 크레딧 기간(가입 후 30일) 중에도 이 구성은 전부 무료 한도 내이므로, 크레딧 만료 시 회수되는 리소스가 없다.

--- a/terraform/prod/budget.tf
+++ b/terraform/prod/budget.tf
@@ -1,0 +1,34 @@
+# 예산 알람. 이 계정은 전부 Always Free 한도 내 구성이라 정상 상태의 월 요금은 0원이다.
+# 따라서 1달러라도 잡히면 그 자체가 이상 신호다 — 10% 룰이 조기 경보 역할을 한다.
+
+resource "oci_budget_budget" "monthly" {
+  compartment_id = var.tenancy_ocid
+  display_name   = "trypto-monthly"
+  description    = "월 예산 10달러. 정상 운영 시 0원이어야 한다"
+  amount         = 10
+  reset_period   = "MONTHLY"
+  target_type    = "COMPARTMENT"
+  targets        = [var.tenancy_ocid]
+}
+
+# 실제 청구액이 1달러(10%)를 넘는 순간 — "뭔가 과금되기 시작했다" 조기 경보
+resource "oci_budget_alert_rule" "actual_early" {
+  budget_id      = oci_budget_budget.monthly.id
+  display_name   = "actual-1usd"
+  type           = "ACTUAL"
+  threshold      = 10
+  threshold_type = "PERCENTAGE"
+  recipients     = "kshee848@gmail.com"
+  message        = "[trypto] 오라클 실제 청구액이 1달러를 넘었다. 무료 한도 밖 리소스가 생겼는지 확인할 것."
+}
+
+# 월말 예측치가 10달러(100%)를 넘을 때
+resource "oci_budget_alert_rule" "forecast_full" {
+  budget_id      = oci_budget_budget.monthly.id
+  display_name   = "forecast-10usd"
+  type           = "FORECAST"
+  threshold      = 100
+  threshold_type = "PERCENTAGE"
+  recipients     = "kshee848@gmail.com"
+  message        = "[trypto] 오라클 월말 예상 요금이 예산 10달러를 초과할 전망이다."
+}

--- a/terraform/prod/cloud-init.yaml
+++ b/terraform/prod/cloud-init.yaml
@@ -1,0 +1,31 @@
+#cloud-config
+# 첫 부팅에서 서버를 배포 가능한 상태로 만든다.
+# 앱 배포 자체(compose, nginx 사이트 설정, 인증서)는 deploy 단계에서 SSH 로 한다.
+
+package_update: true
+packages:
+  - docker.io
+  - docker-compose-v2
+  - nginx
+  - certbot
+  - python3-certbot-dns-cloudflare
+  - mysql-client-core-8.0
+
+runcmd:
+  # 오라클 우분투 이미지는 iptables 가 22 외 전부 거부한다.
+  # 보안 목록(클라우드 방화벽)을 열어도 여기가 막혀 있으면 접속이 안 되므로 반드시 연다.
+  - iptables -I INPUT -p tcp --dport 80 -j ACCEPT
+  - iptables -I INPUT -p tcp --dport 443 -j ACCEPT
+  - netfilter-persistent save
+  # 도커
+  - systemctl enable --now docker
+  - usermod -aG docker ubuntu
+  # 스왑 4GB (램 12GB 라 필수는 아니지만 OOM 보험)
+  - fallocate -l 4G /swapfile
+  - chmod 600 /swapfile
+  - mkswap /swapfile
+  - swapon /swapfile
+  - echo '/swapfile none swap sw 0 0' >> /etc/fstab
+  # 배포 디렉토리
+  - mkdir -p /opt/trypto
+  - chown ubuntu:ubuntu /opt/trypto

--- a/terraform/prod/compute.tf
+++ b/terraform/prod/compute.tf
@@ -1,0 +1,56 @@
+# 앱 서버. Always Free A1 한도(2 OCPU / 12GB) 를 통째로 한 대에 쓴다.
+# "Out of host capacity" 로 실패하면 apply 를 재시도한다 (README 참고).
+resource "oci_core_instance" "app" {
+  availability_domain = data.oci_identity_availability_domains.ads.availability_domains[0].name
+  compartment_id      = local.compartment_id
+  display_name        = "trypto-app"
+  shape               = "VM.Standard.A1.Flex"
+  freeform_tags       = local.tags
+
+  shape_config {
+    ocpus         = var.instance_ocpus
+    memory_in_gbs = var.instance_memory_gbs
+  }
+
+  source_details {
+    source_type             = "image"
+    source_id               = data.oci_core_images.ubuntu_arm.images[0].id
+    boot_volume_size_in_gbs = var.boot_volume_gbs
+  }
+
+  create_vnic_details {
+    subnet_id        = oci_core_subnet.public.id
+    hostname_label   = "app"
+    # 고정(RESERVED) 공인 IP 를 아래에서 따로 붙이므로 임시 IP 는 받지 않는다.
+    assign_public_ip = false
+  }
+
+  metadata = {
+    ssh_authorized_keys = file(pathexpand(var.ssh_public_key_path))
+    user_data           = base64encode(file("${path.module}/cloud-init.yaml"))
+  }
+
+  lifecycle {
+    # 이미지가 새 버전으로 갱신될 때마다 인스턴스를 갈아치우려 드는 것을 막는다.
+    ignore_changes = [source_details]
+  }
+}
+
+data "oci_core_vnic_attachments" "app" {
+  compartment_id = local.compartment_id
+  instance_id    = oci_core_instance.app.id
+}
+
+data "oci_core_private_ips" "app" {
+  vnic_id = data.oci_core_vnic_attachments.app.vnic_attachments[0].vnic_id
+}
+
+# 고정 공인 IP. 인스턴스를 지웠다 다시 만들어도 이 IP 는 유지되므로
+# Cloudflare A 레코드를 다시 만질 일이 없다. (오라클은 공인 IPv4 무료)
+resource "oci_core_public_ip" "app" {
+  compartment_id = local.compartment_id
+  display_name   = "trypto-app-ip"
+  lifetime       = "RESERVED"
+  private_ip_id  = data.oci_core_private_ips.app.private_ips[0].id
+  freeform_tags  = local.tags
+}

--- a/terraform/prod/data.tf
+++ b/terraform/prod/data.tf
@@ -1,0 +1,13 @@
+data "oci_identity_availability_domains" "ads" {
+  compartment_id = local.compartment_id
+}
+
+# 우분투 24.04 ARM(aarch64) 최신 이미지
+data "oci_core_images" "ubuntu_arm" {
+  compartment_id           = local.compartment_id
+  operating_system         = "Canonical Ubuntu"
+  operating_system_version = "24.04"
+  shape                    = "VM.Standard.A1.Flex"
+  sort_by                  = "TIMECREATED"
+  sort_order               = "DESC"
+}

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -1,0 +1,151 @@
+# 프로덕션 인프라 (오라클 클라우드, Always Free 한도 내).
+# 부하테스트 스택(terraform/)과 완전히 분리된 별도 상태를 가진다.
+#
+#   terraform -chdir=terraform/prod init
+#   terraform -chdir=terraform/prod apply
+#
+# A1 인스턴스 생성이 "Out of host capacity" 로 실패하면 시간을 두고 apply 를 재시도한다.
+# 자세한 절차는 README.md 참고.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 6.0"
+    }
+  }
+}
+
+provider "oci" {
+  tenancy_ocid     = var.tenancy_ocid
+  user_ocid        = var.user_ocid
+  fingerprint      = var.fingerprint
+  private_key_path = var.private_key_path
+  region           = var.region
+}
+
+locals {
+  # 개인 계정이라 루트 컴파트먼트(=테넌시)를 그대로 쓴다.
+  compartment_id = var.compartment_ocid != "" ? var.compartment_ocid : var.tenancy_ocid
+  tags           = { project = "trypto-prod" }
+}
+
+# ---------- 네트워크 ----------
+
+resource "oci_core_vcn" "trypto" {
+  compartment_id = local.compartment_id
+  display_name   = "trypto-vcn"
+  cidr_blocks    = ["10.0.0.0/16"]
+  dns_label      = "trypto"
+  freeform_tags  = local.tags
+}
+
+resource "oci_core_internet_gateway" "igw" {
+  compartment_id = local.compartment_id
+  vcn_id         = oci_core_vcn.trypto.id
+  display_name   = "trypto-igw"
+  freeform_tags  = local.tags
+}
+
+resource "oci_core_route_table" "public" {
+  compartment_id = local.compartment_id
+  vcn_id         = oci_core_vcn.trypto.id
+  display_name   = "trypto-public-rt"
+  freeform_tags  = local.tags
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    network_entity_id = oci_core_internet_gateway.igw.id
+  }
+}
+
+# 앱 VM 이 사는 퍼블릭 서브넷. 바깥에서 80/443, 관리자 IP 에서 22 만 받는다.
+resource "oci_core_security_list" "public" {
+  compartment_id = local.compartment_id
+  vcn_id         = oci_core_vcn.trypto.id
+  display_name   = "trypto-public-sl"
+  freeform_tags  = local.tags
+
+  ingress_security_rules {
+    protocol = "6" # TCP
+    source   = var.admin_cidr
+    tcp_options {
+      min = 22
+      max = 22
+    }
+  }
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+    tcp_options {
+      min = 80
+      max = 80
+    }
+  }
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+    tcp_options {
+      min = 443
+      max = 443
+    }
+  }
+
+  egress_security_rules {
+    protocol    = "all"
+    destination = "0.0.0.0/0"
+  }
+}
+
+# 관리형 MySQL 이 사는 프라이빗 서브넷. 퍼블릭 서브넷에서 오는 3306/33060 만 받는다.
+resource "oci_core_security_list" "private" {
+  compartment_id = local.compartment_id
+  vcn_id         = oci_core_vcn.trypto.id
+  display_name   = "trypto-private-sl"
+  freeform_tags  = local.tags
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = "10.0.0.0/24"
+    tcp_options {
+      min = 3306
+      max = 3306
+    }
+  }
+  ingress_security_rules {
+    protocol = "6"
+    source   = "10.0.0.0/24"
+    tcp_options {
+      min = 33060
+      max = 33060
+    }
+  }
+
+  egress_security_rules {
+    protocol    = "all"
+    destination = "0.0.0.0/0"
+  }
+}
+
+resource "oci_core_subnet" "public" {
+  compartment_id    = local.compartment_id
+  vcn_id            = oci_core_vcn.trypto.id
+  display_name      = "trypto-public"
+  cidr_block        = "10.0.0.0/24"
+  dns_label         = "pub"
+  route_table_id    = oci_core_route_table.public.id
+  security_list_ids = [oci_core_security_list.public.id]
+  freeform_tags     = local.tags
+}
+
+resource "oci_core_subnet" "private" {
+  compartment_id             = local.compartment_id
+  vcn_id                     = oci_core_vcn.trypto.id
+  display_name               = "trypto-private"
+  cidr_block                 = "10.0.1.0/24"
+  dns_label                  = "db"
+  prohibit_public_ip_on_vnic = true
+  security_list_ids          = [oci_core_security_list.private.id]
+  freeform_tags              = local.tags
+}

--- a/terraform/prod/mysql.tf
+++ b/terraform/prod/mysql.tf
@@ -1,0 +1,50 @@
+# 관리형 MySQL (HeatWave Always Free). 계정당 1개, 홈 리전 전용.
+#
+# 기존 MySQL 컨테이너가 command 로 강제하던 값과의 동등성:
+#   - time_zone=+09:00        → 아래 구성(configuration)에서 지정
+#   - utf8mb4_unicode_ci      → 서버 전역이 아니라 데이터베이스 생성 시 지정한다.
+#     최초 1회 VM 에서:  CREATE DATABASE trypto CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+resource "oci_mysql_mysql_configuration" "kst" {
+  compartment_id = local.compartment_id
+  display_name   = "trypto-kst"
+  shape_name     = "MySQL.Free"
+
+  # 참고: provider 가 variables 대신 options 를 권하는 경고를 내지만,
+  # options 블록에는 time_zone 항목이 없어 여기서는 variables 가 맞다.
+  variables {
+    time_zone = "+09:00"
+  }
+}
+
+resource "oci_mysql_mysql_db_system" "trypto" {
+  compartment_id      = local.compartment_id
+  display_name        = "trypto-mysql"
+  availability_domain = data.oci_identity_availability_domains.ads.availability_domains[0].name
+
+  # Always Free 전용 shape. 스토리지 50GB 고정, 자동 백업 포함.
+  shape_name              = "MySQL.Free"
+  configuration_id        = oci_mysql_mysql_configuration.kst.id
+  data_storage_size_in_gb = 50
+
+  subnet_id      = oci_core_subnet.private.id
+  hostname_label = "mysql" # → mysql.db.trypto.oraclevcn.com (VCN 안에서만 풀린다)
+  port           = 3306
+  port_x         = 33060
+
+  admin_username = var.mysql_admin_username
+  admin_password = var.mysql_admin_password
+
+  crash_recovery = "ENABLED"
+
+  # Always Free DB 시스템은 backup_policy 블록을 지정하면 생성이 거부된다.
+  # 대신 일일 자동 백업이 기본으로 켜진 채 제공된다.
+
+  deletion_policy {
+    is_delete_protected        = true
+    final_backup               = "REQUIRE_FINAL_BACKUP"
+    automatic_backup_retention = "RETAIN"
+  }
+
+  freeform_tags = local.tags
+}

--- a/terraform/prod/outputs.tf
+++ b/terraform/prod/outputs.tf
@@ -1,0 +1,18 @@
+output "app_public_ip" {
+  description = "Cloudflare A 레코드가 가리킬 고정 공인 IP"
+  value       = oci_core_public_ip.app.ip_address
+}
+
+output "ssh_command" {
+  value = "ssh ubuntu@${oci_core_public_ip.app.ip_address}"
+}
+
+output "mysql_host" {
+  description = ".env 의 MYSQL_HOST 에 넣을 값 (VCN 내부 전용 주소)"
+  value       = "mysql.db.trypto.oraclevcn.com"
+}
+
+output "mysql_ip" {
+  description = "호스트명이 안 풀릴 때를 대비한 프라이빗 IP"
+  value       = oci_mysql_mysql_db_system.trypto.ip_address
+}

--- a/terraform/prod/retry-apply.sh
+++ b/terraform/prod/retry-apply.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# A1 무료 인스턴스가 "Out of host capacity" 로 실패할 때 용량이 풀릴 때까지 apply 를 재시도한다.
+# 성공하면 outputs 를 로그에 남기고 종료한다.
+#
+#   nohup bash terraform/prod/retry-apply.sh &   (레포 루트에서)
+#   진행 확인: tail terraform/prod/apply-retry.log
+cd "$(dirname "$0")"
+LOG=apply-retry.log
+MAX=72 # 10분 간격 x 72회 = 12시간
+
+for i in $(seq 1 "$MAX"); do
+  echo "=== 시도 $i/$MAX $(date '+%F %T') ===" >>"$LOG"
+  if terraform apply -input=false -auto-approve -no-color >>"$LOG" 2>&1; then
+    echo "=== 성공 $(date '+%F %T') ===" >>"$LOG"
+    terraform output -no-color >>"$LOG" 2>&1
+    exit 0
+  fi
+  echo "--- 실패, 10분 뒤 재시도 ---" >>"$LOG"
+  sleep 600
+done
+
+echo "=== $MAX 회 모두 실패. 셰이프 축소(1코어/6GB)나 PAYG 전환을 검토한다 ===" >>"$LOG"
+exit 1

--- a/terraform/prod/terraform.tfvars.example
+++ b/terraform/prod/terraform.tfvars.example
@@ -1,0 +1,19 @@
+# 복사해서 terraform.tfvars 로 만들고 값을 채운다. (tfvars 는 gitignore 에 걸려 있다)
+# 아래 인증 4종은 오라클 콘솔 → 프로필 → 내 프로파일 → API 키 → "키 추가" 하면
+# "구성 파일 미리보기"에 전부 나온다.
+
+tenancy_ocid     = "ocid1.tenancy.oc1..aaaaaaaa________________________"
+user_ocid        = "ocid1.user.oc1..aaaaaaaa________________________"
+fingerprint      = "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99"
+private_key_path = "C:/Users/saree98/.oci/oci_api_key.pem"
+
+region = "ap-osaka-1"
+
+# ssh-keygen -t ed25519 -f C:/Users/saree98/.ssh/trypto_oracle 로 생성
+ssh_public_key_path = "C:/Users/saree98/.ssh/trypto_oracle.pub"
+
+# 내 공인 IP (https://ifconfig.me 에서 확인) + /32
+admin_cidr = "0.0.0.0/32"
+
+# .env.prod 의 MYSQL_PASSWORD 와 같은 값을 쓴다
+mysql_admin_password = "CHANGEME"

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -1,0 +1,74 @@
+# 인증 4종은 오라클 콘솔에서 API 키를 만들면 "구성 파일 미리보기"에 그대로 나온다.
+# README.md 의 사전 준비 절차 참고.
+
+variable "tenancy_ocid" {
+  description = "테넌시 OCID"
+  type        = string
+}
+
+variable "user_ocid" {
+  description = "사용자 OCID"
+  type        = string
+}
+
+variable "fingerprint" {
+  description = "API 키 지문"
+  type        = string
+}
+
+variable "private_key_path" {
+  description = "API 개인 키(.pem) 경로"
+  type        = string
+}
+
+variable "region" {
+  description = "홈 리전. Always Free 자원은 홈 리전에서만 만들 수 있다"
+  type        = string
+  default     = "ap-osaka-1"
+}
+
+variable "compartment_ocid" {
+  description = "리소스를 담을 컴파트먼트. 비우면 루트(테넌시)를 쓴다"
+  type        = string
+  default     = ""
+}
+
+variable "ssh_public_key_path" {
+  description = "VM 접속용 SSH 공개 키 경로"
+  type        = string
+}
+
+variable "admin_cidr" {
+  description = "SSH(22) 를 허용할 관리자 IP 대역 (예: 1.2.3.4/32)"
+  type        = string
+}
+
+variable "instance_ocpus" {
+  description = "A1 코어 수. Always Free 한도는 총 2 OCPU (2026-06 축소 이후)"
+  type        = number
+  default     = 2
+}
+
+variable "instance_memory_gbs" {
+  description = "A1 메모리(GB). Always Free 한도는 총 12GB"
+  type        = number
+  default     = 12
+}
+
+variable "boot_volume_gbs" {
+  description = "부트 볼륨 크기(GB). Always Free 블록 스토리지 총 한도는 200GB"
+  type        = number
+  default     = 100
+}
+
+variable "mysql_admin_username" {
+  description = "관리형 MySQL 관리자 계정명 (.env 의 MYSQL_USERNAME 과 맞춘다)"
+  type        = string
+  default     = "trypto"
+}
+
+variable "mysql_admin_password" {
+  description = "관리형 MySQL 관리자 비밀번호 (.env 의 MYSQL_PASSWORD 와 맞춘다)"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary

trypto 를 Oracle Cloud Always Free 자원으로 프로덕션 배포하기 위한 인프라 코드와 배포 자동화를 추가한다. 본 PR 의 구성으로 https://trypto.dev 가 실제 배포되어 운영 중이다.

- **인프라 정의 (terraform/prod)** — VCN·A1 인스턴스·관리형 MySQL·고정 IP·예산 알람을 Always Free 한도 내로 정의
- **프로덕션 구성 개편** — MySQL 컨테이너를 관리형(HeatWave)으로 대체, 호스트 nginx TLS 종단 전제로 포트 재배치
- **배포 자동화 (deploy/)** — 콘텐츠 해시 태그로 변경 모듈만 arm64 빌드·푸시하는 반복 배포 스크립트와 부트스트랩 런북

---

## 주요 변경 사항

### 인프라 (terraform/prod — 신규)

- VCN 을 퍼블릭(VM)/프라이빗(DB) 서브넷으로 분리하고 보안 목록으로 3306 을 VM 서브넷에만 허용
- A1 Flex 2 OCPU/12GB 인스턴스, 고정(RESERVED) 공인 IP, cloud-init 으로 도커·nginx·certbot·스왑 초기화
- 관리형 MySQL 은 time_zone=+09:00 구성을 적용하여 기존 컨테이너 설정과 동작을 일치시킴
- 예산 알람: 실청구 $1 초과 시 조기 경보, 월말 예측 $10 초과 시 경보
- A1 용량 부족(Out of host capacity) 대응 재시도 스크립트 포함

### 프로덕션 구성 (docker-compose.prod.yml, .env.prod.example)

- MySQL 서비스·볼륨 제거, 접속 정보를 .env 필수값으로 파라미터화
- 프론트 컨테이너를 127.0.0.1:8081 로 바인딩 — 호스트 nginx(80/443) 가 TLS 종단 후 프록시
- 프로덕션 환경변수 템플릿(.env.prod.example) 신설, 실값 파일은 gitignore 등재

### 빌드 (Dockerfile 4종)

- 빌드 스테이지를 `--platform=$BUILDPLATFORM` 으로 고정 — jar·Vite 번들은 아키텍처 무관이므로 arm64 크로스 빌드 시 QEMU 에뮬레이션을 회피 (기존 x86 빌드 경로에는 영향 없음)

### 배포 (deploy/ — 신규)

- `deploy.sh`: 모듈별 소스 콘텐츠 해시 → 태그 생성 → Hub 존재 시 스킵 → arm64 빌드·푸시 → 서버 pull·교체. VITE_ 값 변경 시 프론트 태그가 자동 변경됨
- `nginx-trypto.conf`: TLS 종단·웹소켓 업그레이드·인증서 갱신 경로
- `README.md`: 1회성 부트스트랩(시계열 시드·DB 생성·최초 스키마·인증서)과 반복 배포 절차를 분리 문서화

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| Oracle Always Free A1 채택 | 실측 상시 부하(램 2.85GB, CPU 0.42코어)가 AWS 무료 한도(2GB, 지속 0.4코어)를 초과. A1 은 12GB·전용 2코어를 기한 없이 무료 제공 |
| 관리형 MySQL 분리 | 유일한 비가역 데이터(계정·주문·잔고)를 VM 장애 반경 밖에 두고 일일 자동 백업을 무상 확보 |
| 호스트 nginx + certbot (CDN 미사용) | 웹소켓 시세 스트림 앞단의 프록시 계층을 제거하여 장애 지점 축소 |
| 콘텐츠 해시 이미지 태그 | 태그가 소스에서 결정되므로 옛 태그 고정으로 옛 코드가 기동되는 사고를 구조적으로 차단 |
| 부트스트랩과 반복 배포의 분리 | 데이터 볼륨을 건드리는 1회성 절차가 반복 배포 경로에 섞이지 않도록 격리 |

---

## Test Plan

### 실배포 검증 (2026-07-16 수행)

- [x] terraform apply 로 전체 인프라 생성 — VCN·A1·관리형 MySQL·예산 알람
- [x] arm64 이미지 4종 빌드·푸시 후 서버 기동 — 컨테이너 9개 전원 healthy
- [x] 시계열 시드(1.2GB) 볼륨 이식 후 InfluxDB 정상 기동 및 차트 데이터 확인
- [x] https://trypto.dev 200 응답, HTTP→HTTPS 리다이렉트, 인증서 자동 갱신 등록 확인
- [x] 최초 스키마 생성(ddl create 1회) 후 none 복귀, 관리형 MySQL 연결 확인

Closes #300