### PR TITLE
[#327] 시장가 주문 위반 판정이 이번 주문을 두 번 세는 문제 수정

### DIFF
--- a/api/src/main/java/ksh/tryptobackend/trading/adapter/out/service/RuleViolationCheckerImpl.java
+++ b/api/src/main/java/ksh/tryptobackend/trading/adapter/out/service/RuleViolationCheckerImpl.java
@@ -8,9 +8,7 @@ import ksh.tryptobackend.investmentround.application.port.in.CheckRuleViolations
 import ksh.tryptobackend.investmentround.application.port.in.dto.query.CheckRuleViolationsQuery;
 import ksh.tryptobackend.investmentround.application.port.in.dto.result.RuleViolationCheckResult;
 import ksh.tryptobackend.trading.application.port.out.OrderQueryPort;
-import ksh.tryptobackend.trading.application.port.out.PositionQueryPort;
 import ksh.tryptobackend.trading.domain.event.OrderPlacedEvent;
-import ksh.tryptobackend.trading.domain.model.Position;
 import ksh.tryptobackend.trading.domain.model.RuleViolation;
 import ksh.tryptobackend.trading.domain.service.RuleViolationChecker;
 import lombok.RequiredArgsConstructor;
@@ -20,18 +18,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RuleViolationCheckerImpl implements RuleViolationChecker {
 
-    private final PositionQueryPort positionQueryPort;
     private final OrderQueryPort orderQueryPort;
     private final CheckRuleViolationsUseCase checkRuleViolationsUseCase;
 
     @Override
     public List<RuleViolation> check(OrderPlacedEvent event) {
-        Position position = positionQueryPort
-                .findByWalletIdAndCoinId(event.walletId(), event.coinId())
-                .orElseGet(() -> Position.empty(event.walletId(), event.coinId()));
         long todayOrderCount = countTodayOrders(event.walletId(), event.createdAt());
 
-        CheckRuleViolationsQuery query = RuleViolationTranslator.toQuery(event, position, todayOrderCount);
+        CheckRuleViolationsQuery query = RuleViolationTranslator.toQuery(event, todayOrderCount);
         List<RuleViolationCheckResult> results = checkRuleViolationsUseCase.checkViolations(query);
         return RuleViolationTranslator.toRuleViolations(results);
     }

--- a/api/src/main/java/ksh/tryptobackend/trading/adapter/out/service/RuleViolationTranslator.java
+++ b/api/src/main/java/ksh/tryptobackend/trading/adapter/out/service/RuleViolationTranslator.java
@@ -4,21 +4,19 @@ import java.util.List;
 import ksh.tryptobackend.investmentround.application.port.in.dto.query.CheckRuleViolationsQuery;
 import ksh.tryptobackend.investmentround.application.port.in.dto.result.RuleViolationCheckResult;
 import ksh.tryptobackend.trading.domain.event.OrderPlacedEvent;
-import ksh.tryptobackend.trading.domain.model.Position;
 import ksh.tryptobackend.trading.domain.model.RuleViolation;
-import ksh.tryptobackend.trading.domain.vo.Price;
 
 final class RuleViolationTranslator {
 
     private RuleViolationTranslator() {}
 
-    static CheckRuleViolationsQuery toQuery(OrderPlacedEvent event, Position position, long todayOrderCount) {
+    static CheckRuleViolationsQuery toQuery(OrderPlacedEvent event, long todayOrderCount) {
         return new CheckRuleViolationsQuery(
                 event.walletId(),
                 event.exchangeCoinId(),
                 event.isBuy(),
-                position.isAtLoss(Price.of(event.currentPrice())),
-                position.getAveragingDownCount(),
+                event.atLoss(),
+                event.averagingDownCount(),
                 todayOrderCount,
                 event.createdAt());
     }

--- a/api/src/main/java/ksh/tryptobackend/trading/application/service/PlaceOrderService.java
+++ b/api/src/main/java/ksh/tryptobackend/trading/application/service/PlaceOrderService.java
@@ -8,10 +8,13 @@ import ksh.tryptobackend.trading.application.port.in.PlaceOrderUseCase;
 import ksh.tryptobackend.trading.application.port.in.dto.command.PlaceOrderCommand;
 import ksh.tryptobackend.trading.application.port.out.MarketQueryPort;
 import ksh.tryptobackend.trading.application.port.out.OrderCommandPort;
+import ksh.tryptobackend.trading.application.port.out.PositionCommandPort;
 import ksh.tryptobackend.trading.domain.model.Order;
+import ksh.tryptobackend.trading.domain.model.Position;
 import ksh.tryptobackend.trading.domain.service.BalanceChangeApplier;
 import ksh.tryptobackend.trading.domain.service.WalletOwnershipVerifier;
 import ksh.tryptobackend.trading.domain.vo.BalanceChange;
+import ksh.tryptobackend.trading.domain.vo.HoldingSnapshot;
 import ksh.tryptobackend.trading.domain.vo.MarketInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +27,7 @@ public class PlaceOrderService implements PlaceOrderUseCase {
     private final IdempotencyKeyCommandPort idempotencyKeyCommandPort;
     private final OrderCommandPort orderCommandPort;
     private final MarketQueryPort marketQueryPort;
+    private final PositionCommandPort positionCommandPort;
     private final BalanceChangeApplier balanceChangeApplier;
     private final WalletOwnershipVerifier walletOwnershipVerifier;
     private final Clock clock;
@@ -37,7 +41,14 @@ public class PlaceOrderService implements PlaceOrderUseCase {
         idempotencyKeyCommandPort.preempt(cmd.idempotencyKey(), IdempotencyResourceType.PLACE_ORDER, now);
 
         MarketInfo marketInfo = marketQueryPort.findByExchangeCoinId(cmd.exchangeCoinId());
-        Order order = Order.create(cmd, marketInfo, now);
+
+        // 체결 정산은 커밋 직전에 실행되므로 여기서 읽으면 시장가·지정가 모두 체결 전 값이다
+        Position position = positionCommandPort.getOrCreate(
+                cmd.walletId(), marketInfo.tradingPair().tradedCoinId());
+        HoldingSnapshot holdingSnapshot =
+                new HoldingSnapshot(position.isAtLoss(marketInfo.currentPrice()), position.getAveragingDownCount());
+
+        Order order = Order.create(cmd, marketInfo, holdingSnapshot, now);
 
         BalanceChange reservation = order.planReservation(marketInfo.tradingPair());
         balanceChangeApplier.apply(order.getWalletId(), reservation);

--- a/api/src/main/java/ksh/tryptobackend/trading/domain/event/OrderPlacedEvent.java
+++ b/api/src/main/java/ksh/tryptobackend/trading/domain/event/OrderPlacedEvent.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import ksh.tryptobackend.trading.domain.model.Order;
 import ksh.tryptobackend.trading.domain.vo.BalanceChange;
+import ksh.tryptobackend.trading.domain.vo.HoldingSnapshot;
 import ksh.tryptobackend.trading.domain.vo.MarketInfo;
 import ksh.tryptobackend.trading.domain.vo.Side;
 
@@ -11,14 +12,25 @@ public final class OrderPlacedEvent {
 
     private final Order order;
     private final MarketInfo market;
+    private final HoldingSnapshot holdingSnapshot;
 
-    private OrderPlacedEvent(Order order, MarketInfo market) {
+    private OrderPlacedEvent(Order order, MarketInfo market, HoldingSnapshot holdingSnapshot) {
         this.order = order;
         this.market = market;
+        this.holdingSnapshot = holdingSnapshot;
     }
 
-    public static OrderPlacedEvent of(Order order, MarketInfo market) {
-        return new OrderPlacedEvent(order, market);
+    public static OrderPlacedEvent of(Order order, MarketInfo market, HoldingSnapshot holdingSnapshot) {
+        return new OrderPlacedEvent(order, market, holdingSnapshot);
+    }
+
+    // 판정 근거는 주문 시점 스냅샷을 쓴다. 커밋 이후 보유 정보를 다시 읽으면 시장가는 이번 체결이 이미 반영돼 있다
+    public boolean atLoss() {
+        return holdingSnapshot.atLoss();
+    }
+
+    public int averagingDownCount() {
+        return holdingSnapshot.averagingDownCount();
     }
 
     public Long orderId() {

--- a/api/src/main/java/ksh/tryptobackend/trading/domain/model/Order.java
+++ b/api/src/main/java/ksh/tryptobackend/trading/domain/model/Order.java
@@ -12,6 +12,7 @@ import ksh.tryptobackend.trading.domain.event.OrderFilledEvent;
 import ksh.tryptobackend.trading.domain.event.OrderPlacedEvent;
 import ksh.tryptobackend.trading.domain.vo.BalanceChange;
 import ksh.tryptobackend.trading.domain.vo.Fill;
+import ksh.tryptobackend.trading.domain.vo.HoldingSnapshot;
 import ksh.tryptobackend.trading.domain.vo.InterpretedOrderInput;
 import ksh.tryptobackend.trading.domain.vo.MarketInfo;
 import ksh.tryptobackend.trading.domain.vo.Money;
@@ -42,7 +43,8 @@ public class Order extends AggregateRoot {
     private Fill fill;
     private OrderStatus status;
 
-    public static Order create(PlaceOrderCommand cmd, MarketInfo marketInfo, LocalDateTime now) {
+    public static Order create(
+            PlaceOrderCommand cmd, MarketInfo marketInfo, HoldingSnapshot holdingSnapshot, LocalDateTime now) {
         if (marketInfo.suspended()) {
             throw new CustomException(ErrorCode.MARKET_SUSPENDED);
         }
@@ -60,7 +62,7 @@ public class Order extends AggregateRoot {
                 .createdAt(now)
                 .build();
 
-        order.registerEvent(OrderPlacedEvent.of(order, marketInfo));
+        order.registerEvent(OrderPlacedEvent.of(order, marketInfo, holdingSnapshot));
         if (order.isMarketOrder()) {
             order.fill(marketInfo.currentPrice(), marketInfo.tradingPair().quoteScale(), now);
             order.registerEvent(OrderFilledEvent.of(order, marketInfo));

--- a/api/src/main/java/ksh/tryptobackend/trading/domain/vo/HoldingSnapshot.java
+++ b/api/src/main/java/ksh/tryptobackend/trading/domain/vo/HoldingSnapshot.java
@@ -1,0 +1,13 @@
+package ksh.tryptobackend.trading.domain.vo;
+
+/**
+ * 주문 시점의 보유 상태.
+ *
+ * <p>위반 판정은 커밋 이후에 실행되는데, 시장가 주문은 그 전에 체결 정산이 끝나 보유 정보가 이미 바뀐다. 판정이 이번 주문을 두 번 세지 않도록 주문 시점 값을 담아둔다.
+ */
+public record HoldingSnapshot(boolean atLoss, int averagingDownCount) {
+
+    public static HoldingSnapshot empty() {
+        return new HoldingSnapshot(false, 0);
+    }
+}

--- a/api/src/test/java/ksh/tryptobackend/trading/domain/model/OrderTest.java
+++ b/api/src/test/java/ksh/tryptobackend/trading/domain/model/OrderTest.java
@@ -15,6 +15,7 @@ import ksh.tryptobackend.trading.domain.event.OrderPlacedEvent;
 import ksh.tryptobackend.trading.domain.vo.BalanceChange;
 import ksh.tryptobackend.trading.domain.vo.ExchangeInfo;
 import ksh.tryptobackend.trading.domain.vo.Fill;
+import ksh.tryptobackend.trading.domain.vo.HoldingSnapshot;
 import ksh.tryptobackend.trading.domain.vo.MarketInfo;
 import ksh.tryptobackend.trading.domain.vo.OrderStatus;
 import ksh.tryptobackend.trading.domain.vo.OrderType;
@@ -86,7 +87,7 @@ class OrderTest {
         @Test
         @DisplayName("시장가 매수 — price(주문 총액) 누락이면 PRICE_REQUIRED")
         void marketBuy_withoutPrice_throws() {
-            assertThatThrownBy(() -> Order.create(
+            assertThatThrownBy(() -> createOrder(
                             cmd(Side.BUY, OrderType.MARKET, null, null), ctx(new BigDecimal("100274000")), NOW))
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
@@ -96,7 +97,7 @@ class OrderTest {
         @Test
         @DisplayName("시장가 매수 — volume을 보내면 VOLUME_NOT_ALLOWED")
         void marketBuy_withVolume_throws() {
-            assertThatThrownBy(() -> Order.create(
+            assertThatThrownBy(() -> createOrder(
                             cmd(Side.BUY, OrderType.MARKET, new BigDecimal("0.001"), new BigDecimal("100000")),
                             ctx(new BigDecimal("100274000")),
                             NOW))
@@ -108,7 +109,7 @@ class OrderTest {
         @Test
         @DisplayName("시장가 매도 — volume 누락이면 VOLUME_REQUIRED")
         void marketSell_withoutVolume_throws() {
-            assertThatThrownBy(() -> Order.create(
+            assertThatThrownBy(() -> createOrder(
                             cmd(Side.SELL, OrderType.MARKET, null, null), ctx(new BigDecimal("100274000")), NOW))
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
@@ -118,7 +119,7 @@ class OrderTest {
         @Test
         @DisplayName("시장가 매도 — price를 보내면 PRICE_NOT_ALLOWED")
         void marketSell_withPrice_throws() {
-            assertThatThrownBy(() -> Order.create(
+            assertThatThrownBy(() -> createOrder(
                             cmd(Side.SELL, OrderType.MARKET, new BigDecimal("0.001"), new BigDecimal("100000000")),
                             ctx(new BigDecimal("100274000")),
                             NOW))
@@ -130,7 +131,7 @@ class OrderTest {
         @Test
         @DisplayName("지정가 — volume 누락이면 VOLUME_REQUIRED")
         void limit_withoutVolume_throws() {
-            assertThatThrownBy(() -> Order.create(
+            assertThatThrownBy(() -> createOrder(
                             cmd(Side.BUY, OrderType.LIMIT, null, new BigDecimal("100000000")),
                             ctx(new BigDecimal("100000000")),
                             NOW))
@@ -142,7 +143,7 @@ class OrderTest {
         @Test
         @DisplayName("지정가 — price 누락이면 PRICE_REQUIRED")
         void limit_withoutPrice_throws() {
-            assertThatThrownBy(() -> Order.create(
+            assertThatThrownBy(() -> createOrder(
                             cmd(Side.BUY, OrderType.LIMIT, new BigDecimal("0.005"), null),
                             ctx(new BigDecimal("100000000")),
                             NOW))
@@ -154,7 +155,7 @@ class OrderTest {
         @Test
         @DisplayName("시장가 매도 — 주문 금액(volume × 현재가)이 최소 미달이면 BELOW_MIN_ORDER_AMOUNT")
         void marketSell_belowMinOrderAmount_throws() {
-            assertThatThrownBy(() -> Order.create(
+            assertThatThrownBy(() -> createOrder(
                             cmd(Side.SELL, OrderType.MARKET, new BigDecimal("0.00000001"), null),
                             ctx(new BigDecimal("100274000")),
                             NOW))
@@ -166,7 +167,7 @@ class OrderTest {
         @Test
         @DisplayName("지정가 매수 — 주문 금액(volume × 지정가)이 최소 미달이면 BELOW_MIN_ORDER_AMOUNT")
         void limitBuy_belowMinOrderAmount_throws() {
-            assertThatThrownBy(() -> Order.create(
+            assertThatThrownBy(() -> createOrder(
                             cmd(Side.BUY, OrderType.LIMIT, new BigDecimal("0.00000001"), new BigDecimal("100000000")),
                             ctx(new BigDecimal("100000000")),
                             NOW))
@@ -186,7 +187,7 @@ class OrderTest {
             BigDecimal totalPrice = new BigDecimal("100000");
             BigDecimal currentPrice = new BigDecimal("100274000");
 
-            Order order = Order.create(cmd(Side.BUY, OrderType.MARKET, null, totalPrice), ctx(currentPrice), NOW);
+            Order order = createOrder(cmd(Side.BUY, OrderType.MARKET, null, totalPrice), ctx(currentPrice), NOW);
 
             BigDecimal expectedAmount = order.getQuantity().value().multiply(currentPrice);
             assertThat(order.getFilledAmount().value()).isEqualByComparingTo(expectedAmount);
@@ -198,7 +199,7 @@ class OrderTest {
             BigDecimal sellQuantity = new BigDecimal("0.5");
             BigDecimal currentPrice = new BigDecimal("100274000");
 
-            Order order = Order.create(cmd(Side.SELL, OrderType.MARKET, sellQuantity, null), ctx(currentPrice), NOW);
+            Order order = createOrder(cmd(Side.SELL, OrderType.MARKET, sellQuantity, null), ctx(currentPrice), NOW);
 
             BigDecimal expectedAmount = sellQuantity.multiply(currentPrice);
             assertThat(order.getFilledAmount().value()).isEqualByComparingTo(expectedAmount);
@@ -211,7 +212,7 @@ class OrderTest {
             BigDecimal limitPrice = new BigDecimal("100000000");
             BigDecimal executionPrice = new BigDecimal("99000000");
 
-            Order order = Order.create(cmd(Side.BUY, OrderType.LIMIT, volume, limitPrice), ctx(limitPrice), NOW);
+            Order order = createOrder(cmd(Side.BUY, OrderType.LIMIT, volume, limitPrice), ctx(limitPrice), NOW);
 
             assertThat(order.getFilledAmount()).isNull();
             assertThat(order.getFeeAmount()).isNull();
@@ -231,7 +232,7 @@ class OrderTest {
             BigDecimal limitPrice = new BigDecimal("110000000");
             BigDecimal executionPrice = new BigDecimal("111000000");
 
-            Order order = Order.create(cmd(Side.SELL, OrderType.LIMIT, sellQuantity, limitPrice), ctx(limitPrice), NOW);
+            Order order = createOrder(cmd(Side.SELL, OrderType.LIMIT, sellQuantity, limitPrice), ctx(limitPrice), NOW);
 
             assertThat(order.getFilledAmount()).isNull();
 
@@ -290,7 +291,7 @@ class OrderTest {
         @DisplayName("지정가 매수 잠금 — KRW는 수수료를 정수 절삭해 잔고 15000에 14993 주문이 딱 맞는다")
         void planReservation_limitBuyKrw_feeFlooredToInteger() {
             // 14993 + floor(14993 × 0.0005) = 14993 + 7 = 15000
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.LIMIT, BigDecimal.ONE, new BigDecimal("14993")),
                     ctx(new BigDecimal("14993")),
                     NOW);
@@ -304,7 +305,7 @@ class OrderTest {
         @DisplayName("지정가 매수 잠금 — 기축통화 자릿수 8(USDT)은 수수료를 절삭 없이 더한다")
         void planReservation_limitBuyOverseas_feeKept8Decimals() {
             TradingPair overseasPair = new TradingPair(100L, 1L, 8);
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.LIMIT, BigDecimal.ONE, new BigDecimal("14993")),
                     ctx(new BigDecimal("14993")),
                     NOW);
@@ -317,7 +318,7 @@ class OrderTest {
         @Test
         @DisplayName("지정가 매도 잠금 — 수수료 없이 수량만 잠근다")
         void planReservation_limitSell_locksQuantityOnly() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.SELL, OrderType.LIMIT, new BigDecimal("0.5"), new BigDecimal("14993")),
                     ctx(new BigDecimal("14993")),
                     NOW);
@@ -336,7 +337,7 @@ class OrderTest {
         @Test
         @DisplayName("PENDING 주문 체결 성공 - 상태가 FILLED로 변경되고 filledAt이 설정된다")
         void fill_pendingOrder_filledSuccessfully() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.LIMIT, new BigDecimal("0.005"), new BigDecimal("100000000")),
                     ctx(new BigDecimal("100000000")),
                     NOW);
@@ -351,7 +352,7 @@ class OrderTest {
         @Test
         @DisplayName("FILLED 주문에 fill 시도 - 예외 발생")
         void fill_filledOrder_throwsException() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.MARKET, null, new BigDecimal("100000")),
                     ctx(new BigDecimal("100274000")),
                     NOW);
@@ -364,7 +365,7 @@ class OrderTest {
         @Test
         @DisplayName("지정가 매수 - 지정가보다 높은 체결가로 fill 시도 - 예외 발생")
         void fill_buyAboveLimitPrice_throwsException() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.LIMIT, new BigDecimal("0.005"), new BigDecimal("100000000")),
                     ctx(new BigDecimal("100000000")),
                     NOW);
@@ -376,7 +377,7 @@ class OrderTest {
         @Test
         @DisplayName("지정가 매도 - 지정가보다 낮은 체결가로 fill 시도 - 예외 발생")
         void fill_sellBelowLimitPrice_throwsException() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.SELL, OrderType.LIMIT, new BigDecimal("0.001"), new BigDecimal("110000000")),
                     ctx(new BigDecimal("110000000")),
                     NOW);
@@ -393,7 +394,7 @@ class OrderTest {
         @Test
         @DisplayName("PENDING 지정가 주문 취소 - 상태가 CANCELED로 바뀌고 취소 이벤트가 등록된다")
         void cancel_pendingOrder_cancelled() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.LIMIT, new BigDecimal("0.005"), new BigDecimal("100000000")),
                     ctx(new BigDecimal("100000000")),
                     NOW);
@@ -408,7 +409,7 @@ class OrderTest {
         @Test
         @DisplayName("체결된 주문 취소 시도 - 예외 발생")
         void cancel_filledOrder_throwsException() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.MARKET, null, new BigDecimal("100000")),
                     ctx(new BigDecimal("100274000")),
                     NOW);
@@ -424,7 +425,7 @@ class OrderTest {
         @Test
         @DisplayName("시장가 주문 생성 - OrderPlacedEvent와 OrderFilledEvent가 등록된다")
         void create_marketOrder_registersPlacedAndFilledEvents() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.MARKET, null, new BigDecimal("100000")),
                     ctx(new BigDecimal("100274000")),
                     NOW);
@@ -437,7 +438,7 @@ class OrderTest {
         @Test
         @DisplayName("지정가 주문 생성 - OrderPlacedEvent만 등록된다")
         void create_limitOrder_registersPlacedEventOnly() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.LIMIT, new BigDecimal("0.005"), new BigDecimal("100000000")),
                     ctx(new BigDecimal("100000000")),
                     NOW);
@@ -448,7 +449,7 @@ class OrderTest {
         @Test
         @DisplayName("이벤트는 한 번 꺼내면 비워진다")
         void pullDomainEvents_clearsEvents() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.MARKET, null, new BigDecimal("100000")),
                     ctx(new BigDecimal("100274000")),
                     NOW);
@@ -466,7 +467,7 @@ class OrderTest {
         @Test
         @DisplayName("지정가 주문 생성 직후 - isPending이 true")
         void isPending_limitOrder_true() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.LIMIT, new BigDecimal("0.005"), new BigDecimal("100000000")),
                     ctx(new BigDecimal("100000000")),
                     NOW);
@@ -477,7 +478,7 @@ class OrderTest {
         @Test
         @DisplayName("시장가 주문 생성 직후 - isPending이 false")
         void isPending_marketOrder_false() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.MARKET, null, new BigDecimal("100000")),
                     ctx(new BigDecimal("100274000")),
                     NOW);
@@ -488,7 +489,7 @@ class OrderTest {
         @Test
         @DisplayName("체결된 주문 - isPending이 false")
         void isPending_filledOrder_false() {
-            Order order = Order.create(
+            Order order = createOrder(
                     cmd(Side.BUY, OrderType.LIMIT, new BigDecimal("0.005"), new BigDecimal("100000000")),
                     ctx(new BigDecimal("100000000")),
                     NOW);
@@ -496,5 +497,9 @@ class OrderTest {
 
             assertThat(order.isPending()).isFalse();
         }
+    }
+
+    private static Order createOrder(PlaceOrderCommand cmd, MarketInfo marketInfo, LocalDateTime now) {
+        return Order.create(cmd, marketInfo, HoldingSnapshot.empty(), now);
     }
 }


### PR DESCRIPTION
## Summary

시장가 주문의 투자 원칙 위반 판정이 체결 정산 이후의 보유 정보를 읽어, 이번 주문을 두 번 세던 문제를 수정한다.

- **주문 시점 스냅샷** — 판정에 필요한 보유 상태를 주문 시점에 읽어 `OrderPlacedEvent` 에 담는다
- **재조회 제거** — 위반 판정이 커밋 이후 보유 정보를 다시 읽지 않는다

---

## 핵심 흐름

```
주문 트랜잭션
 ├ 보유 정보 읽기 → 손실 여부·물타기 횟수      ← 정산 전이라 항상 체결 전 값
 ├ Order.create(..., holdingSnapshot)         → 이벤트에 스냅샷 보존
 ├ 커밋 직전: 체결 정산 (시장가면 여기서 횟수 증가)
 ├ 커밋
 └ 커밋 이후: 위반 판정                        ← 재조회 대신 스냅샷 사용
```

기존에는 마지막 단계에서 보유 정보를 다시 읽었다. 시장가 주문은 그 전에 정산이 끝나 물타기 횟수가 이미 증가한 상태였고, 판정 로직이 거기에 `+1` 을 더해 같은 매수를 두 번 셌다.

제한을 1회로 설정한 경우:

| | 의도 | 수정 전 |
|---|---|---|
| 읽은 횟수 | 0 | 1 (이번 매수 반영됨) |
| 판정값 | 0+1 = 1 | 1+1 = 2 |
| 결과 | 허용 | **위반** |

지정가 주문은 주문 시점에 체결이 없어 정산이 실행되지 않으므로 원래 정상 동작했다. 같은 규칙이 주문 유형에 따라 다르게 판정되던 상태였다.

---

## 주요 변경 사항

### 도메인 계층

- `HoldingSnapshot` VO 신규 추가. 주문 시점의 손실 여부와 물타기 횟수를 담는다
- `OrderPlacedEvent` 가 스냅샷을 보관하고 `atLoss()`·`averagingDownCount()` 로 노출한다
- `Order.create` 가 스냅샷을 받아 이벤트에 전달한다

### 애플리케이션 계층

- `PlaceOrderService` 가 주문 시점에 보유 정보를 읽어 스냅샷을 만든다. 체결 정산은 커밋 직전에 실행되므로 이 시점 값은 시장가·지정가 모두 체결 전이다

### 어댑터 계층

- `RuleViolationTranslator` 가 보유 정보 대신 이벤트 스냅샷을 사용한다
- `RuleViolationCheckerImpl` 에서 보유 정보 재조회와 `PositionQueryPort` 의존을 제거한다

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 판정 근거를 이벤트에 스냅샷으로 보존 | 판정 시점(주문)과 실행 시점(커밋 이후)이 어긋나 있어, 그 사이 정산이 값을 바꾼다. 이벤트가 이미 주문 시점 시세를 담고 있어 같은 원리의 확장이다 |
| 판정 리스너를 `BEFORE_COMMIT` 으로 옮기지 않음 | 위반 기록 INSERT 가 주문 트랜잭션에 합류하면 기록 실패가 주문 롤백으로 번진다. 커밋 이후로 분리한 기존 설계를 유지한다 |
| 보유 정보 조회에 기존 `getOrCreate` 재사용 | 실제 구현이 조회일 뿐 아무것도 생성하지 않아 새 메서드가 필요 없다 |

---

## Test Plan

### 인수 테스트

- [x] 투자 원칙 위반 기록 — 물타기 제한: 제한 횟수까지는 허용되고 초과분부터 위반으로 기록된다
- [x] 물타기 횟수는 전량 매도 후 초기화된다: 재매수 후 첫 물타기가 위반으로 잡히지 않는다
- [x] 기존 시나리오 회귀 없음 (주문 생성·송금·보유 목록·스냅샷 배치)

### 도메인 단위 테스트

- [x] `OrderTest` 52건 통과 (주문 생성 시그니처 변경 반영)
- [x] `PositionTest` 통과

---

## 미반영 사항

- 손실 여부 판정이 체결 후 평균 매수가를 기준으로 하던 오차도 이번 스냅샷 적용으로 함께 해소된다. 별도 검증 시나리오는 추가하지 않았다.

Closes #327