### PR TITLE
[#355] 비로그인 사용자에게 마켓·랭킹 공개 및 로그인 유도 모달 도입

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,8 +16,11 @@ import { MyPage } from "@/pages/MyPage";
 function App() {
   return (
     <Routes>
-      {/* 랜딩: 인증 여부와 무관하게 누구나 접근 */}
+      {/* 인증 여부와 무관하게 누구나 접근. 남의 것을 보기만 하는 화면은 열어 두고,
+          내 것을 건드리는 순간(주문·랭커 포트폴리오)에 각 화면이 로그인을 묻는다 */}
       <Route path="/" element={<LandingPage />} />
+      <Route path="/market" element={<MarketPage />} />
+      <Route path="/ranking" element={<RankingPage />} />
 
       {/* Public: 미인증 사용자만 접근 */}
       <Route element={<PublicRoute />}>
@@ -32,12 +35,11 @@ function App() {
         <Route path="/round/new" element={<RoundCreatePage />} />
       </Route>
 
-      {/* Protected: 인증 필요. 라운드를 한 번도 시작한 적 없으면 라운드 생성부터 하게 한다 */}
+      {/* Protected: 인증 필요. 라운드를 한 번도 시작한 적 없으면 라운드 생성부터 하게 한다.
+          내 자산·내 기록만 담는 화면이라 라운드 없이는 보여줄 것이 없다 */}
       <Route element={<ProtectedRoute />}>
-        <Route path="/market" element={<MarketPage />} />
         <Route path="/portfolio" element={<PortfolioPage />} />
         <Route path="/wallet" element={<WalletPage />} />
-        <Route path="/ranking" element={<RankingPage />} />
         <Route path="/regret" element={<RegretPage />} />
         <Route path="/mypage" element={<MyPage />} />
       </Route>

--- a/frontend/src/components/auth/LoginPromptDialog.tsx
+++ b/frontend/src/components/auth/LoginPromptDialog.tsx
@@ -1,0 +1,41 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { SocialLoginButtons } from "./SocialLoginButtons";
+
+interface LoginPromptDialogProps {
+  /** 로그인이 왜 필요한지 알리는 한 줄. null 이면 닫힌 상태다. */
+  reason: string | null;
+  onClose: () => void;
+}
+
+export function LoginPromptDialog({ reason, onClose }: LoginPromptDialogProps) {
+  return (
+    <Dialog
+      open={reason !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-[380px]">
+        <DialogHeader>
+          <div className="flex items-center gap-2.5">
+            <img src="/favicon.png" alt="" className="h-8 w-8 rounded-xl" />
+            <DialogTitle>로그인하고 이어서 하기</DialogTitle>
+          </div>
+          <DialogDescription>{reason}</DialogDescription>
+        </DialogHeader>
+
+        <SocialLoginButtons />
+
+        <p className="text-center text-xs text-muted-foreground">
+          보던 화면 그대로 이어집니다. 따로 가입할 것은 없습니다.
+        </p>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/auth/LoginPromptDialog.tsx
+++ b/frontend/src/components/auth/LoginPromptDialog.tsx
@@ -30,7 +30,9 @@ export function LoginPromptDialog({ reason, onClose }: LoginPromptDialogProps) {
           <DialogDescription>{reason}</DialogDescription>
         </DialogHeader>
 
-        <SocialLoginButtons />
+        {/* 로그인에 성공하면 모달은 제 할 일을 마쳤으므로 스스로 물러난다.
+            인증 상태를 지켜보다 닫으면, 나중에 로그아웃할 때 남은 문구를 들고 되살아난다 */}
+        <SocialLoginButtons onSuccess={onClose} />
 
         <p className="text-center text-xs text-muted-foreground">
           보던 화면 그대로 이어집니다. 따로 가입할 것은 없습니다.

--- a/frontend/src/components/auth/SocialLoginButtons.tsx
+++ b/frontend/src/components/auth/SocialLoginButtons.tsx
@@ -9,8 +9,8 @@ const IS_DEV = import.meta.env.DEV;
  * 로그인 화면과 로그인 유도 모달이 같은 버튼을 쓴다. 인가는 팝업이 다녀오고 주 창은 제자리에
  * 남으므로, 이 묶음을 어디에 놓든 로그인을 마친 사용자는 보던 자리에 그대로 있게 된다.
  */
-export function SocialLoginButtons() {
-  const { pendingProvider, error, start } = useSocialLogin();
+export function SocialLoginButtons({ onSuccess }: { onSuccess?: () => void }) {
+  const { pendingProvider, error, start } = useSocialLogin({ onSuccess });
 
   const kakaoReady = isSocialConfigured("kakao");
   const googleReady = isSocialConfigured("google");

--- a/frontend/src/components/auth/SocialLoginButtons.tsx
+++ b/frontend/src/components/auth/SocialLoginButtons.tsx
@@ -1,0 +1,71 @@
+import { useSocialLogin } from "@/hooks/useSocialLogin";
+import { isSocialConfigured } from "@/lib/auth/social";
+
+const IS_DEV = import.meta.env.DEV;
+
+/**
+ * 카카오·구글 로그인 버튼 묶음.
+ *
+ * 로그인 화면과 로그인 유도 모달이 같은 버튼을 쓴다. 인가는 팝업이 다녀오고 주 창은 제자리에
+ * 남으므로, 이 묶음을 어디에 놓든 로그인을 마친 사용자는 보던 자리에 그대로 있게 된다.
+ */
+export function SocialLoginButtons() {
+  const { pendingProvider, error, start } = useSocialLogin();
+
+  const kakaoReady = isSocialConfigured("kakao");
+  const googleReady = isSocialConfigured("google");
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => start("kakao")}
+        disabled={!kakaoReady || pendingProvider !== null}
+        className="flex h-12 w-full items-center justify-center gap-2 rounded-lg bg-[#FEE500] text-sm font-semibold text-[#191600] transition-all duration-150 hover:brightness-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="#191600" aria-hidden="true">
+          <path d="M12 3C6.477 3 2 6.463 2 10.735c0 2.724 1.822 5.116 4.575 6.485-.202.735-.732 2.664-.838 3.077-.13.513.188.506.396.368.163-.108 2.596-1.762 3.65-2.48.717.106 1.46.162 2.217.162 5.523 0 10-3.463 10-7.735C22 6.463 17.523 3 12 3Z" />
+        </svg>
+        {pendingProvider === "kakao" ? "카카오로 로그인 중…" : "카카오로 로그인"}
+      </button>
+      <button
+        type="button"
+        onClick={() => start("google")}
+        disabled={!googleReady || pendingProvider !== null}
+        className="mt-3 flex h-12 w-full items-center justify-center gap-2 rounded-lg border border-border bg-white text-sm font-semibold text-[#1f1f1f] transition-all duration-150 hover:bg-neutral-50 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            fill="#4285F4"
+            d="M23.52 12.27c0-.85-.08-1.67-.22-2.45H12v4.64h6.46a5.52 5.52 0 0 1-2.4 3.62v3h3.88c2.27-2.09 3.58-5.17 3.58-8.81Z"
+          />
+          <path
+            fill="#34A853"
+            d="M12 24c3.24 0 5.96-1.07 7.94-2.91l-3.88-3.01c-1.07.72-2.45 1.15-4.06 1.15-3.13 0-5.78-2.11-6.72-4.95H1.27v3.11A12 12 0 0 0 12 24Z"
+          />
+          <path
+            fill="#FBBC05"
+            d="M5.28 14.28a7.21 7.21 0 0 1 0-4.56V6.61H1.27a12 12 0 0 0 0 10.78l4.01-3.11Z"
+          />
+          <path
+            fill="#EA4335"
+            d="M12 4.77c1.76 0 3.34.61 4.59 1.8l3.44-3.44C17.95 1.19 15.24 0 12 0A12 12 0 0 0 1.27 6.61l4.01 3.11C6.22 6.88 8.87 4.77 12 4.77Z"
+          />
+        </svg>
+        {pendingProvider === "google" ? "구글로 로그인 중…" : "구글로 로그인"}
+      </button>
+      {IS_DEV && (!kakaoReady || !googleReady) && (
+        <p className="mt-2 text-center text-xs text-muted-foreground">
+          {[!kakaoReady && "카카오", !googleReady && "구글"].filter(Boolean).join("·")} 로그인
+          설정(<span className="font-mono">.env.local</span>)이 필요합니다.
+        </p>
+      )}
+
+      {error && (
+        <p className="mt-3 rounded-lg bg-destructive/8 px-3 py-2 text-xs font-medium text-destructive">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/landing/LandingNav.tsx
+++ b/frontend/src/components/landing/LandingNav.tsx
@@ -47,7 +47,7 @@ export function LandingNav() {
         </nav>
 
         <Link
-          to={isAuthenticated ? "/market" : "/login"}
+          to="/market"
           className={cn(
             "rounded-full bg-primary px-4 py-2 text-[13px] font-bold text-primary-foreground shadow-md transition-all duration-300 hover:brightness-110 active:scale-[0.98]",
             scrolled

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,31 +1,78 @@
-import { useState } from "react";
-import { Menu, X, LogOut } from "lucide-react";
+import { useState, type ReactNode } from "react";
+import { Menu, X, LogOut, Lock } from "lucide-react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/contexts/AuthContext";
+import { useLoginPrompt } from "@/contexts/LoginPromptContext";
 import { useRound } from "@/contexts/RoundContext";
 
-const navItems = [
+interface NavItem {
+  path: string;
+  label: string;
+  /** 로그인이 필요한 탭에만 있다. 잠긴 상태로 눌렀을 때 모달에 띄울 안내다. */
+  lockReason?: string;
+}
+
+const navItems: NavItem[] = [
   { path: "/market", label: "마켓" },
-  { path: "/portfolio", label: "포트폴리오" },
-  { path: "/wallet", label: "입출금" },
+  { path: "/portfolio", label: "포트폴리오", lockReason: "포트폴리오는 로그인한 뒤에 볼 수 있습니다." },
+  { path: "/wallet", label: "입출금", lockReason: "입출금은 로그인한 뒤에 이용할 수 있습니다." },
   { path: "/ranking", label: "랭킹" },
-  { path: "/regret", label: "투자 복기" },
+  { path: "/regret", label: "투자 복기", lockReason: "투자 복기는 로그인한 뒤에 볼 수 있습니다." },
 ];
 
 export function Header() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { user, logout } = useAuth();
+  const { user, isAuthenticated, logout } = useAuth();
+  const { promptLogin } = useLoginPrompt();
   const { hasActiveRound, isRoundLoading } = useRound();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const showRoundStart = !isRoundLoading && !hasActiveRound;
+  const showRoundStart = isAuthenticated && !isRoundLoading && !hasActiveRound;
 
   // 로그아웃 후에는 랜딩으로 보낸다. 순서가 중요하다 — 먼저 공개 라우트(/)로 옮긴 뒤 세션을 비운다.
   // 반대로 하면 user 가 비는 순간 보호 라우트가 /login 으로 리다이렉트해 이 이동을 덮어쓴다.
   const handleLogout = async () => {
     navigate("/", { replace: true });
     await logout();
+  };
+
+  // 잠긴 탭은 링크가 아니라 버튼으로 낸다. 링크로 보내면 보호 라우트가 /login 으로 튕겨
+  // 보던 시세가 사라지지만, 버튼이면 화면은 그대로 두고 모달만 띄울 수 있다.
+  const renderNavItem = (item: NavItem, className: string, onNavigate?: () => void): ReactNode => {
+    const isActive = location.pathname === item.path;
+    const locked = item.lockReason !== undefined && !isAuthenticated;
+
+    if (locked) {
+      return (
+        <button
+          key={item.path}
+          type="button"
+          onClick={() => {
+            onNavigate?.();
+            promptLogin(item.lockReason);
+          }}
+          className={cn(className, "flex w-full items-center gap-1.5 sm:w-auto")}
+        >
+          {item.label}
+          <Lock className="h-3 w-3 opacity-50" />
+        </button>
+      );
+    }
+
+    return (
+      <Link
+        key={item.path}
+        to={item.path}
+        onClick={onNavigate}
+        className={cn(
+          className,
+          isActive && "bg-foreground/[0.06] font-semibold text-foreground",
+        )}
+      >
+        {item.label}
+      </Link>
+    );
   };
 
   return (
@@ -38,23 +85,12 @@ export function Header() {
 
         {/* Desktop nav */}
         <nav className="hidden items-center gap-1 text-sm sm:flex">
-          {navItems.map((item) => {
-            const isActive = location.pathname === item.path;
-            return (
-              <Link
-                key={item.path}
-                to={item.path}
-                className={cn(
-                  "rounded-lg px-3 py-1.5 text-[13px] font-medium transition-colors",
-                  isActive
-                    ? "bg-foreground/[0.06] font-semibold text-foreground"
-                    : "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",
-                )}
-              >
-                {item.label}
-              </Link>
-            );
-          })}
+          {navItems.map((item) =>
+            renderNavItem(
+              item,
+              "rounded-lg px-3 py-1.5 text-[13px] font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground",
+            ),
+          )}
         </nav>
 
         {/* Desktop user info */}
@@ -67,21 +103,32 @@ export function Header() {
               라운드 시작
             </Link>
           )}
-          {user && (
-            <Link
-              to="/mypage"
-              className="text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+          {isAuthenticated ? (
+            <>
+              {user && (
+                <Link
+                  to="/mypage"
+                  className="text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {user.nickname}
+                </Link>
+              )}
+              <button
+                onClick={() => void handleLogout()}
+                className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
+              >
+                <LogOut className="h-3.5 w-3.5" />
+                <span>로그아웃</span>
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={() => promptLogin("로그인하면 모의투자를 시작할 수 있습니다.")}
+              className="rounded-lg bg-primary px-3 py-1.5 text-[13px] font-semibold text-primary-foreground transition-opacity hover:opacity-90"
             >
-              {user.nickname}
-            </Link>
+              로그인
+            </button>
           )}
-          <button
-            onClick={() => void handleLogout()}
-            className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
-          >
-            <LogOut className="h-3.5 w-3.5" />
-            <span>로그아웃</span>
-          </button>
         </div>
 
         {/* Mobile hamburger */}
@@ -97,24 +144,13 @@ export function Header() {
       {/* Mobile nav dropdown */}
       {mobileOpen && (
         <nav className="border-t border-border/40 bg-background px-4 pb-3 pt-2 sm:hidden">
-          {navItems.map((item) => {
-            const isActive = location.pathname === item.path;
-            return (
-              <Link
-                key={item.path}
-                to={item.path}
-                onClick={() => setMobileOpen(false)}
-                className={cn(
-                  "block rounded-lg px-3 py-2.5 text-sm font-medium transition-colors",
-                  isActive
-                    ? "bg-foreground/[0.06] text-foreground"
-                    : "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",
-                )}
-              >
-                {item.label}
-              </Link>
-            );
-          })}
+          {navItems.map((item) =>
+            renderNavItem(
+              item,
+              "block rounded-lg px-3 py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground",
+              () => setMobileOpen(false),
+            ),
+          )}
 
           {showRoundStart && (
             <Link
@@ -126,26 +162,40 @@ export function Header() {
             </Link>
           )}
 
-          <div className="mt-2 flex items-center justify-between border-t border-border/40 px-3 pt-3">
-            {user && (
-              <Link
-                to="/mypage"
-                onClick={() => setMobileOpen(false)}
-                className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          <div className="mt-2 border-t border-border/40 pt-3">
+            {isAuthenticated ? (
+              <div className="flex items-center justify-between px-3">
+                {user && (
+                  <Link
+                    to="/mypage"
+                    onClick={() => setMobileOpen(false)}
+                    className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    {user.nickname}
+                  </Link>
+                )}
+                <button
+                  onClick={() => {
+                    setMobileOpen(false);
+                    void handleLogout();
+                  }}
+                  className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
+                >
+                  <LogOut className="h-4 w-4" />
+                  <span>로그아웃</span>
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => {
+                  setMobileOpen(false);
+                  promptLogin("로그인하면 모의투자를 시작할 수 있습니다.");
+                }}
+                className="block w-full rounded-lg bg-primary px-3 py-2.5 text-center text-sm font-semibold text-primary-foreground"
               >
-                {user.nickname}
-              </Link>
+                로그인
+              </button>
             )}
-            <button
-              onClick={() => {
-                setMobileOpen(false);
-                void handleLogout();
-              }}
-              className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
-            >
-              <LogOut className="h-4 w-4" />
-              <span>로그아웃</span>
-            </button>
           </div>
         </nav>
       )}

--- a/frontend/src/components/market/OrderPanel.tsx
+++ b/frontend/src/components/market/OrderPanel.tsx
@@ -28,6 +28,8 @@ interface OrderPanelProps {
   orderTargetIds: OrderTargetIds | null;
   orderTargetFailure: OrderTargetFailure | null;
   orderFilledEvent: UserEvent | null;
+  /** 비로그인 상태에서 주문을 누른 순간. 값을 다 채워 둔 채로 로그인만 물어본다. */
+  onRequireLogin: () => void;
 }
 
 const ORDER_TABS: { key: OrderTab; label: string }[] = [
@@ -133,6 +135,7 @@ export function OrderPanel({
   orderTargetIds,
   orderTargetFailure,
   orderFilledEvent,
+  onRequireLogin,
 }: OrderPanelProps) {
   const [activeTab, setActiveTab] = useState<OrderTab>("buy");
   const [historyFilter, setHistoryFilter] = useState<"filled" | "pending">("filled");
@@ -410,6 +413,8 @@ export function OrderPanel({
   }
 
   const mappedUnavailable = !orderTargetIds;
+  // 로그인만 하면 풀리는 막힘이다. 다른 막힘과 달리 주문 버튼을 살려 두고, 누르면 로그인을 묻는다.
+  const needsLogin = orderTargetFailure === "UNAUTHENTICATED";
 
   return (
     // 좁은 화면에서는 주문 패널이 목록 아래에 이어 붙는다. 그 자리에서 붙잡아 두면 스크롤을 가로막는다.
@@ -426,6 +431,21 @@ export function OrderPanel({
               </p>
             </div>
           </div>
+
+          {needsLogin && (
+            <div className="mt-4 rounded-xl border border-primary/25 bg-primary/[0.06] px-3 py-3 text-xs">
+              <p className="text-muted-foreground">
+                시세는 진짜, 돈은 가짜입니다. 로그인하면 바로 주문할 수 있습니다.
+              </p>
+              <button
+                type="button"
+                onClick={onRequireLogin}
+                className="mt-2 font-semibold text-primary underline underline-offset-2"
+              >
+                로그인하고 주문하기
+              </button>
+            </div>
+          )}
 
           {mappedUnavailable && orderTargetFailure === "NO_ROUND" && (
             <div className="mt-4 rounded-xl border border-warning/30 bg-warning/10 px-3 py-3 text-xs text-warning-foreground">
@@ -577,7 +597,11 @@ export function OrderPanel({
 
               {!historyLoading && historyItems.length === 0 && (
                 <div className="rounded-xl border border-dashed border-border/70 bg-secondary/30 px-4 py-6 text-center text-sm text-muted-foreground">
-                  {historyFilter === "filled" ? "체결 내역이 없습니다." : "미체결 주문이 없습니다."}
+                  {needsLogin
+                    ? "로그인하면 내 거래 내역이 여기에 쌓입니다."
+                    : historyFilter === "filled"
+                      ? "체결 내역이 없습니다."
+                      : "미체결 주문이 없습니다."}
                 </div>
               )}
 
@@ -734,8 +758,8 @@ export function OrderPanel({
                     "h-11 rounded-xl text-sm font-semibold",
                     isBuy ? "bg-primary text-primary-foreground" : "bg-destructive text-white",
                   )}
-                  onClick={() => void handleSubmitOrder()}
-                  disabled={isSubmitting || mappedUnavailable}
+                  onClick={() => (needsLogin ? onRequireLogin() : void handleSubmitOrder())}
+                  disabled={isSubmitting || (mappedUnavailable && !needsLogin)}
                 >
                   {isSubmitting ? "요청 중..." : isBuy ? "매수" : "매도"}
                 </Button>

--- a/frontend/src/contexts/LoginPromptContext.tsx
+++ b/frontend/src/contexts/LoginPromptContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+
+// 컴포넌트(LoginPromptProvider)는 같은 파일에 두지 않는다. AuthContext 와 같은 이유다.
+
+export interface LoginPromptContextValue {
+  /**
+   * 로그인이 필요한 동작을 눌렀을 때 부른다.
+   * reason 은 왜 로그인이 필요한지 알리는 한 줄로, 모달 설명에 그대로 쓰인다.
+   */
+  promptLogin: (reason?: string) => void;
+}
+
+export const LoginPromptContext = createContext<LoginPromptContextValue | null>(null);
+
+export function useLoginPrompt(): LoginPromptContextValue {
+  const ctx = useContext(LoginPromptContext);
+  if (!ctx) throw new Error("useLoginPrompt must be used within LoginPromptProvider");
+  return ctx;
+}

--- a/frontend/src/contexts/LoginPromptProvider.tsx
+++ b/frontend/src/contexts/LoginPromptProvider.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { LoginPromptDialog } from "@/components/auth/LoginPromptDialog";
-import { useAuth } from "@/contexts/AuthContext";
 import { LoginPromptContext } from "./LoginPromptContext";
 
 const DEFAULT_REASON = "이 기능은 로그인한 뒤에 이용할 수 있습니다.";
@@ -12,17 +11,11 @@ const DEFAULT_REASON = "이 기능은 로그인한 뒤에 이용할 수 있습�
  * 화면이 통째로 바뀌면 로그인은 넘어야 할 벽이 되지만, 모달이면 하려던 일에 딸린 한 단계로 남는다.
  */
 export function LoginPromptProvider({ children }: { children: ReactNode }) {
-  const { isAuthenticated } = useAuth();
   const [reason, setReason] = useState<string | null>(null);
 
   const promptLogin = useCallback((next?: string) => {
     setReason(next ?? DEFAULT_REASON);
   }, []);
-
-  // 로그인에 성공하면 인증 상태가 바뀐다. 물어볼 것이 없어졌으므로 모달은 스스로 물러난다.
-  useEffect(() => {
-    if (isAuthenticated) setReason(null);
-  }, [isAuthenticated]);
 
   const value = useMemo(() => ({ promptLogin }), [promptLogin]);
 

--- a/frontend/src/contexts/LoginPromptProvider.tsx
+++ b/frontend/src/contexts/LoginPromptProvider.tsx
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { LoginPromptDialog } from "@/components/auth/LoginPromptDialog";
+import { useAuth } from "@/contexts/AuthContext";
+import { LoginPromptContext } from "./LoginPromptContext";
+
+const DEFAULT_REASON = "이 기능은 로그인한 뒤에 이용할 수 있습니다.";
+
+/**
+ * 로그인이 필요한 순간에 띄우는 모달을 화면 어디서나 부를 수 있게 한다.
+ *
+ * 로그인 화면으로 보내지 않고 모달로 묻는 이유는, 보던 시세나 차트를 잃지 않게 하기 위해서다.
+ * 화면이 통째로 바뀌면 로그인은 넘어야 할 벽이 되지만, 모달이면 하려던 일에 딸린 한 단계로 남는다.
+ */
+export function LoginPromptProvider({ children }: { children: ReactNode }) {
+  const { isAuthenticated } = useAuth();
+  const [reason, setReason] = useState<string | null>(null);
+
+  const promptLogin = useCallback((next?: string) => {
+    setReason(next ?? DEFAULT_REASON);
+  }, []);
+
+  // 로그인에 성공하면 인증 상태가 바뀐다. 물어볼 것이 없어졌으므로 모달은 스스로 물러난다.
+  useEffect(() => {
+    if (isAuthenticated) setReason(null);
+  }, [isAuthenticated]);
+
+  const value = useMemo(() => ({ promptLogin }), [promptLogin]);
+
+  return (
+    <LoginPromptContext.Provider value={value}>
+      {children}
+      <LoginPromptDialog reason={reason} onClose={() => setReason(null)} />
+    </LoginPromptContext.Provider>
+  );
+}

--- a/frontend/src/hooks/useSocialLogin.ts
+++ b/frontend/src/hooks/useSocialLogin.ts
@@ -28,7 +28,8 @@ export interface SocialLogin {
  * 소셜 로그인 진행 상태.
  *
  * 인가는 팝업에 맡기고 주 창은 제자리에 남는다. 팝업이 code 를 넘겨주면 주 창이 state 를 대조하고
- * 백엔드와 교환한다. 로그인에 성공하면 인증 상태가 바뀌므로 화면 이동은 PublicRoute 가 맡는다.
+ * 백엔드와 교환한다. 이 훅은 인증 상태만 바꾼다. 그 뒤에 무엇을 할지는 부르는 쪽이 정한다 —
+ * 로그인 화면은 PublicRoute 가 내보내고, 로그인 유도 모달은 스스로 닫힌다.
  * 팝업이 차단되면 주 창을 통째로 제공자에게 보내는 예전 방식으로 물러선다.
  */
 export function useSocialLogin(): SocialLogin {
@@ -92,6 +93,18 @@ export function useSocialLogin(): SocialLogin {
 
   // 로그인을 마치거나 화면을 떠날 때 열어둔 팝업을 남기지 않는다.
   useEffect(() => () => popupRef.current?.close(), []);
+
+  // 팝업이 차단되어 주 창이 제공자를 다녀오는 경우에만 해당한다. 그렇게 떠난 화면이 뒤로 가기로
+  // 되살아나면(bfcache) "로그인 중…"에 멈춘 버튼과 로그인 여부를 모르는 인증 상태를 그대로 들고
+  // 온다. 새로 부팅시켜 둘 다 다시 정하게 한다. 팝업으로 로그인하면 이 화면은 떠나지 않는다.
+  useEffect(() => {
+    function handlePageShow(event: PageTransitionEvent) {
+      if (event.persisted) window.location.reload();
+    }
+
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, []);
 
   const start = useCallback((provider: SocialProvider) => {
     setError("");

--- a/frontend/src/hooks/useSocialLogin.ts
+++ b/frontend/src/hooks/useSocialLogin.ts
@@ -24,6 +24,11 @@ export interface SocialLogin {
   start: (provider: SocialProvider) => void;
 }
 
+export interface UseSocialLoginOptions {
+  /** 로그인에 성공한 직후. 인증 상태는 이미 바뀐 뒤다. */
+  onSuccess?: () => void;
+}
+
 /**
  * 소셜 로그인 진행 상태.
  *
@@ -32,13 +37,19 @@ export interface SocialLogin {
  * 로그인 화면은 PublicRoute 가 내보내고, 로그인 유도 모달은 스스로 닫힌다.
  * 팝업이 차단되면 주 창을 통째로 제공자에게 보내는 예전 방식으로 물러선다.
  */
-export function useSocialLogin(): SocialLogin {
+export function useSocialLogin({ onSuccess }: UseSocialLoginOptions = {}): SocialLogin {
   const { loginWithSocial } = useAuth();
   const [pendingProvider, setPendingProvider] = useState<SocialProvider | null>(null);
   const [error, setError] = useState("");
   const popupRef = useRef<Window | null>(null);
   // 팝업이 결과를 넘기고 닫힌 것인지, 사용자가 그냥 닫은 것인지 가른다.
   const answeredRef = useRef(false);
+
+  // 성공 처리는 구독을 다시 맺지 않으려고 ref 로 들고 있는다. 갱신은 렌더가 끝난 뒤에 한다.
+  const onSuccessRef = useRef(onSuccess);
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+  }, [onSuccess]);
 
   const finish = useCallback(
     async (message: SocialCallbackMessage) => {
@@ -64,6 +75,7 @@ export function useSocialLogin(): SocialLogin {
         // pendingProvider 는 비우지 않는다. 인증 상태가 바뀌면 곧 이 화면이 사라지므로,
         // 그 사이에 버튼이 다시 눌리지 않게 잠가둔 채로 둔다.
         loginWithSocial({ userId: login.userId, nickname: login.nickname });
+        onSuccessRef.current?.();
       } catch (e: unknown) {
         setError(isApiClientError(e) ? e.message : "로그인 처리 중 오류가 발생했습니다.");
         setPendingProvider(null);

--- a/frontend/src/lib/api/id-mapping.ts
+++ b/frontend/src/lib/api/id-mapping.ts
@@ -6,7 +6,9 @@ export interface OrderTargetIds {
   exchangeCoinId: number;
 }
 
-export type OrderTargetFailure = "NO_ROUND" | "COIN_UNLISTED" | "LOOKUP_FAILED";
+// UNAUTHENTICATED 는 이 파일이 아니라 화면이 정한다. 로그인하지 않으면 지갑도 없어 해석은
+// NO_ROUND 로 떨어지는데, 로그인부터 해야 하는 것과 라운드를 시작해야 하는 것은 안내가 다르다.
+export type OrderTargetFailure = "UNAUTHENTICATED" | "NO_ROUND" | "COIN_UNLISTED" | "LOOKUP_FAILED";
 
 export type OrderTargetResult =
   | { ok: true; ids: OrderTargetIds }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { AuthProvider } from './contexts/AuthProvider'
+import { LoginPromptProvider } from './contexts/LoginPromptProvider'
 import { RoundProvider } from './contexts/RoundProvider'
 import './index.css'
 import App from './App.tsx'
@@ -11,7 +12,9 @@ createRoot(document.getElementById('root')!).render(
     <BrowserRouter>
       <AuthProvider>
         <RoundProvider>
-          <App />
+          <LoginPromptProvider>
+            <App />
+          </LoginPromptProvider>
         </RoundProvider>
       </AuthProvider>
     </BrowserRouter>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -45,7 +45,9 @@ const REGRET_STEPS = [
 export function LandingPage() {
   const { isAuthenticated } = useAuth();
 
-  const ctaTo = isAuthenticated ? "/market" : "/login";
+  // 로그인 여부와 무관하게 마켓으로 보낸다. 처음 온 사람에게 로그인 화면부터 들이밀면
+  // 무엇을 주는 곳인지 보기도 전에 판단해야 한다. 시세를 먼저 보여주고, 주문할 때 묻는다.
+  const ctaTo = "/market";
   const ctaLabel = isAuthenticated ? "이어서 투자하기" : "지금 날려보기";
 
   return (

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,27 +1,6 @@
-import { useEffect } from "react";
-import { useSocialLogin } from "@/hooks/useSocialLogin";
-import { isSocialConfigured } from "@/lib/auth/social";
-
-const IS_DEV = import.meta.env.DEV;
+import { SocialLoginButtons } from "@/components/auth/SocialLoginButtons";
 
 export function LoginPage() {
-  const { pendingProvider, error, start } = useSocialLogin();
-
-  const kakaoReady = isSocialConfigured("kakao");
-  const googleReady = isSocialConfigured("google");
-
-  // 팝업이 차단되어 주 창이 제공자를 다녀오는 경우에만 해당한다. 그렇게 떠난 화면이 뒤로 가기로
-  // 되살아나면(bfcache) "로그인 중…"에 멈춘 버튼과 로그인 여부를 모르는 인증 상태를 그대로 들고
-  // 온다. 새로 부팅시켜 둘 다 다시 정하게 한다. 팝업으로 로그인하면 이 화면은 떠나지 않는다.
-  useEffect(() => {
-    function handlePageShow(event: PageTransitionEvent) {
-      if (event.persisted) window.location.reload();
-    }
-
-    window.addEventListener("pageshow", handlePageShow);
-    return () => window.removeEventListener("pageshow", handlePageShow);
-  }, []);
-
   return (
     <div className="flex min-h-dvh items-center justify-center bg-background px-4">
       <div className="w-full max-w-[380px] animate-enter">
@@ -38,56 +17,7 @@ export function LoginPage() {
 
         {/* Login card */}
         <div className="rounded-xl border border-border bg-card p-6">
-          {/* 소셜 로그인 (주 로그인) */}
-          <button
-            type="button"
-            onClick={() => start("kakao")}
-            disabled={!kakaoReady || pendingProvider !== null}
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-lg bg-[#FEE500] text-sm font-semibold text-[#191600] transition-all duration-150 hover:brightness-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="#191600" aria-hidden="true">
-              <path d="M12 3C6.477 3 2 6.463 2 10.735c0 2.724 1.822 5.116 4.575 6.485-.202.735-.732 2.664-.838 3.077-.13.513.188.506.396.368.163-.108 2.596-1.762 3.65-2.48.717.106 1.46.162 2.217.162 5.523 0 10-3.463 10-7.735C22 6.463 17.523 3 12 3Z" />
-            </svg>
-            {pendingProvider === "kakao" ? "카카오로 로그인 중…" : "카카오로 로그인"}
-          </button>
-          <button
-            type="button"
-            onClick={() => start("google")}
-            disabled={!googleReady || pendingProvider !== null}
-            className="mt-3 flex h-12 w-full items-center justify-center gap-2 rounded-lg border border-border bg-white text-sm font-semibold text-[#1f1f1f] transition-all duration-150 hover:bg-neutral-50 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
-              <path
-                fill="#4285F4"
-                d="M23.52 12.27c0-.85-.08-1.67-.22-2.45H12v4.64h6.46a5.52 5.52 0 0 1-2.4 3.62v3h3.88c2.27-2.09 3.58-5.17 3.58-8.81Z"
-              />
-              <path
-                fill="#34A853"
-                d="M12 24c3.24 0 5.96-1.07 7.94-2.91l-3.88-3.01c-1.07.72-2.45 1.15-4.06 1.15-3.13 0-5.78-2.11-6.72-4.95H1.27v3.11A12 12 0 0 0 12 24Z"
-              />
-              <path
-                fill="#FBBC05"
-                d="M5.28 14.28a7.21 7.21 0 0 1 0-4.56V6.61H1.27a12 12 0 0 0 0 10.78l4.01-3.11Z"
-              />
-              <path
-                fill="#EA4335"
-                d="M12 4.77c1.76 0 3.34.61 4.59 1.8l3.44-3.44C17.95 1.19 15.24 0 12 0A12 12 0 0 0 1.27 6.61l4.01 3.11C6.22 6.88 8.87 4.77 12 4.77Z"
-              />
-            </svg>
-            {pendingProvider === "google" ? "구글로 로그인 중…" : "구글로 로그인"}
-          </button>
-          {IS_DEV && (!kakaoReady || !googleReady) && (
-            <p className="mt-2 text-center text-xs text-muted-foreground">
-              {[!kakaoReady && "카카오", !googleReady && "구글"].filter(Boolean).join("·")} 로그인
-              설정(<span className="font-mono">.env.local</span>)이 필요합니다.
-            </p>
-          )}
-
-          {error && (
-            <p className="mt-3 rounded-lg bg-destructive/8 px-3 py-2 text-xs font-medium text-destructive">
-              {error}
-            </p>
-          )}
+          <SocialLoginButtons />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -11,10 +11,14 @@ import { OrderPanel } from "@/components/market/OrderPanel";
 import { EmergencyFundingCard } from "@/components/round/EmergencyFundingCard";
 import { useRound } from "@/contexts/RoundContext";
 import { useAuth } from "@/contexts/AuthContext";
+import { useLoginPrompt } from "@/contexts/LoginPromptContext";
 import { EXCHANGES } from "@/lib/types/coins";
-import { cn } from "@/lib/utils";
 import { isChosungQuery, toChosung, toJamo } from "@/lib/hangul";
-import { resolveOrderTargetIds, type OrderTargetResult } from "@/lib/api/id-mapping";
+import {
+  resolveOrderTargetIds,
+  type OrderTargetFailure,
+  type OrderTargetResult,
+} from "@/lib/api/id-mapping";
 import { useExchangeCoins } from "@/hooks/useExchangeCoins";
 import { useTickers } from "@/hooks/useTickers";
 import { useUserEvents } from "@/hooks/useUserEvents";
@@ -25,7 +29,8 @@ import type { FilterType } from "@/components/market/FilterChips";
 
 export function MarketPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { user } = useAuth();
+  const { user, isAuthenticated } = useAuth();
+  const { promptLogin } = useLoginPrompt();
   const { activeRound, chargeEmergencyFunding, getWalletId } = useRound();
 
   const [orderFilledEvent, setOrderFilledEvent] = useState<UserEvent | null>(null);
@@ -147,7 +152,13 @@ export function MarketPage() {
 
   const orderTarget = resolved?.target === orderTargetKey ? resolved.result : null;
   const orderTargetIds = orderTarget?.ok ? orderTarget.ids : null;
-  const orderTargetFailure = orderTarget && !orderTarget.ok ? orderTarget.reason : null;
+  // 로그인하지 않았으면 지갑이 없어 해석은 NO_ROUND 로 떨어진다. 라운드를 시작하라고 안내할 자리가
+  // 아니라 로그인을 물어볼 자리이므로 여기서 가른다.
+  const orderTargetFailure: OrderTargetFailure | null = !isAuthenticated
+    ? "UNAUTHENTICATED"
+    : orderTarget && !orderTarget.ok
+      ? orderTarget.reason
+      : null;
 
   const handleExchangeChange = (key: string) => {
     setSearchParams({ exchange: key });
@@ -203,13 +214,7 @@ export function MarketPage() {
             코인 목록을 불러오는 중...
           </div>
         ) : (
-          <div
-            className={cn(
-              "animate-enter-delay-3 mt-6 grid grid-cols-1 gap-6",
-              // 라운드가 없으면 옆 칸에 띄울 것이 없다. 빈 열을 남기지 않고 차트와 목록이 폭을 다 쓰게 한다.
-              activeRound && "lg:grid-cols-[minmax(0,1fr)_360px]",
-            )}
-          >
+          <div className="animate-enter-delay-3 mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
             <div className="space-y-5">
               {selectedCoin && (
                 <CandleChartPanel
@@ -233,27 +238,31 @@ export function MarketPage() {
               />
             </div>
 
-            {/* Side panel */}
-            {activeRound && (
-              <div className="space-y-5">
+            {/* Side panel — 주문 패널은 로그인이나 라운드가 없어도 자리를 지킨다.
+                빈 화면보다, 값이 채워진 패널을 두고 무엇이 더 필요한지 그 자리에서 알리는 편이 낫다 */}
+            <div className="space-y-5">
+              {activeRound && (
                 <EmergencyFundingCard
                   round={activeRound}
                   onCharge={chargeEmergencyFunding}
                 />
-                {selectedCoin && (
-                  <OrderPanel
-                    baseCurrency={exchange.baseCurrency}
-                    coinSymbol={selectedCoin.symbol}
-                    coinName={selectedCoin.name}
-                    currentPrice={selectedCoin.currentPrice}
-                    feeRate={0.0005}
-                    orderTargetIds={orderTargetIds}
-                    orderTargetFailure={orderTargetFailure}
-                    orderFilledEvent={orderFilledEvent}
-                  />
-                )}
-              </div>
-            )}
+              )}
+              {selectedCoin && (
+                <OrderPanel
+                  baseCurrency={exchange.baseCurrency}
+                  coinSymbol={selectedCoin.symbol}
+                  coinName={selectedCoin.name}
+                  currentPrice={selectedCoin.currentPrice}
+                  feeRate={0.0005}
+                  orderTargetIds={orderTargetIds}
+                  orderTargetFailure={orderTargetFailure}
+                  orderFilledEvent={orderFilledEvent}
+                  onRequireLogin={() =>
+                    promptLogin(`${selectedCoin.symbol} 주문은 로그인한 뒤에 넣을 수 있습니다.`)
+                  }
+                />
+              )}
+            </div>
           </div>
         )}
 

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { Header } from "@/components/layout/Header";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
+import { useLoginPrompt } from "@/contexts/LoginPromptContext";
 import {
   getMyRanking,
   getRankerPortfolio,
@@ -113,7 +114,8 @@ function StatsPlaceholder() {
 }
 
 export function RankingPage() {
-  const { user } = useAuth();
+  const { user, isAuthenticated } = useAuth();
+  const { promptLogin } = useLoginPrompt();
   const [searchParams, setSearchParams] = useSearchParams();
   const periodParam = searchParams.get("period");
   const period: RankingPeriod =
@@ -228,6 +230,13 @@ export function RankingPage() {
   }
 
   function handleToggleRow(entry: RankingItem) {
+    // 순위는 누구나 보지만 남의 포트폴리오는 로그인해야 열린다. 서버가 401 로 막는 자리라
+    // 펼쳐 놓고 오류를 보여주는 대신, 펼치기 전에 로그인을 묻는다.
+    if (!isAuthenticated) {
+      promptLogin(`${entry.nickname}님이 무엇을 들고 있는지는 로그인한 뒤에 볼 수 있습니다.`);
+      return;
+    }
+
     const nextExpanded = expandedUserId === entry.userId ? null : entry.userId;
     setExpandedUserId(nextExpanded);
 
@@ -290,7 +299,20 @@ export function RankingPage() {
             <aside className="flex flex-col gap-4 lg:sticky lg:top-24 lg:self-start">
               <div className="rounded-2xl bg-card p-4 shadow-card">
                 <p className="mb-3 text-xs font-semibold text-muted-foreground">내 랭킹</p>
-                {myRanking ? (
+                {!isAuthenticated ? (
+                  <div>
+                    <p className="text-sm leading-relaxed text-muted-foreground">
+                      로그인하면 이 목록에 내 이름도 오릅니다.
+                    </p>
+                    <Button
+                      variant="outline"
+                      className="mt-3 w-full"
+                      onClick={() => promptLogin("내 순위는 로그인한 뒤에 볼 수 있습니다.")}
+                    >
+                      로그인하고 순위 확인하기
+                    </Button>
+                  </div>
+                ) : myRanking ? (
                   <div>
                     <div className="flex items-center gap-3">
                       <RankBadge rank={myRanking.rank} />


### PR DESCRIPTION
## Summary

처음 방문한 사용자가 로그인 여부를 결정하기 전에 서비스의 실체를 확인할 수 있도록, 조회 전용 화면을 인증 없이 열고 로그인은 실제로 필요한 순간에 요청하도록 바꾼다.

- **마켓·랭킹 공개** — 시세·차트·랭킹 목록을 인증 없이 열람
- **로그인 유도 모달** — 화면을 이동시키지 않고 그 자리에서 로그인을 요청
- **라운드 강제 이동 해제** — 로그인 후 라운드가 없어도 시세를 볼 수 있음

서버는 변경하지 않았다. 코인 목록·캔들·랭킹 조회와 시세 WebSocket 은 이미 공개 엔드포인트였다.

---

## 핵심 흐름

```
랜딩 "지금 날려보기"
  → /market (비로그인)             시세·차트·주문 패널 모두 보임
  → 매수 클릭
      → 로그인 모달 (화면 유지)     보던 코인·차트 그대로
      → 소셜 로그인 성공
      → 모달 자동 종료              같은 자리에서 이어짐
  → 주문 패널이 "라운드 시작하기" 안내로 전환
  → 라운드 생성 → 주문
```

---

## 주요 변경 사항

### 라우팅

- `/market`, `/ranking` 을 `ProtectedRoute` 밖으로 옮겨 공개 라우트로 전환했다.
- `ProtectedRoute` 는 `/portfolio`, `/wallet`, `/regret`, `/mypage` 만 담당한다. 이 화면들은 내 자산과 내 기록만 담기 때문에 라운드 없이는 보여줄 것이 없어, 라운드 미보유 시 생성 화면으로 보내는 기존 동작을 유지한다.

### 로그인 유도

- `LoginPromptProvider` / `useLoginPrompt` 를 추가해 화면 어디서나 `promptLogin(사유)` 로 모달을 띄울 수 있게 했다.
- 로그인 화면과 모달이 같은 버튼을 쓰도록 `SocialLoginButtons` 를 분리했다. bfcache 복구 처리도 화면이 아니라 `useSocialLogin` 훅으로 옮겨, 어느 화면에서 로그인하든 동일하게 동작한다.
- `useSocialLogin` 에 `onSuccess` 를 추가했다. 모달은 이 신호를 받아 스스로 닫힌다.

### 화면

- **Header** — 잠긴 탭은 링크 대신 버튼으로 렌더링하고 자물쇠 아이콘을 붙였다. 비로그인 시 로그아웃 자리에 로그인 버튼을 둔다.
- **MarketPage** — 주문 패널이 라운드·로그인 여부와 무관하게 항상 자리를 지킨다. 비로그인 상태에서 매수/매도를 누르면 선택한 코인 이름을 담아 로그인을 요청한다.
- **RankingPage** — 랭커 포트폴리오는 서버가 401 로 막는 자리라, 펼치기 전에 로그인을 요청한다. `내 랭킹` 카드에는 로그인 CTA 를 둔다.
- **LandingPage / LandingNav** — 진입 버튼의 목적지를 `/login` 에서 `/market` 으로 바꿨다.

### 타입

- `OrderTargetFailure` 에 `UNAUTHENTICATED` 를 추가했다. 비로그인은 지갑이 없어 해석이 `NO_ROUND` 로 떨어지는데, 로그인해야 하는 것과 라운드를 시작해야 하는 것은 안내가 달라야 한다.

---

## 설계 결정

| 결정 | 이유 |
|------|------|
| 로그인 화면 이동 대신 모달 | 화면이 통째로 바뀌면 로그인이 넘어야 할 벽이 되지만, 모달이면 하려던 일에 딸린 한 단계로 남는다. 인가를 팝업이 처리하므로 주 창은 제자리에 있다 |
| 비로그인에도 주문 패널 노출 | 값이 채워진 패널을 보여주고 버튼에서 막는 편이, 아무것도 없는 화면보다 무엇을 얻는지 분명하다 |
| 모달이 인증 상태를 감시하지 않고 성공 신호를 받음 | 상태를 지켜보다 닫으면, 이후 로그아웃 시점에 남아 있던 안내 문구를 들고 모달이 되살아난다 |
| 잠긴 탭을 버튼으로 렌더링 | 링크로 두면 보호 라우트가 `/login` 으로 보내 보던 시세가 사라진다 |
| 랭커 포트폴리오는 펼치기 전에 차단 | 서버가 401 로 응답하므로, 펼쳐 놓고 오류를 보여주는 것보다 낫다 |
| 마켓에서 라운드 강제 이동 제거 | 시세 열람은 라운드와 무관하다. 주문 시점에 주문 패널이 라운드 생성을 안내한다 |

---

## Test Plan

프로덕션 API 를 프록시로 연결한 개발 서버에서 비로그인 상태로 검증했다. 조회 API 만 호출했다.

### 비로그인 열람

- [x] `/market` 진입 시 시세 카드·거래소 탭·캔들 차트·코인 목록이 모두 렌더링된다
- [x] `/ranking` 진입 시 순위 목록과 기간별 통계가 조회된다
- [x] 프로덕션 `/ws` 가 인증 쿠키 없이 101 로 업그레이드되어 실시간 시세가 전달된다
- [x] `/api/rankings/me` 는 비로그인 상태에서 호출되지 않는다

### 로그인 요청 지점

- [x] 주문 패널의 매수 버튼 클릭 시 선택한 코인 이름을 담은 모달이 뜨고, 뒤 화면은 유지된다
- [x] 주문 패널 안내의 `로그인하고 주문하기` 클릭 시 동일하게 동작한다
- [x] 잠긴 탭(포트폴리오·입출금·투자 복기) 클릭 시 해당 탭 이름을 담은 모달이 뜬다
- [x] `내 랭킹` 카드의 CTA 클릭 시 모달이 뜬다

### 레이아웃

- [x] 데스크톱(1440px)에서 차트·목록과 주문 패널이 2열로 배치된다
- [x] 모바일(390px)에서 햄버거 메뉴에 자물쇠 표시와 로그인 버튼이 정상 렌더링된다

### 빌드

- [x] `tsc -b` 통과
- [x] `eslint src` 통과 (기존 `useVirtualList` 경고 외 신규 지적 없음)
- [x] `vite build` 통과

---

## 미반영 사항

- 모바일 앱(`mobile/`)은 변경하지 않았다. 설치까지 마친 사용자는 이미 진입 문턱을 넘었고, 전역 `redirect` 로 인증을 일괄 판정하는 구조라 화면별로 여는 비용이 웹보다 크다. 웹에서 효과를 확인한 뒤 옮기는 편이 낫다.
- 로그인 직후 라운드 생성 화면으로 자동 이동하던 동작이 사라졌다. 대신 주문 패널이 라운드 생성을 안내한다. 신규 사용자의 온보딩 동선은 실사용 후 재검토가 필요하다.

Closes #355