### PR TITLE
[#318] 복기 탭 거래소별 조회 지원

### DIFF
--- a/frontend/src/components/regret/RegretChart.tsx
+++ b/frontend/src/components/regret/RegretChart.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback } from "react";
 import { cn } from "@/lib/utils";
+import { formatCurrency, formatCurrencyCompact, formatCurrencyShort } from "@/lib/formatters";
 import type { RegretSummary, AssetSnapshot, ViolationMarker } from "@/lib/types/regret";
 import { getTickInterval } from "@/lib/types/regret";
 
@@ -11,17 +12,7 @@ interface RegretChartProps {
   btcHoldValues: number[] | null; // null이면 비활성
   hasEnabledRules: boolean;
   totalDays: number;
-}
-
-function formatKRWShort(value: number): string {
-  const abs = Math.abs(value);
-  if (abs < 1_0000) return abs.toLocaleString("ko-KR");
-  const man = Math.round(abs / 1_0000);
-  const eok = Math.floor(man / 1_0000);
-  const rest = man % 1_0000;
-  if (eok === 0) return `${man.toLocaleString("ko-KR")}만`;
-  if (rest > 0) return `${eok}억${rest.toLocaleString("ko-KR")}만`;
-  return `${eok}억`;
+  baseCurrency: string;          // 거래소 기축통화 (KRW/USDT)
 }
 
 const W = 700;
@@ -36,6 +27,7 @@ export function RegretChart({
   btcHoldValues,
   hasEnabledRules,
   totalDays,
+  baseCurrency,
 }: RegretChartProps) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
