### PR TITLE
[#349] 아이콘 교체분 배포를 위한 앱 버전 상향

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: trypto
 description: Trypto 코인 모의투자 모바일 앱
 publish_to: none
-version: 1.0.0+1
+version: 1.0.1+2
 
 environment:
   # json_serializable 이 includeIfNull: false 필드에 null-aware element(`?instance.x`) 를


### PR DESCRIPTION
## Summary

#347 에서 교체한 로고·런처 아이콘을 실제 기기에 내보내기 위해 앱 버전을 올린다.

- `mobile/pubspec.yaml` — `1.0.0+1` → `1.0.1+2`

---

## 주요 변경 사항

버전 문자열 한 줄 변경이다. 코드 변경은 없다.

`versionName` 을 올려 릴리스 자산과 설치본을 구분할 수 있게 하고, `versionCode` 를 함께 올려 기존 설치본 위에 정상적으로 덮어쓰기 설치되도록 한다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 자산을 교체하지 않고 새 릴리스를 올린다 | 같은 `v1.0.0` 자산을 덮어쓰면 어떤 APK 가 설치돼 있는지 구분할 수 없다 |
| 패치 버전만 올린다 | 기능·API 변경 없이 아이콘과 표기만 바뀌었다 |
| 릴리스 자산 이름은 `trypto-android.apk` 로 고정 유지 | 랜딩의 다운로드 버튼이 `releases/latest/download/trypto-android.apk` 를 가리킨다. 이름을 바꾸면 버튼이 깨진다 |

---

## Test Plan

- [x] `flutter build apk --release --dart-define-from-file=env/prod.json` 로 릴리스 서명 빌드
- [x] APK 에 박힌 서버 주소가 `https://trypto.dev` 인지 확인 (에뮬레이터 주소 `10.0.2.2` 가 아님)
- [x] 릴리스 서명 지문이 기존 키와 동일한지 확인

---

## 미반영 사항

- **GitHub Releases 업로드** — 머지 후 `v1.0.1` 태그로 별도 진행한다.

Closes #349