### PR TITLE
[#304] 마켓 메타 중복 적재 방지

### DIFF
--- a/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/CoinCommandAdapter.java
+++ b/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/CoinCommandAdapter.java
@@ -15,8 +15,13 @@ public class CoinCommandAdapter implements CoinCommandPort {
 
     @Override
     public Coin save(String symbol, String name) {
-        CoinJpaEntity entity = new CoinJpaEntity(symbol, name);
-        CoinJpaEntity saved = repository.save(entity);
-        return saved.toDomain();
+        CoinJpaEntity entity = repository
+                .findBySymbol(symbol)
+                .map(existing -> {
+                    existing.updateName(name);
+                    return existing;
+                })
+                .orElseGet(() -> new CoinJpaEntity(symbol, name));
+        return repository.save(entity).toDomain();
     }
 }

--- a/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/ExchangeCoinCommandAdapter.java
+++ b/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/ExchangeCoinCommandAdapter.java
@@ -15,8 +15,13 @@ public class ExchangeCoinCommandAdapter implements ExchangeCoinCommandPort {
 
     @Override
     public ExchangeCoin save(Long exchangeId, Long coinId, String displayName) {
-        ExchangeCoinJpaEntity entity = new ExchangeCoinJpaEntity(exchangeId, coinId, displayName);
-        ExchangeCoinJpaEntity saved = repository.save(entity);
-        return saved.toDomain();
+        ExchangeCoinJpaEntity entity = repository
+                .findByExchangeIdAndCoinId(exchangeId, coinId)
+                .map(existing -> {
+                    existing.updateDisplayName(displayName);
+                    return existing;
+                })
+                .orElseGet(() -> new ExchangeCoinJpaEntity(exchangeId, coinId, displayName));
+        return repository.save(entity).toDomain();
     }
 }

--- a/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/ExchangeCommandAdapter.java
+++ b/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/ExchangeCommandAdapter.java
@@ -17,8 +17,14 @@ public class ExchangeCommandAdapter implements ExchangeCommandPort {
 
     @Override
     public Exchange save(String name, ExchangeMarketType marketType, Long baseCurrencyCoinId, BigDecimal feeRate) {
-        Long nextId = repository.count() + 1;
-        ExchangeJpaEntity entity = new ExchangeJpaEntity(nextId, name, marketType, baseCurrencyCoinId, feeRate);
+        ExchangeJpaEntity entity = repository
+                .findByName(name)
+                .map(existing -> {
+                    existing.update(marketType, baseCurrencyCoinId, feeRate);
+                    return existing;
+                })
+                .orElseGet(() ->
+                        new ExchangeJpaEntity(repository.count() + 1, name, marketType, baseCurrencyCoinId, feeRate));
         return repository.save(entity).toDomain();
     }
 }

--- a/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/persistence/entity/CoinJpaEntity.java
+++ b/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/persistence/entity/CoinJpaEntity.java
@@ -22,7 +22,7 @@ public class CoinJpaEntity {
     @Column(name = "coin_id")
     private Long id;
 
-    @Column(name = "symbol", nullable = false)
+    @Column(name = "symbol", nullable = false, unique = true)
     private String symbol;
 
     @Column(name = "name", nullable = false)
@@ -30,6 +30,10 @@ public class CoinJpaEntity {
 
     public CoinJpaEntity(String symbol, String name) {
         this.symbol = symbol;
+        this.name = name;
+    }
+
+    public void updateName(String name) {
         this.name = name;
     }
 

--- a/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/persistence/entity/ExchangeCoinJpaEntity.java
+++ b/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/persistence/entity/ExchangeCoinJpaEntity.java
@@ -6,13 +6,19 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import ksh.tryptobackend.marketdata.domain.model.ExchangeCoin;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "exchange_coin")
+@Table(
+        name = "exchange_coin",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uk_exchange_coin",
+                        columnNames = {"exchange_id", "coin_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExchangeCoinJpaEntity {
@@ -34,6 +40,10 @@ public class ExchangeCoinJpaEntity {
     public ExchangeCoinJpaEntity(Long exchangeId, Long coinId, String displayName) {
         this.exchangeId = exchangeId;
         this.coinId = coinId;
+        this.displayName = displayName;
+    }
+
+    public void updateDisplayName(String displayName) {
         this.displayName = displayName;
     }
 

--- a/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/persistence/entity/ExchangeJpaEntity.java
+++ b/api/src/main/java/ksh/tryptobackend/marketdata/adapter/out/persistence/entity/ExchangeJpaEntity.java
@@ -23,7 +23,7 @@ public class ExchangeJpaEntity {
     @Column(name = "exchange_id")
     private Long id;
 
-    @Column(name = "name", nullable = false, length = 50)
+    @Column(name = "name", nullable = false, length = 50, unique = true)
     private String name;
 
     @Enumerated(EnumType.STRING)
@@ -40,6 +40,12 @@ public class ExchangeJpaEntity {
             Long id, String name, ExchangeMarketType marketType, Long baseCurrencyCoinId, BigDecimal feeRate) {
         this.id = id;
         this.name = name;
+        this.marketType = marketType;
+        this.baseCurrencyCoinId = baseCurrencyCoinId;
+        this.feeRate = feeRate;
+    }
+
+    public void update(ExchangeMarketType marketType, Long baseCurrencyCoinId, BigDecimal feeRate) {
         this.marketType = marketType;
         this.baseCurrencyCoinId = baseCurrencyCoinId;
         this.feeRate = feeRate;

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -64,7 +64,7 @@ erDiagram
 
     EXCHANGE_MARKET {
         id exchange_id PK "주 식별자"
-        string name "거래소명"
+        string name UK "거래소명"
         string market_type "DOMESTIC OVERSEAS"
         id base_currency_coin_id FK "기축통화 코인 ID"
         number fee_rate "기본 수수료율"
@@ -78,7 +78,7 @@ erDiagram
 
     EXCHANGE_COIN {
         id exchange_coin_id PK "주 식별자"
-        id exchange_id FK "거래소 ID"
+        id exchange_id FK "거래소 ID (exchange_id + coin_id 복합 유니크)"
         id coin_id FK "코인 ID"
         string display_name "거래소별 표시명"
     }


### PR DESCRIPTION
## Summary

마켓 메타 동기화가 멱등하지 않아 재기동마다 거래소·코인·거래소코인 행이 중복 적재되던 문제를 바로잡는다.

- **어댑터 upsert 전환** — 자연키(name / symbol / exchange_id+coin_id) 기준으로 있으면 갱신, 없으면 삽입
- **유니크 제약 추가** — 코드가 실수해도 DB 가 중복을 막는 안전망

---

## 주요 변경 사항

### 어댑터 계층

- `ExchangeCommandAdapter` — `findByName` 으로 조회 후 upsert. 신규일 때만 ID 를 부여한다.
- `CoinCommandAdapter` — `findBySymbol` 기준 upsert.
- `ExchangeCoinCommandAdapter` — `findByExchangeIdAndCoinId` 기준 upsert.
- 각 JPA 엔티티에 갱신 메서드(`update` / `updateName` / `updateDisplayName`)를 추가한다.

### 인프라 및 설정

- `coin.symbol`, `exchange_market.name` 단일 유니크, `exchange_coin(exchange_id, coin_id)` 복합 유니크를 엔티티에 선언한다.
- `docs/schema.md` ERD 에 위 유니크 제약을 반영한다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 자연키 기준 upsert | 재기동마다 sync 가 다시 실행돼도 중복이 쌓이지 않게 한다 |
| 유니크 제약 병행 | 애플리케이션 로직이 실패해도 DB 레벨에서 중복을 원천 차단한다 |
| 기존 프로덕션 중복은 일회성 SQL 로 정리 | 정본(최소 ID)으로 자식 참조를 remap 후 중복 삭제·시퀀스 리셋. 배포 전 수동 실행 완료 |

---

## Test Plan

- [x] api 모듈 컴파일 검증
- [x] 프로덕션 중복 정리 SQL 실행 후 `exchange_market` 이 name 당 1행임을 확인

Closes #304