@@ -68,9 +60,10 @@ export function RegretChart({
     const btcPath = btcHoldValues ? toPath(btcHoldValues) : null;
 
     // Y축 눈금
+    // 눈금값은 반올림하지 않는다. USDT처럼 소수 단위 자산은 반올림하면 눈금이 서로 겹친다.
     const yTicks = Array.from({ length: 5 }, (_, i) => {
       const val = yMin + ((yMax - yMin) / 4) * i;
-      return { value: Math.round(val), y: getY(val) };
+      return { value: val, y: getY(val) };
     });
 
     // X축 라벨 — 시즌 기간에 따라 adaptive 간격
@@ -129,8 +122,8 @@ export function RegretChart({
       <div className="mb-5">
         <p className="text-xs font-medium text-muted-foreground">놓친 수익</p>
         <p className="mt-1 font-mono text-3xl font-bold tabular-nums text-negative">
-          {summary.missedProfit.toLocaleString("ko-KR")}
-          <span className="ml-2 text-base font-bold text-muted-foreground">KRW</span>
+          {summary.missedProfit < 0 ? "-" : ""}
+          {formatCurrency(Math.abs(summary.missedProfit), baseCurrency)}
         </p>
       </div>
 
@@ -139,7 +132,7 @@ export function RegretChart({
         <div className="rounded-xl bg-secondary/50 px-3 py-3">
           <p className="text-[11px] font-medium text-muted-foreground">실제 자산</p>
           <p className="mt-1 font-mono text-base font-bold tabular-nums">
-            {summary.actualAsset.toLocaleString("ko-KR")}
+            {formatCurrencyCompact(summary.actualAsset, baseCurrency)}
           </p>
         </div>
         <div className="rounded-xl bg-secondary/50 px-3 py-3">
@@ -148,7 +141,7 @@ export function RegretChart({
             "mt-1 font-mono text-base font-bold tabular-nums",
             summary.ruleFollowedAsset > summary.actualAsset ? "text-positive" : "",
           )}>
-            {summary.ruleFollowedAsset.toLocaleString("ko-KR")}
+            {formatCurrencyCompact(summary.ruleFollowedAsset, baseCurrency)}
           </p>
         </div>
         <div className="rounded-xl bg-secondary/50 px-3 py-3">
@@ -192,8 +185,8 @@ export function RegretChart({
             onMouseLeave={() => setHoveredIndex(null)}
           >
             {/* Y축 그리드 */}
-            {chartData.yTicks.map((tick) => (
-              <g key={tick.value}>
+            {chartData.yTicks.map((tick, i) => (
+              <g key={i}>
                 <line
                   x1={PAD.left} y1={tick.y}
                   x2={W - PAD.right} y2={tick.y}
@@ -204,7 +197,7 @@ export function RegretChart({
                   textAnchor="end" dominantBaseline="middle"
                   fill="var(--muted-foreground)" fontSize={10} fontFamily="inherit"
                 >
-                  {formatKRWShort(tick.value)}
+                  {formatCurrencyShort(tick.value, baseCurrency)}
                 </text>
               </g>
             ))}
@@ -300,18 +293,18 @@ export function RegretChart({
                 <p className="mb-1 font-semibold">{snapshots[hoveredIndex].fullDate}</p>
                 <p>
                   <span className="mr-1.5 inline-block h-1.5 w-1.5 rounded-full bg-primary" />
-                  실제: {formatKRWShort(snapshots[hoveredIndex].actual)}
+                  실제: {formatCurrencyShort(snapshots[hoveredIndex].actual, baseCurrency)}
                 </p>
                 {hasEnabledRules && (
                   <p>
                     <span className="mr-1.5 inline-block h-1.5 w-1.5 rounded-full bg-negative" />
-                    시뮬레이션: {formatKRWShort(simulationLine[hoveredIndex])}
+                    시뮬레이션: {formatCurrencyShort(simulationLine[hoveredIndex], baseCurrency)}
                   </p>
                 )}
                 {btcHoldValues && (
                   <p>
                     <span className="mr-1.5 inline-block h-1.5 w-1.5 rounded-full" style={{ backgroundColor: "#f7931a" }} />
-                    BTC 홀드: {formatKRWShort(btcHoldValues[hoveredIndex])}
+                    BTC 홀드: {formatCurrencyShort(btcHoldValues[hoveredIndex], baseCurrency)}
                   </p>
                 )}
                 {chartData.hoverPoints[hoveredIndex].violation && (

--- a/frontend/src/components/regret/ViolationTradeList.tsx
+++ b/frontend/src/components/regret/ViolationTradeList.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/types/regret";
 import type { ViolationFilter } from "@/lib/types/regret";
 import { cn } from "@/lib/utils";
+import { formatCurrencyCompact } from "@/lib/formatters";
 
 const FILTER_TABS: { key: ViolationFilter; label: string }[] = [
   { key: "ALL", label: "전체" },
@@ -16,9 +17,10 @@ const FILTER_TABS: { key: ViolationFilter; label: string }[] = [
 
 interface ViolationTradeListProps {
   trades: ViolationTrade[];
+  baseCurrency: string;
 }
 
-export function ViolationTradeList({ trades }: ViolationTradeListProps) {
+export function ViolationTradeList({ trades, baseCurrency }: ViolationTradeListProps) {
   const [filter, setFilter] = useState<ViolationFilter>("ALL");
 
   const filtered = useMemo(() => {
@@ -107,8 +109,8 @@ export function ViolationTradeList({ trades }: ViolationTradeListProps) {
                   isLoss ? "text-negative" : "text-positive",
                 )}
               >
-                {isLoss ? "" : "+"}
-                {trade.profitLoss.toLocaleString("ko-KR")}
+                {isLoss ? "-" : "+"}
+                {formatCurrencyCompact(Math.abs(trade.profitLoss), baseCurrency)}
               </span>
             </div>
           );

--- a/frontend/src/lib/formatters.ts
+++ b/frontend/src/lib/formatters.ts
@@ -36,6 +36,25 @@ export function formatCurrencyCompact(value: number, baseCurrency: string): stri
   return Math.round(value).toLocaleString("ko-KR");
 }
 
+// ── 통화별 금액 약어 (차트 축·툴팁처럼 폭이 좁은 자리 전용) ──
+
+export function formatCurrencyShort(value: number, baseCurrency: string): string {
+  const abs = Math.abs(value);
+  const sign = value < 0 ? "-" : "";
+  if (baseCurrency === "USDT") {
+    if (abs >= 1_000_000) return `${sign}$${(abs / 1_000_000).toFixed(1)}M`;
+    if (abs >= 10_000) return `${sign}$${(abs / 1_000).toFixed(1)}K`;
+    return `${sign}$${abs.toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
+  }
+  if (abs < 1_0000) return `${sign}${Math.round(abs).toLocaleString("ko-KR")}`;
+  const man = Math.round(abs / 1_0000);
+  const eok = Math.floor(man / 1_0000);
+  const rest = man % 1_0000;
+  if (eok === 0) return `${sign}${man.toLocaleString("ko-KR")}만`;
+  if (rest > 0) return `${sign}${eok}억${rest.toLocaleString("ko-KR")}만`;
+  return `${sign}${eok}억`;
+}
+
 // ── 법정통화 환산 표시 (≈ 접두사 포함) ──────────────────────
 
 export function formatFiatEstimate(value: number, baseCurrency: string): string {

--- a/frontend/src/pages/RegretPage.tsx
+++ b/frontend/src/pages/RegretPage.tsx
@@ -1,5 +1,7 @@
 import { useState, useMemo, useEffect, useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
 import { Header } from "@/components/layout/Header";
+import { ExchangeTabs } from "@/components/market/ExchangeTabs";
 import { RegretChart } from "@/components/regret/RegretChart";
 import { MeVsMe } from "@/components/regret/MeVsMe";
 import { ViolationTradeList } from "@/components/regret/ViolationTradeList";
@@ -9,6 +11,7 @@ import type { RuleType } from "@/lib/types/round";
 import type { AssetSnapshot, RegretSummary, ViolationMarker, RuleToggleItem, BenchmarkItem, ViolationTrade } from "@/lib/types/regret";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRound } from "@/contexts/RoundContext";
+import { EXCHANGES } from "@/lib/types/coins";
 import { getRegretReport, getRegretChart } from "@/lib/api/regret-api";
 
 /** 복기 리포트는 야간 배치로 생성된다. 배치 전에는 서버가 0으로 채운 빈 리포트를 준다. */
@@ -20,8 +23,31 @@ const EMPTY_SUMMARY: RegretSummary = {
 };
 
 export function RegretPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
   const { user } = useAuth();
   const { activeRound } = useRound();
+
+  // 거래소마다 기축통화가 달라 복기 지표는 합산하지 않는다. 탭으로 하나씩 본다.
+  const exchangeTabItems = useMemo(() => {
+    if (!activeRound) return [];
+    return activeRound.wallets.map((w) => {
+      const exchange = EXCHANGES.find((e) => e.id === w.exchangeId);
+      return {
+        id: exchange?.key ?? String(w.exchangeId),
+        name: exchange?.name ?? String(w.exchangeId),
+        baseCurrency: exchange?.baseCurrency ?? "",
+      };
+    });
+  }, [activeRound]);
+
+  const defaultExchange = exchangeTabItems[0]?.id ?? "upbit";
+  const requestedExchange = searchParams.get("exchange") ?? defaultExchange;
+  // 라운드에 없는 거래소가 쿼리로 들어오면 첫 번째 지갑으로 되돌린다.
+  const selectedExchange = exchangeTabItems.some((e) => e.id === requestedExchange)
+    ? requestedExchange
+    : defaultExchange;
+  const selectedExchangeItem = exchangeTabItems.find((e) => e.id === selectedExchange);
+  const baseCurrency = selectedExchangeItem?.baseCurrency ?? "KRW";
 
   const [enabledRules, setEnabledRules] = useState<Set<RuleType>>(
     new Set(["STOP_LOSS", "TAKE_PROFIT", "NO_CHASE_BUY", "AVERAGING_LIMIT", "OVERTRADE_LIMIT"]),
@@ -45,16 +71,18 @@ export function RegretPage() {
   const loadRegretData = useCallback(async () => {
     if (!user || !activeRound) return;
 
-    // 첫 번째 거래소의 exchangeId 사용
-    const firstWallet = activeRound.wallets[0];
-    if (!firstWallet) return;
+    const exchange = EXCHANGES.find((e) => e.key === selectedExchange);
+    if (!exchange) return;
+
+    const wallet = activeRound.wallets.find((w) => w.exchangeId === exchange.id);
+    if (!wallet) return;
 
     setLoading(true);
     setLoadFailed(false);
     try {
       const [reportData, chartData] = await Promise.all([
-        getRegretReport(activeRound.roundId, firstWallet.exchangeId, user.userId),
-        getRegretChart(activeRound.roundId, firstWallet.exchangeId, user.userId),
+        getRegretReport(activeRound.roundId, exchange.id, user.userId),
+        getRegretChart(activeRound.roundId, exchange.id, user.userId),
       ]);
 
       setSummary(reportData.summary);
@@ -71,7 +99,7 @@ export function RegretPage() {
     } finally {
       setLoading(false);
     }
-  }, [user, activeRound]);
+  }, [user, activeRound, selectedExchange]);
 
   useEffect(() => {
     void loadRegretData();
@@ -98,10 +126,20 @@ export function RegretPage() {
       {/* Page header */}
       <section className="animate-enter border-b border-border/40 pb-6 pt-8">
         <div className="mx-auto max-w-6xl px-4">
-          <h1 className="font-display text-3xl tracking-tight">투자 복기</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            규칙만 지켰으면 얼마를 벌었을까?
-          </p>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="font-display text-3xl tracking-tight">투자 복기</h1>
+              <p className="mt-2 text-sm text-muted-foreground">
+                규칙만 지켰으면 얼마를 벌었을까?
+                {selectedExchangeItem && ` · ${selectedExchangeItem.name} ${baseCurrency} 기준`}
+              </p>
+            </div>
+            <ExchangeTabs
+              exchanges={exchangeTabItems}
+              selected={selectedExchange}
+              onSelect={(id) => setSearchParams({ exchange: id })}
+            />
+          </div>
         </div>
       </section>
 
@@ -122,6 +160,7 @@ export function RegretPage() {
               btcHoldValues={btcHoldEnabled ? btcHoldValues : null}
               hasEnabledRules={enabledRules.size > 0}
               totalDays={totalDays}
+              baseCurrency={baseCurrency}
             />
 
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-[380px_1fr]">
@@ -133,7 +172,7 @@ export function RegretPage() {
                 ruleToggles={ruleToggles}
                 benchmarks={benchmarks}
               />
-              <ViolationTradeList trades={violationTrades} />
+              <ViolationTradeList trades={violationTrades} baseCurrency={baseCurrency} />
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

복기 탭에서 거래소를 골라 볼 수 있게 한다. 지금까지는 첫 번째 지갑(업비트)의 복기 데이터만 보여 빗썸·바이낸스의 리포트·그래프는 서버에 있어도 확인할 방법이 없었다.

- **거래소 탭** — 포트폴리오 탭과 동일한 `ExchangeTabs` + `?exchange=` 쿼리 파라미터 방식
- **기축통화 표기** — 금액을 거래소 기축통화(KRW/USDT) 기준으로 표시

---

## 주요 변경 사항

### 화면 (RegretPage)

- 라운드 지갑 목록에서 거래소 탭 항목을 만들고, 선택한 거래소의 `exchangeId` 로 리포트·그래프를 조회한다. 탭을 바꾸면 두 API 를 다시 호출한다.
- 라운드에 없는 거래소가 쿼리 파라미터로 들어오면 첫 번째 지갑으로 되돌린다.
- 부제에 현재 보고 있는 거래소와 기축통화를 표시한다.

### 컴포넌트 (RegretChart · ViolationTradeList)

- `baseCurrency` 를 받아 놓친 수익·실제 자산·원칙 준수 시 자산·Y축 눈금·툴팁·위반 거래 손익을 기축통화 기준으로 표시한다. 하드코딩된 `KRW` 라벨과 원화 전용 `toLocaleString("ko-KR")` 을 제거했다.
- Y축 눈금값의 정수 반올림을 없앴다. USDT 자산은 값 범위가 좁아 반올림하면 눈금끼리 겹친다.

### 공통 (formatters)

- `formatCurrencyShort` 를 추가했다. KRW 는 억/만, USDT 는 K/M 로 줄인다. `RegretChart` 안에만 있던 원화 전용 `formatKRWShort` 를 대체한다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 거래소 선택을 쿼리 파라미터로 유지 | 포트폴리오·지갑·마켓 탭이 모두 `?exchange=` 를 쓴다. 같은 방식이라 탭 간 이동과 새로고침 동작이 일관된다 |
| 거래소별 합산 없이 탭으로 분리 | 국내는 KRW, 바이낸스는 USDT 로 기축통화가 달라 합산이 성립하지 않는다 |
| 탭 목록을 라운드 지갑에서 생성 | 라운드에 없는 거래소를 고르면 리포트 조회가 `WALLET_NOT_FOUND` 로 실패한다. 선택지 자체를 지갑이 있는 거래소로 제한했다 |
| 금액 약어 포맷터를 공통 모듈로 이동 | 통화 분기가 필요해졌고, 숫자 포맷은 `lib/formatters.ts` 에 모으는 것이 기존 규칙이다 |

---

## Test Plan

- [x] `npm run build` (tsc + vite) 통과
- [x] `npm run lint` 통과 (기존 `useVirtualList.ts` 경고 1건 외 신규 없음)
- [ ] 도커 스택 기동 후 빗썸·바이낸스 탭 전환 육안 확인 — 미실행

프론트엔드 전용 변경이라 서버 인수 테스트 대상은 없다. 리포트가 없는 거래소는 서버가 빈 리포트를, 자산 타임라인이 비면 빈 차트 결과를 주는 것을 코드로 확인했다.

Closes #318