### PR TITLE
[#353] 웹 모바일 레이아웃 최적화

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <!-- iOS 홈 화면은 시스템이 직접 모서리를 깎으므로 라운딩 없는 전면 배경 아이콘을 준다.
          라운드 타일을 주면 잘려나간 모서리가 검게 남는다. -->
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@500;600;700;800&display=swap" rel="stylesheet" />

--- a/frontend/src/components/market/CandleChartPanel.tsx
+++ b/frontend/src/components/market/CandleChartPanel.tsx
@@ -10,6 +10,7 @@ import {
   type CandleItem,
 } from "@/lib/api/candle-api";
 import { connect, isConnected, subscribeTickers } from "@/lib/api/websocket";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import type { CoinData } from "@/lib/types/coins";
 
 interface CandleChartPanelProps {
@@ -41,6 +42,10 @@ const DEFAULT_VISIBLE_COUNT: Record<CandleInterval, number> = {
   "1M": 18,
 };
 
+function defaultVisibleCount(interval: CandleInterval, isMobile: boolean): number {
+  return isMobile ? MOBILE_VISIBLE_COUNT[interval] : DEFAULT_VISIBLE_COUNT[interval];
+}
+
 const MIN_VISIBLE_COUNT = 12;
 // 보이는 구간의 왼쪽 끝이 이 개수만큼 남았을 때 미리 과거 캔들을 당겨 온다. 벽에 닿기 전에
 // 채워 두어야 스와이프가 끊기지 않는다.
@@ -49,9 +54,35 @@ const PREFETCH_THRESHOLD = 8;
 // 시세로 만든 봉이 자리를 지켜야 하므로, 서버가 따라잡을 때까지 몇 개는 들고 있는다.
 const LIVE_CANDLE_LIMIT = 4;
 const RECONCILE_DELAY_MS = 15_000;
-const CHART_WIDTH = 960;
-const CHART_HEIGHT = 440;
-const PADDING = { top: 20, right: 124, bottom: 42, left: 20 };
+
+// SVG 는 viewBox 를 화면 폭에 맞춰 통째로 줄인다. 데스크톱 비율(960×440)을 좁은 화면에 그대로 쓰면
+// 높이가 납작해지고 글자도 같은 비율로 줄어 읽을 수 없다. 좁은 화면은 세로로 긴 좌표계를 따로 쓴다.
+const DESKTOP_CHART = {
+  width: 960,
+  height: 440,
+  padding: { top: 20, right: 124, bottom: 42, left: 20 },
+  axisFontSize: 13,
+  tickFontSize: 12,
+} as const;
+
+const MOBILE_CHART = {
+  width: 380,
+  height: 340,
+  padding: { top: 14, right: 70, bottom: 30, left: 10 },
+  axisFontSize: 9,
+  tickFontSize: 9,
+} as const;
+
+// 좁은 화면은 봉을 적게 띄워야 한 봉이 손끝으로 짚을 만큼 넓어진다.
+const MOBILE_VISIBLE_COUNT: Record<CandleInterval, number> = {
+  "1m": 24,
+  "1h": 20,
+  "4h": 18,
+  "1d": 20,
+  "1w": 16,
+  "1M": 12,
+};
+
 const TOOLTIP_WIDTH = 220;
 const TOOLTIP_HEIGHT = 138;
 const TOOLTIP_OFFSET_X = 10;
@@ -180,12 +211,15 @@ export function CandleChartPanel({
   coin,
 }: CandleChartPanelProps) {
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
+  const isMobile = useIsMobile();
+  // 두 상수 중 하나를 가리키므로 참조가 그대로다. 아래 합성 결과들이 매 렌더 다시 계산되지 않는다.
+  const metrics = isMobile ? MOBILE_CHART : DESKTOP_CHART;
   const [interval, setInterval] = useState<CandleInterval>("1d");
   // 어느 요청의 결과인지 함께 담아 둔다. 그래야 코인·거래소·주기를 막 바꾼 직후의 '아직 못 받은 상태'를
   // 이펙트에서 비우지 않고 렌더에서 그대로 판단할 수 있다.
   const [loaded, setLoaded] = useState<{ key: string; candles: CandleItem[] } | null>(null);
   const [live, setLive] = useState<{ key: string; candles: CandleItem[] } | null>(null);
-  const [visibleCount, setVisibleCount] = useState(DEFAULT_VISIBLE_COUNT["1d"]);
+  const [visibleCount, setVisibleCount] = useState(() => defaultVisibleCount("1d", isMobile));
   const [anchorEndIndex, setAnchorEndIndex] = useState(0);
   const [followingLatest, setFollowingLatest] = useState(true);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
@@ -237,7 +271,7 @@ export function CandleChartPanel({
       const candles = data ?? EMPTY_CANDLES;
       setLoaded({ key: requestKey, candles });
       // 받아온 개수로 줄이지 않는다. 서버 캔들이 아직 없어도 실시간 봉이 쌓이면 그려야 한다.
-      setVisibleCount(DEFAULT_VISIBLE_COUNT[interval]);
+      setVisibleCount(defaultVisibleCount(interval, isMobile));
       setAnchorEndIndex(candles.length);
       setFollowingLatest(true);
       setHoveredIndex(null);
@@ -250,7 +284,7 @@ export function CandleChartPanel({
     return () => {
       cancelled = true;
     };
-  }, [fetchCandles, interval, requestKey]);
+  }, [fetchCandles, interval, isMobile, requestKey]);
 
   // 실시간 체결가를 그 시각이 속한 봉에 접어 넣는다. 시세 목록과 달리 프레임 단위로 합치지 않고
   // 들어오는 체결을 모두 본다. 한 프레임 안의 체결을 버리면 그 봉의 고가·저가가 얕아진다.
@@ -335,28 +369,33 @@ export function CandleChartPanel({
     const range = maxPrice - minPrice || maxPrice * 0.02 || 1;
     const paddedMin = Math.max(0, minPrice - range * 0.08);
     const paddedMax = maxPrice + range * 0.08;
-    const plotWidth = CHART_WIDTH - PADDING.left - PADDING.right;
-    const plotHeight = CHART_HEIGHT - PADDING.top - PADDING.bottom;
+    const plotWidth = metrics.width - metrics.padding.left - metrics.padding.right;
+    const plotHeight = metrics.height - metrics.padding.top - metrics.padding.bottom;
     const slotWidth = plotWidth / visibleCandles.length;
-    const candleWidth = Math.max(6, Math.min(16, slotWidth * 0.62));
+    const candleWidth = Math.max(4, Math.min(16, slotWidth * 0.62));
 
-    const getX = (index: number) => PADDING.left + (index + 0.5) * slotWidth;
+    const getX = (index: number) => metrics.padding.left + (index + 0.5) * slotWidth;
     const getY = (price: number) =>
-      PADDING.top + (1 - (price - paddedMin) / (paddedMax - paddedMin || 1)) * plotHeight;
+      metrics.padding.top + (1 - (price - paddedMin) / (paddedMax - paddedMin || 1)) * plotHeight;
 
     const yTicks = Array.from({ length: 4 }, (_, index) => {
       const value = paddedMax - ((paddedMax - paddedMin) / 3) * index;
       return { value, y: getY(value) };
     });
 
-    const xTickStep = Math.max(1, Math.floor(visibleCandles.length / 4));
+    const xTickStep = Math.max(1, Math.floor(visibleCandles.length / (isMobile ? 3 : 4)));
+    const lastIndex = visibleCandles.length - 1;
     const xTicks = visibleCandles
       .map((candle, index) => ({
         index,
         x: getX(index),
         label: formatTickTime(candle.time, interval),
       }))
-      .filter((tick) => tick.index % xTickStep === 0 || tick.index === visibleCandles.length - 1);
+      .filter((tick) => {
+        if (tick.index % xTickStep === 0) return true;
+        // 마지막 봉의 시각은 따로 세운다. 다만 바로 앞 눈금과 붙으면 글자가 겹치므로 그때는 세우지 않는다.
+        return tick.index === lastIndex && lastIndex % xTickStep >= xTickStep / 2;
+      });
 
     const first = visibleCandles[0];
     const last = visibleCandles[visibleCandles.length - 1];
@@ -385,7 +424,7 @@ export function CandleChartPanel({
       latest: last,
       changeRate,
     };
-  }, [interval, visibleCandles]);
+  }, [interval, isMobile, metrics, visibleCandles]);
 
   const hoveredCandle =
     chartData && hoveredIndex !== null ? chartData.hoverPoints[hoveredIndex] : null;
@@ -508,8 +547,8 @@ export function CandleChartPanel({
 
     const svgRect = event.currentTarget.getBoundingClientRect();
     const containerRect = chartContainerRef.current?.getBoundingClientRect() ?? svgRect;
-    const x = ((event.clientX - svgRect.left) / svgRect.width) * CHART_WIDTH;
-    const y = ((event.clientY - svgRect.top) / svgRect.height) * CHART_HEIGHT;
+    const x = ((event.clientX - svgRect.left) / svgRect.width) * metrics.width;
+    const y = ((event.clientY - svgRect.top) / svgRect.height) * metrics.height;
     const localX = event.clientX - containerRect.left;
     const localY = event.clientY - containerRect.top;
 
@@ -521,10 +560,10 @@ export function CandleChartPanel({
     }
 
     const isOutsidePlot =
-      x < PADDING.left ||
-      x > CHART_WIDTH - PADDING.right ||
-      y < PADDING.top ||
-      y > CHART_HEIGHT - PADDING.bottom;
+      x < metrics.padding.left ||
+      x > metrics.width - metrics.padding.right ||
+      y < metrics.padding.top ||
+      y > metrics.height - metrics.padding.bottom;
     if (isOutsidePlot) {
       setHoveredIndex(null);
       setPointerPosition(null);
@@ -590,9 +629,9 @@ export function CandleChartPanel({
       event.stopPropagation();
 
       const rect = container.getBoundingClientRect();
-      const x = ((event.clientX - rect.left) / rect.width) * CHART_WIDTH;
+      const x = ((event.clientX - rect.left) / rect.width) * metrics.width;
       const hoveredVisibleIndex = clamp(
-        Math.floor((x - PADDING.left) / Math.max(chartData.slotWidth, 1)),
+        Math.floor((x - metrics.padding.left) / Math.max(chartData.slotWidth, 1)),
         0,
         Math.max(visibleCandles.length - 1, 0),
       );
@@ -626,6 +665,7 @@ export function CandleChartPanel({
     mergedCandles.length,
     chartData,
     endIndex,
+    metrics,
     moveViewport,
     zoomTo,
     visibleCandles.length,
@@ -635,29 +675,29 @@ export function CandleChartPanel({
 
   return (
     <section className="overflow-hidden rounded-xl border border-border bg-card">
-      <div className="border-b border-border/50 px-5 py-5 sm:px-6">
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-          <div className="space-y-2">
-            <div className="flex flex-wrap items-end gap-2">
-              <h2 className="text-4xl font-bold tracking-tight">
+      <div className="border-b border-border/50 px-4 py-4 sm:px-6 sm:py-5">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+          <div className="space-y-1.5 sm:space-y-2">
+            <div className="flex flex-wrap items-end gap-x-2 gap-y-1">
+              <h2 className="text-2xl font-bold tracking-tight sm:text-4xl">
                 {coin.symbol}
-                <span className="ml-2 text-2xl font-semibold text-muted-foreground">
+                <span className="ml-2 text-lg font-semibold text-muted-foreground sm:text-2xl">
                   / {baseCurrency}
                 </span>
               </h2>
-              <span className="pb-1 text-base font-medium text-muted-foreground">
+              <span className="pb-0.5 text-sm font-medium text-muted-foreground sm:pb-1 sm:text-base">
                 {coin.name}
               </span>
             </div>
 
-            <div className="flex flex-wrap items-center gap-3">
-              <p className="font-mono text-4xl font-bold tabular-nums">
+            <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+              <p className="font-mono text-2xl font-bold tabular-nums sm:text-4xl">
                 {getCurrencySymbol(baseCurrency)}
                 {formatPrice(coin.currentPrice, baseCurrency)}
               </p>
               <span
                 className={cn(
-                  "rounded-full px-3 py-1.5 text-sm font-bold",
+                  "rounded-full px-2.5 py-1 text-xs font-bold sm:px-3 sm:py-1.5 sm:text-sm",
                   coin.changeRate > 0 && "bg-positive/15 text-positive",
                   coin.changeRate < 0 && "bg-negative/15 text-negative",
                   coin.changeRate === 0 && "bg-secondary text-muted-foreground",
@@ -669,14 +709,14 @@ export function CandleChartPanel({
           </div>
 
           <div className="flex min-w-0 flex-col gap-2 xl:items-end">
-            <div className="overflow-x-auto">
-              <div className="flex min-w-max flex-nowrap gap-2 pb-1">
+            <div className="no-scrollbar -mx-4 overflow-x-auto px-4 sm:mx-0 sm:px-0">
+              <div className="flex min-w-max flex-nowrap gap-1.5 pb-1 sm:gap-2">
               {INTERVAL_OPTIONS.map((option) => (
                 <button
                   key={option.value}
                   onClick={() => setInterval(option.value)}
                   className={cn(
-                    "rounded-full border px-4 py-2 text-sm font-semibold transition-all",
+                    "rounded-full border px-3 py-1.5 text-xs font-semibold transition-all sm:px-4 sm:py-2 sm:text-sm",
                     interval === option.value
                       ? "border-primary bg-primary text-primary-foreground"
                       : "border-border/70 bg-white text-muted-foreground hover:border-primary/30 hover:text-foreground",
@@ -691,9 +731,9 @@ export function CandleChartPanel({
         </div>
       </div>
 
-      <div className="px-4 py-4 sm:px-6 sm:py-6">
+      <div className="px-3 py-3 sm:px-6 sm:py-6">
         {!chartData ? (
-          <div className="flex h-64 items-center justify-center rounded-[24px] border border-border/60 bg-white text-sm text-muted-foreground">
+          <div className="flex h-56 items-center justify-center rounded-[24px] border border-border/60 bg-white text-center text-sm text-muted-foreground sm:h-64">
             {loading ? "캔들 데이터를 불러오는 중..." : "캔들 데이터가 부족합니다"}
           </div>
         ) : (
@@ -703,7 +743,7 @@ export function CandleChartPanel({
           style={{ overscrollBehavior: "contain" }}
         >
           <svg
-            viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+            viewBox={`0 0 ${metrics.width} ${metrics.height}`}
             className="block w-full touch-none"
             style={{ touchAction: "none" }}
             onPointerDown={handlePointerDown}
@@ -718,20 +758,20 @@ export function CandleChartPanel({
             {chartData.yTicks.map((tick) => (
               <g key={tick.value}>
                 <line
-                  x1={PADDING.left}
+                  x1={metrics.padding.left}
                   y1={tick.y}
-                  x2={CHART_WIDTH - PADDING.right}
+                  x2={metrics.width - metrics.padding.right}
                   y2={tick.y}
                   stroke="var(--border)"
                   strokeWidth={1}
                   strokeDasharray="4 6"
                 />
                 <text
-                  x={CHART_WIDTH - 12}
+                  x={metrics.width - 6}
                   y={tick.y + 4}
                   textAnchor="end"
                   fill="var(--muted-foreground)"
-                  fontSize="13"
+                  fontSize={metrics.axisFontSize}
                 >
                   {formatAxisLabel(tick.value, baseCurrency)}
                 </text>
@@ -742,10 +782,10 @@ export function CandleChartPanel({
               <text
                 key={`${tick.index}-${tick.label}`}
                 x={tick.x}
-                y={CHART_HEIGHT - 12}
+                y={metrics.height - 10}
                 textAnchor="middle"
                 fill="var(--muted-foreground)"
-                fontSize="12"
+                fontSize={metrics.tickFontSize}
               >
                 {tick.label}
               </text>
@@ -789,18 +829,18 @@ export function CandleChartPanel({
               <>
                 <line
                   x1={hoveredCandle.x}
-                  y1={PADDING.top}
+                  y1={metrics.padding.top}
                   x2={hoveredCandle.x}
-                  y2={CHART_HEIGHT - PADDING.bottom}
+                  y2={metrics.height - metrics.padding.bottom}
                   stroke="var(--foreground)"
                   strokeOpacity="0.24"
                   strokeWidth={1}
                   strokeDasharray="4 4"
                 />
                 <line
-                  x1={PADDING.left}
+                  x1={metrics.padding.left}
                   y1={chartData.getY(hoveredCandle.close)}
-                  x2={CHART_WIDTH - PADDING.right}
+                  x2={metrics.width - metrics.padding.right}
                   y2={chartData.getY(hoveredCandle.close)}
                   stroke="var(--foreground)"
                   strokeOpacity="0.16"

--- a/frontend/src/components/market/CoinTable.tsx
+++ b/frontend/src/components/market/CoinTable.tsx
@@ -4,6 +4,7 @@ import { formatPrice, formatVolume, formatChangeRate, getCurrencySymbol } from "
 import { SortIcon } from "@/components/ui/SortIcon";
 import type { SortDir } from "@/hooks/useSort";
 import { useVirtualList, virtualRowStyle } from "@/hooks/useVirtualList";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import { usePriceFlash } from "@/hooks/usePriceFlash";
 import type { CoinData } from "@/lib/types/coins";
 
@@ -22,12 +23,16 @@ interface CoinTableProps {
   toolbar?: ReactNode;
 }
 
-const GRID_COLS = "grid-cols-[2fr_minmax(100px,140px)_minmax(80px,100px)_minmax(160px,1fr)]";
+// 좁은 화면에서는 네 칸을 다 세울 폭이 없다. 거래대금을 접고 코인·현재가·전일대비만 남긴다.
+const GRID_COLS =
+  "grid-cols-[minmax(0,1fr)_auto_72px] sm:grid-cols-[2fr_minmax(100px,140px)_minmax(80px,100px)_minmax(160px,1fr)]";
 
 // 가상화는 행 높이를 미리 알아야 스크롤 높이를 계산할 수 있다. 행은 높이를 고정한다.
 const ROW_HEIGHT = 68;
 const VISIBLE_ROWS = 8;
 const LIST_HEIGHT = ROW_HEIGHT * VISIBLE_ROWS;
+// 헤더 여백은 인라인 스타일로 준다(스크롤바 폭을 더해야 본문과 열이 맞는다). 본문의 px 클래스와 같은 값이어야 한다.
+const LIST_PADDING_X_MOBILE = 12; // px-3
 const LIST_PADDING_X = 20; // px-5
 
 interface CoinRowProps {
@@ -57,21 +62,21 @@ const CoinRow = memo(function CoinRow({
       onClick={handleClick}
       style={style}
       className={cn(
-        "group grid cursor-pointer items-center px-5 transition-colors hover:bg-primary/[0.03]",
+        "group grid cursor-pointer items-center gap-2 px-3 transition-colors hover:bg-primary/[0.03] sm:gap-0 sm:px-5",
         GRID_COLS,
         !isLast && "border-b border-border/30",
         isSelected && "bg-primary/[0.04]",
       )}
     >
-      <div className="flex items-center gap-3">
-        <div className="flex flex-col leading-tight">
+      <div className="flex min-w-0 items-center gap-3">
+        <div className="flex min-w-0 flex-col leading-tight">
           <span className="text-[13px] font-semibold tracking-wide">{coin.symbol}</span>
-          <span className="text-[11px] text-muted-foreground">{coin.name}</span>
+          <span className="truncate text-[11px] text-muted-foreground">{coin.name}</span>
         </div>
       </div>
 
       <div className={cn(
-        "relative text-right font-mono text-sm font-semibold tabular-nums",
+        "relative whitespace-nowrap text-right font-mono text-[13px] font-semibold tabular-nums sm:text-sm",
         coin.changeRate > 0 && "text-positive",
         coin.changeRate < 0 && "text-negative",
       )}>
@@ -96,7 +101,7 @@ const CoinRow = memo(function CoinRow({
         {coin.currentPrice > 0 ? (
           <span
             className={cn(
-              "inline-block rounded-full px-2 py-0.5 font-mono text-xs font-medium tabular-nums",
+              "inline-block whitespace-nowrap rounded-full px-1.5 py-0.5 font-mono text-[11px] font-medium tabular-nums sm:px-2 sm:text-xs",
               coin.changeRate > 0 && "bg-positive/15 text-positive",
               coin.changeRate < 0 && "bg-negative/15 text-negative",
               coin.changeRate === 0 && "text-muted-foreground",
@@ -109,7 +114,7 @@ const CoinRow = memo(function CoinRow({
         )}
       </div>
 
-      <div className="text-right font-mono text-xs tabular-nums text-muted-foreground">
+      <div className="hidden text-right font-mono text-xs tabular-nums text-muted-foreground sm:block">
         {coin.volume > 0 ? formatVolume(coin.volume, baseCurrency) : "-"}
       </div>
     </div>
@@ -130,25 +135,28 @@ export function CoinTable({
     count: coins.length,
     rowHeight: ROW_HEIGHT,
   });
+  const isMobile = useIsMobile();
 
   const currencySymbol = getCurrencySymbol(baseCurrency);
 
-  const columns: { key: CoinSortKey; label: string; sortable: boolean }[] = [
+  const columns: { key: CoinSortKey; label: string; sortable: boolean; mobileHidden?: boolean }[] = [
     { key: "name", label: "코인명", sortable: true },
     { key: "price", label: "현재가", sortable: true },
     { key: "change", label: "전일대비", sortable: true },
-    { key: "volume", label: "거래대금(24H)", sortable: true },
+    { key: "volume", label: "거래대금(24H)", sortable: true, mobileHidden: true },
   ];
+
+  const rowPaddingX = isMobile ? LIST_PADDING_X_MOBILE : LIST_PADDING_X;
 
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-card">
-      {toolbar && <div className="border-b border-border/40 px-5 py-3">{toolbar}</div>}
+      {toolbar && <div className="border-b border-border/40 px-3 py-3 sm:px-5">{toolbar}</div>}
 
       <div
-        className={cn("grid items-center bg-secondary/30 py-3.5", GRID_COLS)}
+        className={cn("grid items-center gap-2 bg-secondary/30 py-3 sm:gap-0 sm:py-3.5", GRID_COLS)}
         style={{
-          paddingLeft: LIST_PADDING_X,
-          paddingRight: LIST_PADDING_X + scrollbarWidth,
+          paddingLeft: rowPaddingX,
+          paddingRight: rowPaddingX + scrollbarWidth,
         }}
       >
         {columns.map((col) => (
@@ -157,9 +165,10 @@ export function CoinTable({
             onClick={() => col.sortable && onSort(col.key)}
             disabled={!col.sortable}
             className={cn(
-              "flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors",
+              "flex items-center gap-1 whitespace-nowrap text-[11px] font-medium text-muted-foreground transition-colors sm:text-xs",
               col.sortable && "hover:text-foreground",
               col.key !== "name" && "justify-end",
+              col.mobileHidden && "hidden sm:flex",
             )}
           >
             {col.key !== "name" && <SortIcon column={col.key} activeColumn={sortKey} direction={sortDir} />}

--- a/frontend/src/components/market/ExchangeTabs.tsx
+++ b/frontend/src/components/market/ExchangeTabs.tsx
@@ -14,7 +14,8 @@ interface ExchangeTabsProps {
 
 export function ExchangeTabs({ exchanges, selected, onSelect }: ExchangeTabsProps) {
   return (
-    <div className="flex gap-1 rounded-full bg-secondary/80 p-1">
+    // 거래소가 늘어나도 좁은 화면에서 줄이 깨지지 않도록, 넘치면 가로로 넘겨 보게 한다.
+    <div className="no-scrollbar flex max-w-full gap-1 overflow-x-auto rounded-full bg-secondary/80 p-1">
       {exchanges.map((exchange) => {
         const isActive = exchange.id === selected;
         return (
@@ -22,7 +23,7 @@ export function ExchangeTabs({ exchanges, selected, onSelect }: ExchangeTabsProp
             key={exchange.id}
             onClick={() => onSelect(exchange.id)}
             className={cn(
-              "relative rounded-full px-4 py-1.5 text-sm font-medium transition-all duration-200",
+              "relative shrink-0 whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium transition-all duration-200 sm:px-4",
               isActive
                 ? "bg-primary text-primary-foreground shadow-md"
                 : "text-muted-foreground hover:text-foreground hover:bg-white/60",

--- a/frontend/src/components/market/MarketOverviewCards.tsx
+++ b/frontend/src/components/market/MarketOverviewCards.tsx
@@ -35,17 +35,18 @@ export function MarketOverviewCards({ coins, baseCurrency, highlightSymbols }: M
         <span className="text-sm font-bold text-foreground">주요 코인</span>
         <span className="text-xs font-medium text-muted-foreground">&middot; 실시간</span>
       </div>
-      <div className="grid grid-cols-3 gap-4">
+      {/* 좁은 화면에서 3등분하면 카드 하나가 시세 한 줄도 못 담는다. 옆으로 넘겨 보게 한다. */}
+      <div className="no-scrollbar -mx-4 flex snap-x snap-mandatory gap-3 overflow-x-auto px-4 sm:mx-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
       {highlighted.map((coin) => {
         const isUp = coin.changeRate > 0;
         return (
           <div
             key={coin.symbol}
-            className="rounded-xl border border-border bg-card p-5 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-card-hover"
+            className="w-[62%] shrink-0 snap-start rounded-xl border border-border bg-card p-4 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-card-hover sm:w-auto sm:p-5"
           >
-            <div className="flex items-start justify-between">
-              <div className="flex items-center gap-2.5">
-                <div>
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex min-w-0 items-center gap-2.5">
+                <div className="min-w-0">
                   <span className="text-sm font-semibold">{coin.symbol}</span>
                   <span className="ml-1.5 text-xs text-muted-foreground">{coin.name}</span>
                 </div>
@@ -53,7 +54,7 @@ export function MarketOverviewCards({ coins, baseCurrency, highlightSymbols }: M
               {coin.currentPrice > 0 ? (
                 <span
                   className={cn(
-                    "rounded-full px-2 py-0.5 text-xs font-medium tabular-nums",
+                    "shrink-0 rounded-full px-2 py-0.5 text-xs font-medium tabular-nums",
                     isUp ? "bg-positive/15 text-positive" : "bg-negative/15 text-negative",
                     coin.changeRate === 0 && "bg-muted text-muted-foreground",
                   )}
@@ -65,7 +66,7 @@ export function MarketOverviewCards({ coins, baseCurrency, highlightSymbols }: M
               )}
             </div>
             <div className="mt-3">
-              <span className="font-mono text-lg font-bold tabular-nums">
+              <span className="block truncate font-mono text-base font-bold tabular-nums sm:text-lg">
                 {coin.currentPrice > 0
                   ? formatCardPrice(coin.currentPrice, baseCurrency)
                   : <span className="text-muted-foreground">-</span>}

--- a/frontend/src/components/market/OrderPanel.tsx
+++ b/frontend/src/components/market/OrderPanel.tsx
@@ -412,8 +412,9 @@ export function OrderPanel({
   const mappedUnavailable = !orderTargetIds;
 
   return (
-    <div className="sticky top-24 space-y-4">
-      <div className="rounded-xl border border-border bg-card p-5">
+    // 좁은 화면에서는 주문 패널이 목록 아래에 이어 붙는다. 그 자리에서 붙잡아 두면 스크롤을 가로막는다.
+    <div className="space-y-4 lg:sticky lg:top-24">
+      <div className="rounded-xl border border-border bg-card p-4 sm:p-5">
           <div className="flex items-center justify-between gap-3">
             <div>
               <p className="text-xs font-semibold text-muted-foreground">주문 패널</p>

--- a/frontend/src/components/portfolio/HoldingsTable.tsx
+++ b/frontend/src/components/portfolio/HoldingsTable.tsx
@@ -27,7 +27,10 @@ function computeHolding(h: HoldingData): ComputedHolding {
   return { ...h, evalAmount, profitLoss, profitRate };
 }
 
-const GRID_COLS = "grid-cols-[1.4fr_minmax(80px,1fr)_minmax(80px,1fr)_minmax(80px,1fr)_minmax(80px,1fr)_minmax(80px,1fr)_minmax(75px,0.8fr)]";
+// 좁은 화면에서는 일곱 칸이 들어가지 않는다. 코인·평가금액·수익률만 세우고,
+// 접은 칸 가운데 수량과 평가손익은 남은 칸 아래에 덧붙여 보여준다.
+const GRID_COLS =
+  "grid-cols-[minmax(0,1fr)_auto_76px] sm:grid-cols-[1.4fr_minmax(80px,1fr)_minmax(80px,1fr)_minmax(80px,1fr)_minmax(80px,1fr)_minmax(80px,1fr)_minmax(75px,0.8fr)]";
 
 export function HoldingsTable({ holdings, baseCurrency }: HoldingsTableProps) {
   const computed = useMemo(() => holdings.map(computeHolding), [holdings]);
@@ -53,28 +56,29 @@ export function HoldingsTable({ holdings, baseCurrency }: HoldingsTableProps) {
     comparator,
   });
 
-  const columns: { key: SortKey; label: string }[] = [
+  const columns: { key: SortKey; label: string; mobileHidden?: boolean }[] = [
     { key: "name", label: "코인명" },
-    { key: "quantity", label: "보유수량" },
-    { key: "avgBuyPrice", label: "평균매수가" },
-    { key: "currentPrice", label: "현재가" },
+    { key: "quantity", label: "보유수량", mobileHidden: true },
+    { key: "avgBuyPrice", label: "평균매수가", mobileHidden: true },
+    { key: "currentPrice", label: "현재가", mobileHidden: true },
     { key: "evalAmount", label: "평가금액" },
-    { key: "profitLoss", label: "평가손익" },
+    { key: "profitLoss", label: "평가손익", mobileHidden: true },
     { key: "profitRate", label: "수익률" },
   ];
 
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-card">
-      <div className="overflow-x-auto">
+      <div className="sm:overflow-x-auto">
         {/* Header */}
-        <div className={cn("grid min-w-[700px] items-center bg-secondary/30 px-5 py-3.5", GRID_COLS)}>
+        <div className={cn("grid items-center gap-2 bg-secondary/30 px-3 py-3 sm:min-w-[700px] sm:gap-0 sm:px-5 sm:py-3.5", GRID_COLS)}>
           {columns.map((col) => (
             <button
               key={col.key}
               onClick={() => handleSort(col.key)}
               className={cn(
-                "flex items-center gap-1 whitespace-nowrap text-xs font-medium text-muted-foreground transition-colors hover:text-foreground",
+                "flex items-center gap-1 whitespace-nowrap text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground sm:text-xs",
                 col.key !== "name" && "justify-end",
+                col.mobileHidden && "hidden sm:flex",
               )}
             >
               {col.key !== "name" && <SortIcon column={col.key} activeColumn={sortKey} direction={sortDir} />}
@@ -98,42 +102,55 @@ export function HoldingsTable({ holdings, baseCurrency }: HoldingsTableProps) {
                 <div
                   key={h.coinSymbol}
                   className={cn(
-                    "grid min-w-[700px] items-center px-5 py-[18px] transition-colors hover:bg-primary/[0.03]",
+                    "grid items-center gap-2 px-3 py-3.5 transition-colors hover:bg-primary/[0.03] sm:min-w-[700px] sm:gap-0 sm:px-5 sm:py-[18px]",
                     GRID_COLS,
                     i !== sorted.length - 1 && "border-b border-border/30",
                   )}
                 >
                   {/* Coin info */}
-                  <div className="flex items-center gap-3">
-                    <div className="flex flex-col leading-tight">
+                  <div className="flex min-w-0 items-center gap-3">
+                    <div className="flex min-w-0 flex-col leading-tight">
                       <span className="text-[13px] font-semibold tracking-wide">{h.coinSymbol}</span>
-                      <span className="text-[11px] text-muted-foreground">{h.coinName}</span>
+                      <span className="truncate text-[11px] text-muted-foreground">{h.coinName}</span>
+                      {/* 좁은 화면에서 접은 보유수량 칸을 이름 아래에 되살린다. */}
+                      <span className="mt-0.5 font-mono text-[11px] tabular-nums text-muted-foreground/80 sm:hidden">
+                        {formatQuantity(h.quantity)}
+                      </span>
                     </div>
                   </div>
 
                   {/* Quantity */}
-                  <div className="whitespace-nowrap text-right font-mono text-sm tabular-nums">
+                  <div className="hidden whitespace-nowrap text-right font-mono text-sm tabular-nums sm:block">
                     {formatQuantity(h.quantity)}
                   </div>
 
                   {/* Avg buy price */}
-                  <div className="whitespace-nowrap text-right font-mono text-sm tabular-nums text-muted-foreground">
+                  <div className="hidden whitespace-nowrap text-right font-mono text-sm tabular-nums text-muted-foreground sm:block">
                     {formatPrice(h.avgBuyPrice, baseCurrency)}
                   </div>
 
                   {/* Current price */}
-                  <div className="whitespace-nowrap text-right font-mono text-sm font-semibold tabular-nums">
+                  <div className="hidden whitespace-nowrap text-right font-mono text-sm font-semibold tabular-nums sm:block">
                     {formatPrice(h.currentPrice, baseCurrency)}
                   </div>
 
                   {/* Eval amount */}
-                  <div className="whitespace-nowrap text-right font-mono text-sm tabular-nums">
+                  <div className="whitespace-nowrap text-right font-mono text-[13px] tabular-nums sm:text-sm">
                     {formatCurrencyCompact(h.evalAmount, baseCurrency)}
+                    {/* 좁은 화면에서 접은 평가손익 칸을 평가금액 아래에 되살린다. */}
+                    <span className={cn(
+                      "mt-0.5 block text-[11px] font-semibold sm:hidden",
+                      isPositive && "text-positive",
+                      isNegative && "text-negative",
+                      !isPositive && !isNegative && "text-muted-foreground",
+                    )}>
+                      {isPositive ? "+" : ""}{formatCurrencyCompact(h.profitLoss, baseCurrency)}
+                    </span>
                   </div>
 
                   {/* Profit/Loss */}
                   <div className={cn(
-                    "whitespace-nowrap text-right font-mono text-sm font-semibold tabular-nums",
+                    "hidden whitespace-nowrap text-right font-mono text-sm font-semibold tabular-nums sm:block",
                     isPositive && "text-positive",
                     isNegative && "text-negative",
                   )}>
@@ -143,7 +160,7 @@ export function HoldingsTable({ holdings, baseCurrency }: HoldingsTableProps) {
                   {/* Profit rate */}
                   <div className="flex justify-end">
                     <span className={cn(
-                      "inline-block whitespace-nowrap rounded-full px-2 py-0.5 font-mono text-xs font-medium tabular-nums",
+                      "inline-block whitespace-nowrap rounded-full px-1.5 py-0.5 font-mono text-[11px] font-medium tabular-nums sm:px-2 sm:text-xs",
                       isPositive && "bg-positive/15 text-positive",
                       isNegative && "bg-negative/20 text-negative",
                       !isPositive && !isNegative && "text-muted-foreground",

--- a/frontend/src/components/regret/MeVsMe.tsx
+++ b/frontend/src/components/regret/MeVsMe.tsx
@@ -25,7 +25,7 @@ export function MeVsMe({
   benchmarks,
 }: MeVsMeProps) {
   return (
-    <div className="rounded-xl border border-border bg-card p-5 sm:p-6">
+    <div className="rounded-xl border border-border bg-card p-4 sm:p-6">
       {/* 헤더 */}
       <div className="mb-5">
         <h2 className="text-lg font-bold">나 vs 나</h2>
@@ -48,7 +48,7 @@ export function MeVsMe({
               key={rule.ruleType}
               onClick={() => onToggleRule(rule.ruleType)}
               className={cn(
-                "flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left transition-all",
+                "flex w-full items-center gap-2.5 rounded-xl px-3 py-3 text-left transition-all sm:gap-3",
                 isEnabled ? "bg-secondary/60" : "bg-transparent opacity-40",
               )}
             >
@@ -63,8 +63,8 @@ export function MeVsMe({
                 {isEnabled && <Check className="h-3 w-3" strokeWidth={3} />}
               </div>
 
-              <div className="flex flex-1 flex-col gap-0.5">
-                <div className="flex items-center gap-2">
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <div className="flex flex-wrap items-center gap-x-2">
                   <span className="text-sm font-semibold">{rule.label}</span>
                   <span
                     className="font-mono text-sm font-bold tabular-nums"
@@ -82,7 +82,7 @@ export function MeVsMe({
                 </span>
               </div>
 
-              <span className="rounded-md bg-negative/12 px-2 py-0.5 text-xs font-bold text-negative">
+              <span className="shrink-0 whitespace-nowrap rounded-md bg-negative/12 px-2 py-0.5 text-xs font-bold text-negative">
                 위반 {rule.violationCount}
               </span>
             </button>
@@ -121,12 +121,12 @@ export function MeVsMe({
                   className="h-3 w-3 shrink-0 rounded-full"
                   style={{ backgroundColor: bm.color }}
                 />
-                <span className="flex-1 text-sm font-medium">{bm.label}</span>
+                <span className="min-w-0 flex-1 truncate text-sm font-medium">{bm.label}</span>
 
                 {bm.profitRate !== null && (
                   <span
                     className={cn(
-                      "font-mono text-sm font-bold tabular-nums",
+                      "shrink-0 font-mono text-sm font-bold tabular-nums",
                       isPositive ? "text-positive" : "text-negative",
                     )}
                   >

--- a/frontend/src/components/regret/RegretChart.tsx
+++ b/frontend/src/components/regret/RegretChart.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useCallback } from "react";
 import { EstimateNotice } from "@/components/regret/EstimateNotice";
 import { cn } from "@/lib/utils";
 import { formatCurrency, formatCurrencyCompact, formatCurrencyShort } from "@/lib/formatters";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import type { RegretSummary, AssetSnapshot, ViolationMarker } from "@/lib/types/regret";
 import { getTickInterval } from "@/lib/types/regret";
 
@@ -15,9 +16,21 @@ interface RegretChartProps {
   totalDays: number;
 }
 
-const W = 700;
-const H = 280;
-const PAD = { top: 20, right: 20, bottom: 32, left: 60 };
+// SVG 는 viewBox 를 화면 폭에 맞춰 통째로 줄인다. 데스크톱 비율(700×280)을 좁은 화면에 그대로 쓰면
+// 높이가 납작해지고 축 글자도 같은 비율로 줄어 읽을 수 없다. 좁은 화면은 좌표계를 따로 쓴다.
+const DESKTOP_METRICS = {
+  w: 700,
+  h: 280,
+  pad: { top: 20, right: 20, bottom: 32, left: 60 },
+  fontSize: 10,
+} as const;
+
+const MOBILE_METRICS = {
+  w: 360,
+  h: 250,
+  pad: { top: 14, right: 10, bottom: 26, left: 42 },
+  fontSize: 8,
+} as const;
 
 /** 라운드 전체를 합친 그래프라 거래소 기축통화가 섞인다. 서버가 원화로 환산해 내려준다. */
 const CHART_CURRENCY = "KRW";
@@ -40,6 +53,9 @@ export function RegretChart({
   totalDays,
 }: RegretChartProps) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const isMobile = useIsMobile();
+  // 두 상수 중 하나를 가리키므로 참조가 그대로다. 아래 합성 결과가 매 렌더 다시 계산되지 않는다.
+  const { w: W, h: H, pad: PAD, fontSize: AXIS_FONT_SIZE } = isMobile ? MOBILE_METRICS : DESKTOP_METRICS;
 
   const chartData = useMemo(() => {
     if (snapshots.length < 2) return null;
@@ -76,8 +92,8 @@ export function RegretChart({
       return { value: val, y: getY(val) };
     });
 
-    // X축 라벨 — 시즌 기간에 따라 adaptive 간격
-    const tickInterval = getTickInterval(totalDays);
+    // X축 라벨 — 시즌 기간에 따라 adaptive 간격. 좁은 화면은 폭이 절반이라 라벨도 절반만 세운다.
+    const tickInterval = getTickInterval(totalDays) * (isMobile ? 2 : 1);
     const xLabels: { date: string; x: number }[] = [];
     for (let i = 0; i < n; i += tickInterval) {
       xLabels.push({ date: snapshots[i].date, x: getX(i) });
@@ -108,7 +124,7 @@ export function RegretChart({
     }));
 
     return { actualPath, simPath, btcPath, yTicks, xLabels, markerPoints, hoverPoints };
-  }, [snapshots, markers, simulationLine, btcHoldValues, totalDays]);
+  }, [snapshots, markers, simulationLine, btcHoldValues, totalDays, isMobile, W, H, PAD]);
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent<SVGSVGElement>) => {
@@ -123,11 +139,11 @@ export function RegretChart({
       });
       setHoveredIndex(closest);
     },
-    [chartData],
+    [chartData, W],
   );
 
   return (
-    <div className="rounded-xl border border-border bg-card p-5 sm:p-6">
+    <div className="rounded-xl border border-border bg-card p-4 sm:p-6">
       {/* 상단 요약 */}
       <div className="mb-5">
         <p className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
@@ -135,7 +151,7 @@ export function RegretChart({
           <EstimateNotice />
         </p>
         <p className={cn(
-          "mt-1 font-mono text-3xl font-bold tabular-nums",
+          "mt-1 font-mono text-2xl font-bold tabular-nums sm:text-3xl",
           summary.totalViolationLoss > 0 ? "text-negative" : "text-positive",
         )}>
           {summary.totalViolationLoss < 0 ? "-" : ""}
@@ -144,26 +160,28 @@ export function RegretChart({
         <p className="mt-1 text-xs text-muted-foreground">{describeViolationLoss(summary)}</p>
       </div>
 
-      {/* 3-stat 카드 */}
-      <div className="mb-6 grid grid-cols-3 gap-3">
-        <div className="rounded-xl bg-secondary/50 px-3 py-3">
+      {/* 3-stat 카드 — 좁은 화면에서는 자릿수를 다 세우면 칸을 넘친다. 억·만 단위로 줄여 적는다. */}
+      <div className="mb-6 grid grid-cols-3 gap-2 sm:gap-3">
+        <div className="rounded-xl bg-secondary/50 px-2.5 py-2.5 sm:px-3 sm:py-3">
           <p className="text-[11px] font-medium text-muted-foreground">실제 자산</p>
-          <p className="mt-1 font-mono text-base font-bold tabular-nums">
-            {formatCurrencyCompact(summary.actualAsset, CHART_CURRENCY)}
+          <p className="mt-1 font-mono text-sm font-bold tabular-nums sm:text-base">
+            <span className="sm:hidden">{formatCurrencyShort(summary.actualAsset, CHART_CURRENCY)}</span>
+            <span className="hidden sm:inline">{formatCurrencyCompact(summary.actualAsset, CHART_CURRENCY)}</span>
           </p>
         </div>
-        <div className="rounded-xl bg-secondary/50 px-3 py-3">
+        <div className="rounded-xl bg-secondary/50 px-2.5 py-2.5 sm:px-3 sm:py-3">
           <p className="text-[11px] font-medium text-muted-foreground">규칙 준수 시</p>
           <p className={cn(
-            "mt-1 font-mono text-base font-bold tabular-nums",
+            "mt-1 font-mono text-sm font-bold tabular-nums sm:text-base",
             summary.ruleFollowedAsset > summary.actualAsset ? "text-positive" : "",
           )}>
-            {formatCurrencyCompact(summary.ruleFollowedAsset, CHART_CURRENCY)}
+            <span className="sm:hidden">{formatCurrencyShort(summary.ruleFollowedAsset, CHART_CURRENCY)}</span>
+            <span className="hidden sm:inline">{formatCurrencyCompact(summary.ruleFollowedAsset, CHART_CURRENCY)}</span>
           </p>
         </div>
-        <div className="rounded-xl bg-secondary/50 px-3 py-3">
+        <div className="rounded-xl bg-secondary/50 px-2.5 py-2.5 sm:px-3 sm:py-3">
           <p className="text-[11px] font-medium text-muted-foreground">위반</p>
-          <p className="mt-1 font-mono text-lg font-bold tabular-nums">
+          <p className="mt-1 font-mono text-base font-bold tabular-nums sm:text-lg">
             {summary.totalViolations}<span className="text-sm font-bold">건</span>
           </p>
         </div>
@@ -186,7 +204,7 @@ export function RegretChart({
           <text
             x={W / 2} y={H / 2}
             textAnchor="middle" dominantBaseline="middle"
-            fill="var(--muted-foreground)" fontSize={12} fontFamily="inherit"
+            fill="var(--muted-foreground)" fontSize={AXIS_FONT_SIZE + 2} fontFamily="inherit"
           >
             아직 집계된 자산 추이가 없습니다
           </text>
@@ -212,7 +230,7 @@ export function RegretChart({
                 <text
                   x={PAD.left - 8} y={tick.y + 1}
                   textAnchor="end" dominantBaseline="middle"
-                  fill="var(--muted-foreground)" fontSize={10} fontFamily="inherit"
+                  fill="var(--muted-foreground)" fontSize={AXIS_FONT_SIZE} fontFamily="inherit"
                 >
                   {formatCurrencyShort(tick.value, CHART_CURRENCY)}
                 </text>
@@ -223,7 +241,7 @@ export function RegretChart({
             {chartData.xLabels.map((l) => (
               <text
                 key={l.date} x={l.x} y={H - 6}
-                textAnchor="middle" fill="var(--muted-foreground)" fontSize={10} fontFamily="inherit"
+                textAnchor="middle" fill="var(--muted-foreground)" fontSize={AXIS_FONT_SIZE} fontFamily="inherit"
               >
                 {l.date}
               </text>

--- a/frontend/src/components/regret/ViolationTradeList.tsx
+++ b/frontend/src/components/regret/ViolationTradeList.tsx
@@ -52,12 +52,12 @@ export function ViolationTradeList({ trades }: ViolationTradeListProps) {
   }, [byExchange]);
 
   return (
-    <div className="rounded-xl border border-border bg-card p-5 sm:p-6">
+    <div className="rounded-xl border border-border bg-card p-4 sm:p-6">
       {/* 헤더 */}
       <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h2 className="text-lg font-bold">규칙 위반 거래</h2>
 
-        <div className="flex gap-1.5 rounded-lg bg-secondary/60 p-1">
+        <div className="flex gap-1.5 self-start rounded-lg bg-secondary/60 p-1">
           {FILTER_TABS.map((tab) => {
             const count =
               tab.key === "ALL" ? counts.all : tab.key === "LOSS" ? counts.loss : counts.profit;
@@ -108,9 +108,10 @@ export function ViolationTradeList({ trades }: ViolationTradeListProps) {
           return (
             <div
               key={trade.id}
-              className="flex flex-col gap-2 rounded-xl border border-border/40 px-4 py-3 transition-colors hover:bg-primary/[0.02]"
+              className="flex flex-col gap-2 rounded-xl border border-border/40 px-3 py-3 transition-colors hover:bg-primary/[0.02] sm:px-4"
             >
-              <div className="flex items-center gap-3">
+              {/* 좁은 화면에서는 배지가 여러 개 붙어 한 줄을 넘긴다. 넘치면 다음 줄로 내린다. */}
+              <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 sm:gap-3">
                 <span className="text-sm font-bold">{trade.coinSymbol}</span>
                 <span className="text-xs text-muted-foreground">{trade.date}</span>
 

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -59,7 +59,9 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          // 내용이 화면보다 길어지면(좁은 화면에서 흔하다) 상자 안에서 스크롤한다.
+          // 그러지 않으면 위아래가 잘려 확인 버튼에 손이 닿지 않는다.
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto overscroll-contain rounded-lg border p-4 shadow-lg duration-200 outline-none sm:max-w-lg sm:p-6",
           className
         )}
         {...props}

--- a/frontend/src/components/wallet/TransferHistoryPanel.tsx
+++ b/frontend/src/components/wallet/TransferHistoryPanel.tsx
@@ -102,11 +102,11 @@ export function TransferHistoryPanel({ exchangeId, exchanges, records, assetFilt
 
   return (
     <section className="mt-6 overflow-hidden rounded-xl border border-border bg-card">
-      <div className="border-b border-border/30 px-6 py-5">
-        <h3 className="text-lg font-bold">입출금 내역</h3>
+      <div className="border-b border-border/30 px-4 py-4 sm:px-6 sm:py-5">
+        <h3 className="text-base font-bold sm:text-lg">입출금 내역</h3>
       </div>
 
-      <div className="flex flex-wrap items-center justify-between gap-4 border-b border-border/30 px-6 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-4 border-b border-border/30 px-4 py-4 sm:px-6">
         <div className="flex flex-wrap items-center gap-2">
           {TYPE_TABS.map((tab) => (
             <button
@@ -156,7 +156,7 @@ export function TransferHistoryPanel({ exchangeId, exchanges, records, assetFilt
               <button
                 key={item.id}
                 onClick={() => setSelected(item)}
-                className="w-full px-6 py-4 text-left transition hover:bg-primary/[0.04]"
+                className="w-full px-4 py-4 sm:px-6 text-left transition hover:bg-primary/[0.04]"
               >
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <span className="text-xs text-muted-foreground">{formatDate(item.requestedAt)}</span>

--- a/frontend/src/components/wallet/TransferModal.tsx
+++ b/frontend/src/components/wallet/TransferModal.tsx
@@ -117,9 +117,10 @@ export function TransferModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogContent showCloseButton className="max-w-md gap-0 p-0">
+      {/* p-0 은 기본 여백을 지우는 것이라 sm 이상에서도 같이 지워야 한다. 안쪽 구역이 여백을 직접 쥔다. */}
+      <DialogContent showCloseButton className="max-w-md gap-0 p-0 sm:p-0">
         {/* Header */}
-        <DialogHeader className="border-b border-border/30 px-6 py-5">
+        <DialogHeader className="border-b border-border/30 px-4 py-4 sm:px-6 sm:py-5">
           <div className="flex items-center gap-3">
             <div>
               <DialogTitle>{coin.coinSymbol} 출금</DialogTitle>
@@ -130,7 +131,7 @@ export function TransferModal({
           </div>
         </DialogHeader>
 
-        <div className="space-y-5 px-6 py-5">
+        <div className="space-y-5 px-4 py-5 sm:px-6">
           {/* Destination Exchange */}
           <div className="space-y-2">
             <label className="text-sm font-medium">도착 거래소</label>

--- a/frontend/src/components/wallet/WalletAssetTable.tsx
+++ b/frontend/src/components/wallet/WalletAssetTable.tsx
@@ -6,6 +6,7 @@ import { SortIcon } from "@/components/ui/SortIcon";
 import { useSort } from "@/hooks/useSort";
 import type { SortDir } from "@/hooks/useSort";
 import { useVirtualList, virtualRowStyle } from "@/hooks/useVirtualList";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import type { WalletCoinBalance } from "@/lib/types/wallet";
 
 interface WalletAssetTableProps {
@@ -33,13 +34,17 @@ function formatDisplayQuantity(quantity: number, symbol: string, baseCurrency: s
   return formatQuantity(quantity);
 }
 
-const GRID_COLS = "grid-cols-[1.6fr_minmax(120px,1.2fr)_minmax(100px,1fr)_minmax(90px,0.8fr)]";
+// 좁은 화면에서는 네 칸을 다 세울 폭이 없다. 사용가능·잠금은 접고, 행을 눌러 여는 상세에서 본다.
+const GRID_COLS =
+  "grid-cols-[minmax(0,1fr)_auto] sm:grid-cols-[1.6fr_minmax(120px,1.2fr)_minmax(100px,1fr)_minmax(90px,0.8fr)]";
 
 // 가상화는 행 높이를 미리 알아야 스크롤 높이를 계산할 수 있다. 행은 높이를 고정한다.
 // 보유수량 칸은 수량과 환산액 두 줄이 들어가므로 시세 목록보다 한 행이 높다.
 const ROW_HEIGHT = 72;
 const VISIBLE_ROWS = 8;
 const LIST_HEIGHT = ROW_HEIGHT * VISIBLE_ROWS;
+// 헤더 여백은 인라인 스타일로 준다(스크롤바 폭을 더해야 본문과 열이 맞는다). 본문의 px 클래스와 같은 값이어야 한다.
+const LIST_PADDING_X_MOBILE = 12; // px-3
 const LIST_PADDING_X = 20; // px-5
 
 export function WalletAssetTable({ balances, baseCurrency, onSelectCoin, selectedCoin }: WalletAssetTableProps) {
@@ -91,21 +96,24 @@ export function WalletAssetTable({ balances, baseCurrency, onSelectCoin, selecte
     count: sorted.length,
     rowHeight: ROW_HEIGHT,
   });
+  const isMobile = useIsMobile();
 
-  const columns: { key: SortKey; label: string }[] = [
+  const columns: { key: SortKey; label: string; mobileHidden?: boolean }[] = [
     { key: "name", label: "코인" },
     { key: "total", label: "보유수량" },
-    { key: "available", label: "사용가능" },
-    { key: "locked", label: "잠금" },
+    { key: "available", label: "사용가능", mobileHidden: true },
+    { key: "locked", label: "잠금", mobileHidden: true },
   ];
+
+  const rowPaddingX = isMobile ? LIST_PADDING_X_MOBILE : LIST_PADDING_X;
 
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-card">
       {/* Toolbar */}
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/30 px-5 py-4">
-        <h3 className="text-lg font-bold">보유 자산</h3>
-        <div className="flex items-center gap-3">
-          <div className="relative">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/30 px-3 py-3 sm:px-5 sm:py-4">
+        <h3 className="text-base font-bold sm:text-lg">보유 자산</h3>
+        <div className="flex flex-1 items-center justify-end gap-3">
+          <div className="relative min-w-0 flex-1 sm:flex-none">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/50" />
             <input
               type="text"
@@ -113,10 +121,10 @@ export function WalletAssetTable({ balances, baseCurrency, onSelectCoin, selecte
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               aria-label="코인 검색"
-              className="h-9 w-48 rounded-full border border-border/50 bg-secondary/30 pl-9 pr-3 text-sm outline-none transition-colors placeholder:text-muted-foreground/40 focus:border-primary/40 focus:bg-white"
+              className="h-9 w-full rounded-full border border-border/50 bg-secondary/30 pl-9 pr-3 text-sm outline-none transition-colors placeholder:text-muted-foreground/40 focus:border-primary/40 focus:bg-white sm:w-48"
             />
           </div>
-          <label className="flex cursor-pointer items-center gap-1.5 text-xs font-medium text-muted-foreground select-none">
+          <label className="flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap text-xs font-medium text-muted-foreground select-none">
             <input
               type="checkbox"
               checked={hideSmall}
@@ -128,11 +136,11 @@ export function WalletAssetTable({ balances, baseCurrency, onSelectCoin, selecte
         </div>
       </div>
 
-      <div className="overflow-x-auto">
+      <div className="sm:overflow-x-auto">
         {/* Header */}
         <div
-          className={cn("grid min-w-[640px] items-center bg-secondary/30 py-3.5", GRID_COLS)}
-          style={{ paddingLeft: LIST_PADDING_X, paddingRight: LIST_PADDING_X + scrollbarWidth }}
+          className={cn("grid items-center gap-2 bg-secondary/30 py-3 sm:min-w-[640px] sm:gap-0 sm:py-3.5", GRID_COLS)}
+          style={{ paddingLeft: rowPaddingX, paddingRight: rowPaddingX + scrollbarWidth }}
           role="row"
         >
           {columns.map((col) => (
@@ -141,8 +149,9 @@ export function WalletAssetTable({ balances, baseCurrency, onSelectCoin, selecte
               onClick={() => handleSort(col.key)}
               aria-sort={sortKey === col.key ? (sortDir === "asc" ? "ascending" : "descending") : "none"}
               className={cn(
-                "flex items-center gap-1 whitespace-nowrap text-xs font-medium text-muted-foreground transition-colors hover:text-foreground",
+                "flex items-center gap-1 whitespace-nowrap text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground sm:text-xs",
                 col.key !== "name" && "justify-end",
+                col.mobileHidden && "hidden sm:flex",
               )}
             >
               {col.key !== "name" && <SortIcon column={col.key} activeColumn={sortKey} direction={sortDir} />}
@@ -160,7 +169,7 @@ export function WalletAssetTable({ balances, baseCurrency, onSelectCoin, selecte
         ) : (
           <div
             ref={scrollRef}
-            className="min-w-[640px] overflow-y-auto [scrollbar-gutter:stable]"
+            className="overflow-y-auto [scrollbar-gutter:stable] sm:min-w-[640px]"
             style={{ height: Math.min(LIST_HEIGHT, sorted.length * ROW_HEIGHT) }}
           >
             <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
@@ -178,22 +187,22 @@ export function WalletAssetTable({ balances, baseCurrency, onSelectCoin, selecte
                     onKeyDown={(e) => { if (e.key === "Enter") onSelectCoin?.(isSelected ? null : b); }}
                     style={virtualRowStyle(item, ROW_HEIGHT)}
                     className={cn(
-                      "grid cursor-pointer items-center px-5 transition-colors",
+                      "grid cursor-pointer items-center gap-2 px-3 transition-colors sm:gap-0 sm:px-5",
                       GRID_COLS,
                       isSelected ? "bg-primary/[0.06]" : "hover:bg-primary/[0.03]",
                       item.index !== sorted.length - 1 && "border-b border-border/30",
                     )}
                   >
                     {/* Coin info */}
-                    <div className="flex items-center gap-3">
-                      <div className="flex flex-col leading-tight">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <div className="flex min-w-0 flex-col leading-tight">
                         <span className="text-[13px] font-semibold tracking-wide">{b.coinSymbol}</span>
-                        <span className="text-[11px] text-muted-foreground">{b.coinName}</span>
+                        <span className="truncate text-[11px] text-muted-foreground">{b.coinName}</span>
                       </div>
                     </div>
 
                     {/* Total amount */}
-                    <div className="text-right">
+                    <div className="min-w-0 text-right">
                       <div className={cn("font-mono text-sm tabular-nums", hasBalance ? "font-semibold" : "text-muted-foreground/40")}>
                         {hasBalance ? formatDisplayQuantity(b.total, b.coinSymbol, baseCurrency) : "—"}
                       </div>
@@ -205,13 +214,13 @@ export function WalletAssetTable({ balances, baseCurrency, onSelectCoin, selecte
                     </div>
 
                     {/* Available */}
-                    <div className={cn("text-right font-mono text-sm tabular-nums", !hasBalance && "text-muted-foreground/40")}>
+                    <div className={cn("hidden text-right font-mono text-sm tabular-nums sm:block", !hasBalance && "text-muted-foreground/40")}>
                       {hasBalance ? formatDisplayQuantity(b.available, b.coinSymbol, baseCurrency) : "—"}
                     </div>
 
                     {/* Locked */}
                     <div className={cn(
-                      "text-right font-mono text-sm tabular-nums",
+                      "hidden text-right font-mono text-sm tabular-nums sm:block",
                       b.locked > 0 ? "text-chart-4" : "text-muted-foreground/40",
                     )}>
                       {b.locked > 0

--- a/frontend/src/components/wallet/WalletSummary.tsx
+++ b/frontend/src/components/wallet/WalletSummary.tsx
@@ -26,7 +26,7 @@ export function WalletSummary({ balances, baseCurrency, exchangeName }: WalletSu
   const baseLocked = baseCoin ? baseCoin.locked : 0;
 
   return (
-    <div className="rounded-xl border border-border bg-card p-6">
+    <div className="rounded-xl border border-border bg-card p-4 sm:p-6">
       <div>
         <div className="flex items-center gap-2">
           <p className="text-sm font-medium text-muted-foreground">
@@ -41,11 +41,11 @@ export function WalletSummary({ balances, baseCurrency, exchangeName }: WalletSu
           </button>
         </div>
 
-        <p className="mt-1 font-mono text-3xl font-bold tabular-nums tracking-tight">
+        <p className="mt-1 break-all font-mono text-2xl font-bold tabular-nums tracking-tight sm:text-3xl">
           {visible ? formatCurrency(totalAsset, baseCurrency) : HIDDEN}
         </p>
 
-        <div className="mt-1.5 flex items-center gap-3 text-sm text-muted-foreground">
+        <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
           <span>
             <span className="text-xs">보유 {baseCurrency}</span>{" "}
             <span className={cn("font-mono font-semibold tabular-nums", !visible && "blur-sm select-none")}>

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/**
+ * CSS 클래스만으로는 못 바꾸는 값(SVG 좌표계, 인라인 여백처럼 자바스크립트가 쥔 수치)을
+ * 화면 폭에 따라 갈라야 할 때 쓴다. 보이고 감추는 정도는 tailwind 반응형 클래스로 충분하다.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}
+
+/** tailwind 의 sm(640px) 아래를 모바일로 본다. 반응형 클래스와 기준을 맞춰야 화면이 어긋나지 않는다. */
+export function useIsMobile(): boolean {
+  return useMediaQuery("(max-width: 639px)");
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -97,11 +97,27 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    /* 가로 방향 전환 시 사파리가 글자를 임의로 키우지 않게 한다. */
+    -webkit-text-size-adjust: 100%;
+  }
   body {
     @apply bg-background text-foreground antialiased;
     font-weight: 400;
     font-feature-settings: "cv02", "cv03", "cv04", "cv11";
     letter-spacing: -0.01em;
+    /* 표·차트가 제 상자 안에서 가로로 스크롤한다. 페이지 자체가 옆으로 밀리는 것은 막는다. */
+    overflow-x: hidden;
+  }
+
+  /* iOS 사파리는 16px 미만 입력칸에 포커스가 가면 화면을 확대한다. 확대되면 레이아웃이
+     통째로 어긋나고 사용자가 직접 되돌려야 하므로, 좁은 화면에서는 16px 로 올린다. */
+  @media (max-width: 639px) {
+    input,
+    select,
+    textarea {
+      font-size: 16px;
+    }
   }
 }
 

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -167,12 +167,12 @@ export function MarketPage() {
       <Header />
 
       {/* Page header */}
-      <section className="animate-enter border-b border-border/40 pb-6 pt-8">
+      <section className="animate-enter border-b border-border/40 pb-5 pt-6 sm:pb-6 sm:pt-8">
         <div className="mx-auto max-w-6xl px-4">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
             <div>
-              <h1 className="font-display text-3xl tracking-tight">코인 시세</h1>
-              <p className="mt-2 text-sm text-muted-foreground">
+              <h1 className="font-display text-2xl tracking-tight sm:text-3xl">코인 시세</h1>
+              <p className="mt-1.5 text-sm text-muted-foreground sm:mt-2">
                 {exchange.name} 기준 · {exchange.baseCurrency} 마켓
               </p>
             </div>
@@ -180,20 +180,21 @@ export function MarketPage() {
         </div>
       </section>
 
-      <main className="mx-auto max-w-6xl px-4 py-8">
+      <main className="mx-auto max-w-6xl px-4 py-6 sm:py-8">
         {/* Market overview cards */}
         <div className="animate-enter-delay-1">
           <MarketOverviewCards coins={coins} baseCurrency={exchange.baseCurrency} />
         </div>
 
         {/* Controls */}
-        <div className="animate-enter-delay-2 mb-5 flex flex-wrap items-center gap-3 rounded-xl border border-border bg-card p-4">
+        <div className="animate-enter-delay-2 mb-5 flex flex-wrap items-center gap-3 rounded-xl border border-border bg-card p-3 sm:p-4">
           <ExchangeTabs
             exchanges={exchangeTabItems}
             selected={selectedExchangeKey}
             onSelect={handleExchangeChange}
           />
-          {EXCHANGES.length > 1 && <div className="h-6 w-px bg-border/60" />}
+          {/* 줄이 나뉘면 구분선만 홀로 남아 어색하다. 한 줄에 들어가는 폭에서만 세운다. */}
+          {EXCHANGES.length > 1 && <div className="hidden h-6 w-px bg-border/60 sm:block" />}
           <FilterChips selected={filter} onSelect={setFilter} />
         </div>
 

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useRound } from "@/contexts/RoundContext";
 import { changeNickname, getUserProfile } from "@/lib/api/user-api";
 import { endRound } from "@/lib/api/round-api";
+import { formatKRW } from "@/lib/formatters";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -43,7 +44,7 @@ const STATUS_LABEL: Record<string, string> = {
   ENDED: "종료",
 };
 
-function formatKRW(value: number): string {
+function formatExactKRW(value: number): string {
   return value.toLocaleString("ko-KR") + "원";
 }
 
@@ -116,10 +117,10 @@ export function MyPage() {
       <Header />
 
       {/* Page header */}
-      <section className="animate-enter border-b border-border/40 pb-6 pt-8">
+      <section className="animate-enter border-b border-border/40 pb-5 pt-6 sm:pb-6 sm:pt-8">
         <div className="mx-auto max-w-6xl px-4">
-          <h1 className="font-display text-3xl tracking-tight">마이페이지</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
+          <h1 className="font-display text-2xl tracking-tight sm:text-3xl">마이페이지</h1>
+          <p className="mt-1.5 text-sm text-muted-foreground sm:mt-2">
             프로필 관리 및 투자 라운드 현황
           </p>
         </div>
@@ -193,16 +194,20 @@ export function MyPage() {
                     시작일: {formatDate(activeRound.startedAt)}
                   </p>
 
-                  {/* Stat grid */}
-                  <div className="grid grid-cols-3 gap-3">
+                  {/* Stat grid — 좁은 화면에서 원 단위를 다 적으면 칸을 넘겨 두 줄이 된다. 만·억으로 줄여 적는다. */}
+                  <div className="grid grid-cols-3 gap-2 sm:gap-3">
                     <div className="rounded-xl bg-secondary/40 p-3 text-center">
                       <p className="text-[11px] text-muted-foreground">시드머니</p>
-                      <p className="mt-1 text-sm font-bold">{formatKRW(activeRound.initialSeed)}</p>
+                      <p className="mt-1 text-sm font-bold">
+                        <span className="sm:hidden">{formatKRW(activeRound.initialSeed)}</span>
+                        <span className="hidden sm:inline">{formatExactKRW(activeRound.initialSeed)}</span>
+                      </p>
                     </div>
                     <div className="rounded-xl bg-secondary/40 p-3 text-center">
                       <p className="text-[11px] text-muted-foreground">긴급자금 상한</p>
                       <p className="mt-1 text-sm font-bold">
-                        {formatKRW(activeRound.emergencyFundingLimit)}
+                        <span className="sm:hidden">{formatKRW(activeRound.emergencyFundingLimit)}</span>
+                        <span className="hidden sm:inline">{formatExactKRW(activeRound.emergencyFundingLimit)}</span>
                       </p>
                     </div>
                     <div className="rounded-xl bg-secondary/40 p-3 text-center">

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -89,13 +89,13 @@ export function PortfolioPage() {
       <Header />
 
       {/* Page header */}
-      <section className="animate-enter border-b border-border/40 pb-6 pt-8">
+      <section className="animate-enter border-b border-border/40 pb-5 pt-6 sm:pb-6 sm:pt-8">
         <div className="mx-auto max-w-6xl px-4">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
             <div>
-              <h1 className="font-display text-3xl tracking-tight">투자내역</h1>
+              <h1 className="font-display text-2xl tracking-tight sm:text-3xl">투자내역</h1>
               {selectedExchangeItem && (
-                <p className="mt-2 text-sm text-muted-foreground">
+                <p className="mt-1.5 text-sm text-muted-foreground sm:mt-2">
                   {selectedExchangeItem.name} 기준 · {selectedExchangeItem.baseCurrency} 마켓
                 </p>
               )}

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -244,17 +244,17 @@ export function RankingPage() {
     <div className="min-h-screen bg-background">
       <Header />
 
-      <section className="animate-enter border-b border-border/40 pb-6 pt-8">
+      <section className="animate-enter border-b border-border/40 pb-5 pt-6 sm:pb-6 sm:pt-8">
         <div className="mx-auto max-w-6xl px-4">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
             <div>
-              <h1 className="mb-1 font-display text-3xl tracking-tight">랭킹</h1>
-              <p className="mt-2 text-sm text-muted-foreground">
+              <h1 className="mb-1 font-display text-2xl tracking-tight sm:text-3xl">랭킹</h1>
+              <p className="mt-1.5 text-sm text-muted-foreground sm:mt-2">
                 {periodLabel} 수익률 기준 순위
               </p>
             </div>
 
-            <div className="flex gap-1.5 rounded-lg border border-border bg-card p-1">
+            <div className="flex gap-1.5 self-start rounded-lg border border-border bg-card p-1">
               {PERIOD_TABS.map((tab) => (
                 <button
                   key={tab.key}

--- a/frontend/src/pages/RegretPage.tsx
+++ b/frontend/src/pages/RegretPage.tsx
@@ -98,10 +98,10 @@ export function RegretPage() {
       <Header />
 
       {/* Page header */}
-      <section className="animate-enter border-b border-border/40 pb-6 pt-8">
+      <section className="animate-enter border-b border-border/40 pb-5 pt-6 sm:pb-6 sm:pt-8">
         <div className="mx-auto max-w-6xl px-4">
-          <h1 className="font-display text-3xl tracking-tight">투자 복기</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
+          <h1 className="font-display text-2xl tracking-tight sm:text-3xl">투자 복기</h1>
+          <p className="mt-1.5 text-sm text-muted-foreground sm:mt-2">
             규칙만 지켰으면 얼마를 벌었을까? · 라운드 전체 원화 기준
           </p>
         </div>

--- a/frontend/src/pages/RoundCreatePage.tsx
+++ b/frontend/src/pages/RoundCreatePage.tsx
@@ -81,10 +81,10 @@ export function RoundCreatePage() {
     <div className="min-h-dvh bg-background">
       <RoundCreateHeader />
 
-      <section className="animate-enter border-b border-border/40 pb-6 pt-8">
+      <section className="animate-enter border-b border-border/40 pb-5 pt-6 sm:pb-6 sm:pt-8">
         <div className="mx-auto max-w-2xl px-4">
-          <h1 className="font-display text-3xl tracking-tight">투자 라운드 시작</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
+          <h1 className="font-display text-2xl tracking-tight sm:text-3xl">투자 라운드 시작</h1>
+          <p className="mt-1.5 text-sm text-muted-foreground sm:mt-2">
             시드머니와 투자 원칙을 설정하고 모의투자를 시작하세요.
           </p>
         </div>

--- a/frontend/src/pages/WalletPage.tsx
+++ b/frontend/src/pages/WalletPage.tsx
@@ -187,12 +187,12 @@ export function WalletPage() {
       <Header />
 
       {/* Page header */}
-      <section className="animate-enter border-b border-border/40 pb-6 pt-8">
+      <section className="animate-enter border-b border-border/40 pb-5 pt-6 sm:pb-6 sm:pt-8">
         <div className="mx-auto max-w-6xl px-4">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
             <div>
-              <h1 className="font-display text-3xl tracking-tight">입출금</h1>
-              <p className="mt-2 text-sm text-muted-foreground">
+              <h1 className="font-display text-2xl tracking-tight sm:text-3xl">입출금</h1>
+              <p className="mt-1.5 text-sm text-muted-foreground sm:mt-2">
                 자산 관리 · 입금/출금 내역 확인
               </p>
             </div>


### PR DESCRIPTION
## Summary

웹을 휴대폰으로 열면 표가 페이지 전체를 가로로 밀어내 값이 화면 밖으로 잘리고, 차트는 납작하게 눌려 축 글자가 읽히지 않던 문제를 고쳤습니다.

- **표** — 좁은 화면에서 열을 접고, 접힌 값 중 중요한 것은 남은 칸 아래에 되살립니다
- **차트** — 좁은 화면용 좌표계를 따로 두어 비율과 글자 크기를 지킵니다
- **겹쳐 뜨는 것** — 다이얼로그가 화면보다 길면 상자 안에서 스크롤합니다

---

## 주요 변경 사항

### 공통 기반

`useMediaQuery` / `useIsMobile` 훅을 추가했습니다. SVG 좌표계나 인라인 여백처럼 **자바스크립트가 쥔 수치**는 CSS 클래스로 가를 수 없어 이 훅으로 분기합니다. 보이고 감추는 정도는 종전대로 tailwind 반응형 클래스로 처리하며, 훅의 기준(639px)과 `sm` 브레이크포인트를 일치시켰습니다.

전역으로는 `body` 의 가로 넘침을 막아 표·차트가 제 상자 안에서만 스크롤하게 했고, 좁은 화면 입력칸을 16px 로 올렸습니다. 16px 미만이면 iOS 사파리가 포커스 시 화면을 확대하는데, 확대되면 레이아웃이 통째로 어긋나고 사용자가 직접 되돌려야 합니다.

### 표 — 시세 목록 · 보유 자산 · 투자내역

| 표 | 좁은 화면에서 접는 칸 | 되살리는 곳 |
|----|----------------------|------------|
| 시세 목록 | 거래대금 | — |
| 보유 자산 | 사용가능, 잠금 | 행을 눌러 여는 상세에 이미 있음 |
| 투자내역 | 보유수량, 평균매수가, 현재가, 평가손익 | 수량은 코인명 아래, 평가손익은 평가금액 아래 |

시세 목록은 애초에 가로 스크롤 상자조차 없어 카드가 화면보다 넓어졌고, 이것이 페이지 전체를 옆으로 미는 원인이었습니다.

### 차트 — 캔들 · 자산 추이

SVG 는 viewBox 를 화면 폭에 맞춰 통째로 줄입니다. 데스크톱 비율(캔들 960×440, 자산 추이 700×280)을 390px 화면에 그대로 쓰면 높이가 눌리고 축 글자도 같은 비율로 줄어 4px 까지 작아집니다. 좁은 화면용 좌표계(캔들 380×340, 자산 추이 360×250)를 따로 두고 여백·글자 크기도 함께 갈랐습니다.

캔들 차트는 띄우는 봉 수도 줄여 한 봉이 손끝으로 짚을 만큼 넓어지게 했고, 마지막 x축 눈금이 직전 눈금과 겹치던 것도 고쳤습니다.

### 그 외

- 주요 코인 카드 — 3등분 대신 옆으로 넘겨 보는 카드로 바꿔 시세가 잘리지 않게 함
- 다이얼로그 — 화면보다 길면 상자 안에서 스크롤 (종전에는 확인 버튼에 손이 닿지 않음)
- 주문 패널 — `sticky` 를 데스크톱에서만 적용 (좁은 화면에서는 스크롤을 가로막았음)
- 거래소 탭 — 넘치면 가로로 넘겨 보게 함
- 마이페이지 라운드 금액 — 원 단위로 적으면 칸을 넘겨 두 줄이 되므로 좁은 화면에서만 만·억 단위로 줄임
- 제목·여백 — 좁은 화면에서 한 단계 축소

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 접는 칸은 `hidden sm:block`, 그리드 열은 `grid-cols-[...] sm:grid-cols-[...]` | 화면별로 컴포넌트를 나누면 같은 표를 두 벌 관리해야 한다. 한 벌로 두고 칸만 접는다 |
| 접힌 값 중 수량·평가손익은 남은 칸 아래에 되살림 | 그냥 감추면 모바일 사용자가 손익을 볼 방법이 없다 |
| 가로 스크롤 대신 열 접기 | 표를 옆으로 밀어야 값이 보이는 화면은 값이 없는 것과 같다 |
| 차트는 CSS 가 아니라 훅으로 분기 | viewBox 좌표는 자바스크립트가 쥔 수치라 미디어 쿼리로 바꿀 수 없다 |
| `body { overflow-x: hidden }` 를 안전망으로 둠 | 원인은 개별 컴포넌트에서 모두 고쳤으나, 앞으로 새 화면이 넘쳐도 페이지 전체가 밀리지는 않게 한다 |

---

## Test Plan

Playwright 로 API 를 대역 응답으로 채우고 실제 화면을 렌더링해 확인했습니다.

### 가로 넘침 회귀 검사

- [x] 320 / 360 / 390 / 430 / 540 / 620 / 640 / 700 / 768 / 834 / 1024 / 1280px **12개 폭 × 7개 화면 전부 넘침 0건**

### 모바일(390×844) 화면 확인

- [x] 마켓 — 주요 코인 카드, 거래소 탭, 캔들 차트, 시세 목록, 긴급 자금, 주문 패널
- [x] 투자내역 — 자산 요약, 도넛, 보유 코인 표
- [x] 입출금 — 총 자산, 보유 자산 표, 코인 상세 바텀시트
- [x] 투자 복기 — 자산 추이 차트, 나 vs 나, 규칙 위반 거래
- [x] 랭킹 / 마이페이지 / 라운드 생성
- [x] 긴급 자금 투입 다이얼로그가 화면 안에 들어오고 버튼에 손이 닿음
- [x] 스크롤 중 헤더가 붙어 있고 햄버거 메뉴가 열림

### 데스크톱(1440×900) 회귀 확인

- [x] 시세 목록 4열, 보유 자산 4열, 투자내역 7열 그대로
- [x] 차트 비율과 축 글자 크기 그대로
- [x] 모바일 전용 덧붙임 줄은 보이지 않음

### 빌드

- [x] `tsc -b` 통과
- [x] `eslint` 신규 경고 없음 (기존 `useVirtualList` 경고 1건만)
- [x] 프로덕션 빌드 성공

Closes #353