### PR TITLE
[#345] 안드로이드 릴리스 빌드의 서버 주소와 서명 설정 수정

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -42,6 +42,48 @@ flutter test             # 순수 로직 · 인터셉터 계약 · 티커 성능
 flutter build apk --debug
 ```
 
+## 릴리스 빌드
+
+**운영 배포는 반드시 아래 한 줄로 한다.** `--dart-define-from-file` 을 빠뜨리면 `Env` 의 기본값인
+`http://10.0.2.2:8080`(에뮬레이터 전용 주소)이 그대로 박혀 실기기에서 서버에 붙지 못한다.
+
+```bash
+flutter build apk --release --dart-define-from-file=env/prod.json
+```
+
+산출물은 `build/app/outputs/flutter-apk/app-release.apk` 이며, 랜딩의 다운로드 버튼이 가리키는
+GitHub 릴리스에 `trypto-android.apk` 로 올린다.
+
+### 서명
+
+`android/key.properties.example` 을 `android/key.properties` 로 복사해 채운다. 이 파일과
+키스토어는 `.gitignore` 에 있어 저장소에 들어가지 않는다. 없으면 릴리스 빌드가 실패한다 —
+디버그 키로 조용히 서명되지 않도록 일부러 막아 두었다.
+
+**키스토어를 잃으면 이미 설치된 앱에 업데이트를 올릴 수 없다.** APK 를 직접 배포하므로 Play 앱
+서명 같은 복구 수단이 없다. 키 파일과 비밀번호를 서로 다른 곳에 백업한다.
+
+서명 키를 바꾸면 제공자 콘솔에 등록한 지문도 함께 바꿔야 로그인이 동작한다.
+
+```bash
+# 구글 콘솔에 등록할 SHA-1
+keytool -list -v -keystore <키스토어> -alias trypto
+
+# 카카오 콘솔에 등록할 키 해시
+keytool -exportcert -alias trypto -keystore <키스토어> | openssl sha1 -binary | openssl base64
+```
+
+### 배포 전 확인
+
+APK 에 박힌 서버 주소는 빌드 산출물에서 직접 확인할 수 있다.
+
+```bash
+unzip -o -q -j build/app/outputs/flutter-apk/app-release.apk lib/arm64-v8a/libapp.so -d /tmp/apkchk
+grep -a -o -E '(https?|wss?)://[a-zA-Z0-9._:/-]{3,60}' /tmp/apkchk/libapp.so | sort -u
+```
+
+`10.0.2.2` 가 보이면 운영값 주입에 실패한 것이다.
+
 ## 구조
 
 ```

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -1,7 +1,16 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+// 릴리스 서명 자격증명. `android/key.properties` 는 .gitignore 에 있어 저장소에 들어가지 않는다.
+// 키스토어를 잃으면 이미 설치된 앱에 업데이트를 올릴 수 없다 — 파일과 비밀번호를 따로 백업한다.
+val keystoreProperties = Properties().apply {
+    val file = rootProject.file("key.properties")
+    if (file.exists()) file.inputStream().use { load(it) }
 }
 
 android {
@@ -22,11 +31,35 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            // key.properties 가 없으면 여기서 멈춘다. 디버그 키로 조용히 폴백하지 않는다 —
+            // 그렇게 서명한 APK 를 배포하면 나중에 진짜 키로 바꿀 때 기존 설치자가 전부
+            // 삭제·재설치해야 하고, 제공자 콘솔의 지문도 무효가 된다.
+            val storePath = keystoreProperties.getProperty("storeFile")
+            if (storePath != null) {
+                storeFile = file(storePath)
+                storePassword = keystoreProperties.getProperty("storePassword")
+                keyAlias = keystoreProperties.getProperty("keyAlias")
+                keyPassword = keystoreProperties.getProperty("keyPassword")
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
+        }
+    }
+}
+
+// 릴리스 빌드에만 걸리는 확인. 디버그 빌드와 `flutter test` 는 key.properties 없이도 돌아간다.
+tasks.matching { it.name.contains("Release") && it.name.startsWith("package") }.configureEach {
+    doFirst {
+        if (!rootProject.file("key.properties").exists()) {
+            throw GradleException(
+                "android/key.properties 가 없어 릴리스 서명을 할 수 없다. mobile/README.md 의 '릴리스 빌드' 절을 따른다."
+            )
         }
     }
 }

--- a/mobile/android/key.properties.example
+++ b/mobile/android/key.properties.example
@@ -1,0 +1,11 @@
+# 이 파일을 같은 디렉토리에 `key.properties` 로 복사해 값을 채운다.
+# key.properties 는 .gitignore 에 있어 저장소에 올라가지 않는다 — 그대로 두어야 한다.
+#
+# storeFile 경로는 슬래시(/)로 쓴다. 역슬래시는 이 형식에서 특수문자로 해석된다.
+# 키스토어 파일과 비밀번호는 서로 다른 곳에 백업한다. 잃으면 이미 설치된 앱에
+# 업데이트를 영원히 올릴 수 없다(APK 직배포라 Play 앱 서명 같은 복구 수단이 없다).
+
+storePassword=
+keyPassword=
+keyAlias=trypto
+storeFile=C:/Users/saree98/keystore/trypto-upload.jks

--- a/mobile/env/prod.json
+++ b/mobile/env/prod.json
@@ -1,0 +1,4 @@
+{
+  "API_BASE_URL": "https://trypto.dev",
+  "WS_BASE_URL": "wss://trypto.dev/ws"
+}


### PR DESCRIPTION
## Summary

배포된 APK 가 에뮬레이터 전용 주소(`http://10.0.2.2:8080`)를 가리켜 모든 로그인이 실패하던 문제를 고치고, 릴리스 서명을 디버그 키에서 분리한다.

- **운영 주입값 고정** — `env/prod.json` 으로 서버 주소를 묶어 `--dart-define` 누락을 막는다
- **릴리스 서명 분리** — 별도 키스토어로 서명하고, 자격증명이 없으면 릴리스 빌드를 실패시킨다

---

## 핵심 흐름

기존 배포본에서 로그인이 실패하던 경로는 다음과 같다.

```
로그인 버튼 → 제공자 SDK 인가(성공) → 토큰 획득(성공)
           → POST /api/auth/login/{provider} → http://10.0.2.2:8080 (실기기에서 도달 불가)
           → ApiException(NETWORK_ERROR) → "네트워크에 연결할 수 없습니다"
```

제공자 인증 자체는 정상이었고 서버 교환 단계만 끊겨 있었다. 주소를 운영값으로 바꾸면서 이 경로가 끝까지 이어진다.

---

## 주요 변경 사항

### 빌드 설정

`android/app/build.gradle.kts` 의 릴리스 서명을 `android/key.properties` 에서 읽도록 바꾼다. 이 파일과 키스토어는 기존 `.gitignore` 규칙으로 저장소에 포함되지 않는다.

디버그 키 폴백을 두지 않는다. 자격증명이 없으면 릴리스 패키징 태스크에서 명시적으로 실패한다 — 조용히 디버그 키로 서명된 APK 가 다시 배포되는 것을 막기 위함이다. 디버그 빌드와 `flutter test` 는 영향받지 않는다.

### 운영 주입값

`env/prod.json` 에 운영 서버 주소를 고정하고, 릴리스 빌드는 `--dart-define-from-file` 로 이 파일을 읽는다. 값 자체는 공개 도메인이므로 저장소에 포함한다.

| 키 | 값 |
|---|---|
| `API_BASE_URL` | `https://trypto.dev` |
| `WS_BASE_URL` | `wss://trypto.dev/ws` |

### 문서

`README.md` 에 릴리스 빌드 명령, 서명 설정 절차, 키스토어 분실 시의 파급, 배포 전 APK 검증 방법을 추가한다.

`android/key.properties.example` 을 두어 자격증명 파일의 형식을 남긴다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 자격증명이 없으면 릴리스 빌드를 실패시킨다 | 디버그 키 폴백은 이번 사고를 그대로 재현한다. 서명 없이 배포 가능한 경로 자체를 없앤다 |
| 주입값을 파일로 고정한다 | 명령줄 플래그는 빠뜨릴 수 있다. 누락 시 조용히 개발용 기본값이 적용되는 것이 이 버그의 원인이었다 |
| `env/prod.json` 을 저장소에 포함한다 | 공개 도메인 주소일 뿐 비밀이 아니다. 저장소 밖에 두면 다시 누락 위험이 생긴다 |
| 기존 디버그 지문을 콘솔에서 제거하지 않는다 | 개발 중 로그인이 깨진다. 릴리스 지문을 별도로 추가해 양쪽이 공존하게 한다 |

---

## Test Plan

### 산출물 검증

- [x] 새 APK 의 AOT 스냅샷에 `https://trypto.dev`, `wss://trypto.dev/ws` 만 존재하고 `10.0.2.2` 가 없음
- [x] `apksigner verify` 로 서명 주체가 릴리스 키(`CN=sehee kim`)임을 확인
- [x] 랜딩 다운로드 URL 에서 내려받은 파일이 로컬 빌드 산출물과 동일함(md5 일치)

### 실기기 동작

- [x] 구글 로그인 — 계정 선택부터 세션 발급, 라운드 화면 진입까지 성공
- [x] 카카오 로그인 — 세션 발급 성공
- [x] 앱 재시작 시 저장된 세션으로 인증 복구

---

## 미반영 사항

기존 설치자는 서명이 바뀌어 덮어쓰기 설치가 되지 않는다. 삭제 후 재설치가 필요하며, 랜딩 안내 문구 추가 여부는 별도로 결정한다.

Closes #345